### PR TITLE
Issue/28 search

### DIFF
--- a/canvasapi/canvas.py
+++ b/canvasapi/canvas.py
@@ -773,3 +773,38 @@ class Canvas(object):
             'folders/%s' % (folder_id)
         )
         return Folder(self.__requester, response.json())
+
+    def search_recipients(self, **kwargs):
+        """
+        Find valid recipients (users, courses and groups) that the current user
+        can send messages to.
+        Returns a list of mixed data types.
+
+        :calls: `GET /api/v1/search/recipients  \
+        <https://canvas.instructure.com/doc/api/search.html#method.search.recipients>`_
+
+        :rtype: `list`
+        """
+        response = self.__requester.request(
+            'GET',
+            'search/recipients',
+            **combine_kwargs(**kwargs)
+        )
+        return response.json()
+
+    def search_all_courses(self, **kwargs):
+        """
+        List all the courses visible in the public index.
+        Returns a list of dicts, each containing a single course.
+
+        :calls: `GET /api/v1/search/all_courses \
+        <https://canvas.instructure.com/doc/api/search.html#method.search.all_courses>`_
+
+        :rtype: `list`
+        """
+        response = self.__requester.request(
+            'GET',
+            'search/all_courses',
+            **combine_kwargs(**kwargs)
+        )
+        return response.json()

--- a/canvasapi/canvas.py
+++ b/canvasapi/canvas.py
@@ -785,6 +785,9 @@ class Canvas(object):
 
         :rtype: `list`
         """
+        if 'search' not in kwargs:
+            kwargs['search'] = ' '
+
         response = self.__requester.request(
             'GET',
             'search/recipients',

--- a/tests/fixtures/course.json
+++ b/tests/fixtures/course.json
@@ -1125,5 +1125,26 @@
 		"method": "DELETE",
 		"endpoint": "courses/1/assignments/1/submissions/1/read",
 		"status_code": 204
+	},
+	"search_all_courses": {
+		"method": "GET",
+		"endpoint": "search/all_courses",
+		"data": [
+			{
+				"course":
+				{
+					"id": 1,
+      				"name": "Course 1"
+				}
+			},
+			{
+				"course":
+				{
+					"id": 2,
+      				"name": "Course 2"
+				}
+			}
+		],
+		"status_code": 200
 	}
 }

--- a/tests/fixtures/course.json
+++ b/tests/fixtures/course.json
@@ -1134,14 +1134,14 @@
 				"course":
 				{
 					"id": 1,
-      				"name": "Course 1"
+					"name": "Course 1"
 				}
 			},
 			{
 				"course":
 				{
 					"id": 2,
-      				"name": "Course 2"
+					"name": "Course 2"
 				}
 			}
 		],

--- a/tests/fixtures/user.json
+++ b/tests/fixtures/user.json
@@ -687,5 +687,24 @@
 			"id": 8,
 			"name": "User 8"
 		}
+	},
+	"search_recipients": {
+		"method": "GET",
+		"endpoint": "search/recipients",
+		"data": [
+  			{
+  				"id": "group_1",
+  				"name": "the group",
+  				"type": "context",
+  				"user_count": 3
+  			},
+  			{
+  				"id": 2,
+  				"name": "greg",
+  				"common_courses": {},
+  				"common_groups": {"1": ["Member"]}
+  			}
+		],
+		"status_code": 200
 	}
 }

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -443,3 +443,19 @@ class TestCanvas(unittest.TestCase):
         groups = self.canvas.list_group_participants(222)
         groups_list = [group for group in groups]
         self.assertEqual(len(groups_list), 2)
+
+    # search_recipients()
+    def test_search_recipients(self, m):
+        register_uris({'user': ['search_recipients']}, m)
+
+        recipients = self.canvas.search_recipients()
+        self.assertIsInstance(recipients, list)
+        self.assertEqual(len(recipients), 2)
+
+    # search_all_courses()
+    def test_search_all_courses(self, m):
+        register_uris({'course': ['search_all_courses']}, m)
+
+        courses = self.canvas.search_all_courses()
+        self.assertIsInstance(courses, list)
+        self.assertEqual(len(courses), 2)


### PR DESCRIPTION
Addresses #28 

Methods for both _Find recipients_ and _List all courses_ added, but functionality is limited as the data is difficult to work with.

Notes
---

- search_recipients() will return an empty list unless there is a search term
   - searching " " seems to include all (even results that do not contain spaces)
- both methods return response.json()