### PR TITLE
Python 3 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: python
 python:
   - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
+  - 3.6
 install:
   - pip install -r tests_requirements.txt
   - pip install coveralls

--- a/canvasapi/__init__.py
+++ b/canvasapi/__init__.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 from canvasapi.canvas import Canvas
 
 __all__ = ["Canvas"]

--- a/canvasapi/__init__.py
+++ b/canvasapi/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from canvas import Canvas
+from canvasapi.canvas import Canvas
 
 __all__ = ["Canvas"]
 

--- a/canvasapi/account.py
+++ b/canvasapi/account.py
@@ -495,7 +495,7 @@ class Account(CanvasObject):
 
         :rtype: :class:`canvasapi.paginated_list.PaginatedList` of :class:`canvasapi.group.Group`
         """
-        from group import Group
+        from canvasapi.group import Group
         return PaginatedList(
             Group,
             self._requester,
@@ -515,7 +515,7 @@ class Account(CanvasObject):
         :type name: str
         :rtype: :class:`canvasapi.group.GroupCategory`
         """
-        from group import GroupCategory
+        from canvasapi.group import GroupCategory
 
         response = self._requester.request(
             'POST',
@@ -535,7 +535,7 @@ class Account(CanvasObject):
         :rtype: :class:`canvasapi.paginated_list.PaginatedList` of
             :class:`canvasapi.group.GroupCategory`
         """
-        from group import GroupCategory
+        from canvasapi.group import GroupCategory
 
         return PaginatedList(
             GroupCategory,
@@ -605,7 +605,7 @@ class Account(CanvasObject):
         :rtype: :class:`canvasapi.paginated_list.PaginatedList` of
             :class:`canvasapi.enrollment_term.EnrollmentTerm`
         """
-        from enrollment_term import EnrollmentTerm
+        from canvasapi.enrollment_term import EnrollmentTerm
 
         return PaginatedList(
             EnrollmentTerm,
@@ -626,7 +626,7 @@ class Account(CanvasObject):
         :rtype: :class:`canvasapi.paginated_list.PaginatedList` of
             :class:`canvasapi.login.Login`
         """
-        from login import Login
+        from canvasapi.login import Login
 
         return PaginatedList(
             Login,
@@ -649,7 +649,7 @@ class Account(CanvasObject):
         :type login: `dict`
         :rtype: :class:`canvasapi.login.Login`
         """
-        from login import Login
+        from canvasapi.login import Login
 
         if isinstance(user, dict) and 'id' in user:
             kwargs['user'] = user

--- a/canvasapi/account.py
+++ b/canvasapi/account.py
@@ -1,3 +1,7 @@
+from __future__ import unicode_literals
+
+from builtins import str
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.exceptions import RequiredFieldMissing
 from canvasapi.paginated_list import PaginatedList

--- a/canvasapi/appointment_group.py
+++ b/canvasapi/appointment_group.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.exceptions import RequiredFieldMissing
 from canvasapi.util import combine_kwargs

--- a/canvasapi/assignment.py
+++ b/canvasapi/assignment.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 

--- a/canvasapi/authentication_provider.py
+++ b/canvasapi/authentication_provider.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 

--- a/canvasapi/avatar.py
+++ b/canvasapi/avatar.py
@@ -1,3 +1,7 @@
+from __future__ import unicode_literals
+
+from builtins import str
+
 from canvasapi.canvas_object import CanvasObject
 
 

--- a/canvasapi/bookmark.py
+++ b/canvasapi/bookmark.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 

--- a/canvasapi/calendar_event.py
+++ b/canvasapi/calendar_event.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 

--- a/canvasapi/canvas.py
+++ b/canvasapi/canvas.py
@@ -1,3 +1,7 @@
+from __future__ import unicode_literals
+
+from builtins import object
+
 from canvasapi.account import Account
 from canvasapi.course import Course
 from canvasapi.exceptions import RequiredFieldMissing

--- a/canvasapi/canvas_object.py
+++ b/canvasapi/canvas_object.py
@@ -1,6 +1,9 @@
+from __future__ import unicode_literals
 from datetime import datetime
 import json
 import re
+
+from builtins import str, object
 
 DATE_PATTERN = re.compile('[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z')
 
@@ -25,7 +28,7 @@ class CanvasObject(object):
 
     def __repr__(self):  # pragma: no cover
         classname = self.__class__.__name__
-        attrs = ', '.join(['%s=%s' % (attr, val) for attr, val in self.__dict__.iteritems() if attr != 'attributes'])  # noqa
+        attrs = ', '.join(['%s=%s' % (attr, val) for attr, val in self.__dict__.items() if attr != 'attributes'])  # noqa
         return '%s(%s)' % (classname, attrs)
 
     def to_json(self):
@@ -61,7 +64,7 @@ class CanvasObject(object):
         """
         self.attributes = attributes
 
-        for attribute, value in attributes.iteritems():
+        for attribute, value in attributes.items():
             self.__setattr__(attribute, value)
 
             try:

--- a/canvasapi/canvas_object.py
+++ b/canvasapi/canvas_object.py
@@ -67,11 +67,7 @@ class CanvasObject(object):
         for attribute, value in attributes.items():
             self.__setattr__(attribute, value)
 
-            try:
-                # datetime field
-                if DATE_PATTERN.match(str(value)):
-                    date = datetime.strptime(value, '%Y-%m-%dT%H:%M:%SZ')
-                    self.__setattr__(attribute + '_date', date)
-            # Non-unicode character. We can skip over this attribute.
-            except UnicodeEncodeError:
-                continue
+            # datetime field
+            if DATE_PATTERN.match(str(value)):
+                date = datetime.strptime(value, '%Y-%m-%dT%H:%M:%SZ')
+                self.__setattr__(attribute + '_date', date)

--- a/canvasapi/communication_channel.py
+++ b/canvasapi/communication_channel.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.notification_preference import NotificationPreference
 

--- a/canvasapi/conversation.py
+++ b/canvasapi/conversation.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 

--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.discussion_topic import DiscussionTopic
 from canvasapi.exceptions import RequiredFieldMissing

--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -694,7 +694,7 @@ class Course(CanvasObject):
         :rtype: :class:`canvasapi.paginated_list.PaginatedList` of
             :class:`canvasapi.course.Course`
         """
-        from group import Group
+        from canvasapi.group import Group
         return PaginatedList(
             Group,
             self._requester,

--- a/canvasapi/discussion_topic.py
+++ b/canvasapi/discussion_topic.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.paginated_list import PaginatedList
 from canvasapi.util import combine_kwargs

--- a/canvasapi/enrollment.py
+++ b/canvasapi/enrollment.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from canvasapi.canvas_object import CanvasObject
 
 

--- a/canvasapi/enrollment_term.py
+++ b/canvasapi/enrollment_term.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 

--- a/canvasapi/exceptions.py
+++ b/canvasapi/exceptions.py
@@ -1,3 +1,8 @@
+from __future__ import unicode_literals
+
+from builtins import str
+
+
 class CanvasException(Exception):  # pragma: no cover
     """
     Base class for all errors returned by the Canvas API.

--- a/canvasapi/external_feed.py
+++ b/canvasapi/external_feed.py
@@ -1,3 +1,7 @@
+from __future__ import unicode_literals
+
+from builtins import str
+
 from canvasapi.canvas_object import CanvasObject
 
 

--- a/canvasapi/external_tool.py
+++ b/canvasapi/external_tool.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.exceptions import CanvasException
 from canvasapi.util import combine_kwargs

--- a/canvasapi/file.py
+++ b/canvasapi/file.py
@@ -1,3 +1,7 @@
+from __future__ import unicode_literals
+
+from builtins import str
+
 from canvasapi.canvas_object import CanvasObject
 
 

--- a/canvasapi/folder.py
+++ b/canvasapi/folder.py
@@ -1,3 +1,7 @@
+from __future__ import unicode_literals
+
+from builtins import str
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.paginated_list import PaginatedList
 from canvasapi.util import combine_kwargs

--- a/canvasapi/group.py
+++ b/canvasapi/group.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.discussion_topic import DiscussionTopic
 from canvasapi.folder import Folder

--- a/canvasapi/login.py
+++ b/canvasapi/login.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 

--- a/canvasapi/module.py
+++ b/canvasapi/module.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.exceptions import RequiredFieldMissing
 from canvasapi.paginated_list import PaginatedList

--- a/canvasapi/notification_preference.py
+++ b/canvasapi/notification_preference.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from canvasapi.canvas_object import CanvasObject
 
 

--- a/canvasapi/page.py
+++ b/canvasapi/page.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 from canvasapi.paginated_list import PaginatedList

--- a/canvasapi/page_view.py
+++ b/canvasapi/page_view.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from canvasapi.canvas_object import CanvasObject
 
 

--- a/canvasapi/paginated_list.py
+++ b/canvasapi/paginated_list.py
@@ -1,4 +1,7 @@
+from __future__ import unicode_literals
 import re
+
+from builtins import object
 
 
 class PaginatedList(object):
@@ -25,7 +28,7 @@ class PaginatedList(object):
 
     def __getitem__(self, index):
         assert isinstance(index, (int, slice))
-        if isinstance(index, (int, long)):
+        if isinstance(index, int):
             self.__get_up_to_index(index)
             return self.__elements[index]
         else:
@@ -81,7 +84,7 @@ class PaginatedList(object):
 
         return content
 
-    class _Slice:
+    class _Slice(object):
         def __init__(self, the_list, the_slice):
             self.__list = the_list
             self.__start = the_slice.start or 0

--- a/canvasapi/progress.py
+++ b/canvasapi/progress.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from canvasapi.canvas_object import CanvasObject
 
 

--- a/canvasapi/quiz.py
+++ b/canvasapi/quiz.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 

--- a/canvasapi/requester.py
+++ b/canvasapi/requester.py
@@ -1,3 +1,6 @@
+from __future__ import unicode_literals
+
+from builtins import object
 import requests
 
 from canvasapi.exceptions import (

--- a/canvasapi/section.py
+++ b/canvasapi/section.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.exceptions import RequiredFieldMissing
 from canvasapi.paginated_list import PaginatedList

--- a/canvasapi/submission.py
+++ b/canvasapi/submission.py
@@ -1,3 +1,7 @@
+from __future__ import unicode_literals
+
+from builtins import str
+
 from canvasapi.canvas_object import CanvasObject
 
 

--- a/canvasapi/tab.py
+++ b/canvasapi/tab.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from canvasapi.canvas_object import CanvasObject
 
 

--- a/canvasapi/upload.py
+++ b/canvasapi/upload.py
@@ -1,4 +1,7 @@
+from __future__ import unicode_literals
 import os
+
+from builtins import object
 
 from canvasapi.util import combine_kwargs
 
@@ -54,9 +57,11 @@ class Uploader(object):
         """
         response = response.json()
         if not response.get('upload_url'):
+            self.file.close()
             raise ValueError('Bad API response. No upload_url.')
 
         if not response.get('upload_params'):
+            self.file.close()
             raise ValueError('Bad API response. No upload_params.')
 
         kwargs = response.get('upload_params')

--- a/canvasapi/upload.py
+++ b/canvasapi/upload.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 import os
 
-from builtins import object
+from builtins import object, str
 
 from canvasapi.util import combine_kwargs
 

--- a/canvasapi/user.py
+++ b/canvasapi/user.py
@@ -1,3 +1,7 @@
+from __future__ import unicode_literals
+
+from builtins import str
+
 from canvasapi.bookmark import Bookmark
 from canvasapi.calendar_event import CalendarEvent
 from canvasapi.canvas_object import CanvasObject

--- a/canvasapi/user.py
+++ b/canvasapi/user.py
@@ -295,7 +295,7 @@ class User(CanvasObject):
 
         :rtype: :class:`canvasapi.paginated_list.PaginatedList` of :class:`canvasapi.group.Group`
         """
-        from group import Group
+        from canvasapi.group import Group
 
         return PaginatedList(
             Group,

--- a/canvasapi/util.py
+++ b/canvasapi/util.py
@@ -1,3 +1,8 @@
+from __future__ import unicode_literals
+
+from builtins import str
+
+
 def combine_kwargs(**kwargs):
     """
     Combines a list of keyword arguments into a single dictionary.
@@ -8,7 +13,7 @@ def combine_kwargs(**kwargs):
         new_prefix = prefix + '[' + str(key) + ']'
         if isinstance(value, dict):
             d = {}
-            for k, v in value.iteritems():
+            for k, v in value.items():
                 d.update(flatten_dict(new_prefix, k, v))
             return d
         else:
@@ -17,10 +22,10 @@ def combine_kwargs(**kwargs):
     combined_kwargs = {}
 
     # Loop through all kwargs.
-    for kw, arg in kwargs.iteritems():
+    for kw, arg in kwargs.items():
         if isinstance(arg, dict):
             # If the argument is a dictionary, flatten it.
-            for key, value in arg.iteritems():
+            for key, value in arg.items():
                 combined_kwargs.update(flatten_dict(str(kw), key, value))
         else:
             combined_kwargs.update({str(kw): arg})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+future==0.16.0
 requests==2.10.0
 six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import re
 from setuptools import setup
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     license='MIT License',
     packages=['canvasapi'],
     include_package_data=True,
-    install_requires=['requests'],
+    install_requires=['requests', 'future'],
     zip_safe=False,
     classifiers=[
         'Development Status :: 3 - Alpha',
@@ -33,6 +33,11 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Libraries',
     ],
 )

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 BASE_URL = 'http://example.com/api/v1/'
 API_KEY = '123'
 

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,6 +1,8 @@
+from __future__ import unicode_literals
 import datetime
 import unittest
 
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas
@@ -21,7 +23,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestAccount(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/test_appointment_group.py
+++ b/tests/test_appointment_group.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 import unittest
 
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas
@@ -12,7 +14,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestAppointmentGroup(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 import unittest
 
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas
@@ -11,7 +13,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestAssignment(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
@@ -49,7 +50,6 @@ class TestAssignment(unittest.TestCase):
 @requests_mock.Mocker()
 class TestAssignmentGroup(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/test_authentication_providers.py
+++ b/tests/test_authentication_providers.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 import unittest
 
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas
@@ -11,7 +13,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestAuthenticationProvider(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/test_bookmark.py
+++ b/tests/test_bookmark.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 import unittest
 
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas
@@ -11,7 +13,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestBookmark(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/test_calendar_event.py
+++ b/tests/test_calendar_event.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 import unittest
 
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas
@@ -11,7 +13,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestCalendarEvent(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 from datetime import datetime
 
@@ -22,7 +23,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestCanvas(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
@@ -86,7 +86,7 @@ class TestCanvas(unittest.TestCase):
         course = self.canvas.get_course(2)
 
         self.assertTrue(hasattr(course, 'start_at'))
-        self.assertIsInstance(course.start_at, (str, unicode))
+        self.assertIsInstance(course.start_at, str)
         self.assertTrue(hasattr(course, 'start_at_date'))
         self.assertIsInstance(course.start_at_date, datetime)
 

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 import unittest
 from datetime import datetime
 
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas

--- a/tests/test_canvas_object.py
+++ b/tests/test_canvas_object.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 
 from canvasapi.canvas_object import CanvasObject

--- a/tests/test_communication_channel.py
+++ b/tests/test_communication_channel.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 import unittest
 
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas
@@ -11,7 +13,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestCommunicationChannel(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 import unittest
 
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas
@@ -11,7 +13,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestConversation(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/test_course.py
+++ b/tests/test_course.py
@@ -1,7 +1,9 @@
+from __future__ import unicode_literals
 import unittest
 import uuid
 import os
 
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas
@@ -29,7 +31,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestCourse(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
@@ -135,7 +136,7 @@ class TestCourse(unittest.TestCase):
         html_str = "<script></script><p>hello</p>"
         prev_html = self.course.preview_html(html_str)
 
-        self.assertIsInstance(prev_html, (str, unicode))
+        self.assertIsInstance(prev_html, str)
         self.assertEqual(prev_html, "<p>hello</p>")
 
     # get_settings()
@@ -159,10 +160,9 @@ class TestCourse(unittest.TestCase):
     def test_upload(self, m):
         register_uris({'course': ['upload', 'upload_final']}, m)
 
-        filename = 'testfile_%s' % uuid.uuid4().hex
-        file = open(filename, 'w+')
-
-        response = self.course.upload(file)
+        filename = 'testfile_course_%s' % uuid.uuid4().hex
+        with open(filename, 'w+') as file:
+            response = self.course.upload(file)
 
         self.assertTrue(response[0])
         self.assertIsInstance(response[1], dict)
@@ -450,7 +450,7 @@ class TestCourse(unittest.TestCase):
         discussion = self.course.get_discussion_topic(topic_id)
         self.assertIsInstance(discussion, DiscussionTopic)
         self.assertTrue(hasattr(discussion, 'course_id'))
-        self.assertEquals(discussion.course_id, 1)
+        self.assertEqual(discussion.course_id, 1)
 
     # get_full_discussion_topic()
     def test_get_full_discussion_topic(self, m):
@@ -461,7 +461,7 @@ class TestCourse(unittest.TestCase):
         self.assertIsInstance(discussion, DiscussionTopic)
         self.assertTrue(hasattr(discussion, 'view'))
         self.assertTrue(hasattr(discussion, 'participants'))
-        self.assertEquals(discussion.course_id, 1)
+        self.assertEqual(discussion.course_id, 1)
 
     # get_discussion_topics()
     def test_get_discussion_topics(self, m):
@@ -471,7 +471,7 @@ class TestCourse(unittest.TestCase):
         discussion_list = [discussion for discussion in response]
         self.assertIsInstance(discussion_list[0], DiscussionTopic)
         self.assertTrue(hasattr(discussion_list[0], 'course_id'))
-        self.assertEquals(2, len(discussion_list))
+        self.assertEqual(2, len(discussion_list))
 
     # create_discussion_topic()
     def test_create_discussion_topic(self, m):
@@ -481,8 +481,8 @@ class TestCourse(unittest.TestCase):
         discussion = self.course.create_discussion_topic()
         self.assertIsInstance(discussion, DiscussionTopic)
         self.assertTrue(hasattr(discussion, 'course_id'))
-        self.assertEquals(title, discussion.title)
-        self.assertEquals(discussion.course_id, 1)
+        self.assertEqual(title, discussion.title)
+        self.assertEqual(discussion.course_id, 1)
 
     # reorder_pinned_topics()
     def test_reorder_pinned_topics(self, m):
@@ -782,7 +782,6 @@ class TestCourse(unittest.TestCase):
 @requests_mock.Mocker()
 class TestCourseNickname(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/test_discussion_topic.py
+++ b/tests/test_discussion_topic.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 import unittest
 
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas
@@ -13,7 +15,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestDiscussionTopic(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
@@ -49,7 +50,7 @@ class TestDiscussionTopic(unittest.TestCase):
         discussion = self.discussion_topic.update()
         self.assertIsInstance(discussion, DiscussionTopic)
         self.assertTrue(hasattr(discussion, 'course_id'))
-        self.assertEquals(discussion.course_id, 1)
+        self.assertEqual(discussion.course_id, 1)
 
     # update_entry()
     def test_update_entry(self, m):
@@ -81,8 +82,8 @@ class TestDiscussionTopic(unittest.TestCase):
         entries = self.discussion_topic.list_topic_entries()
         entry_list = [entry for entry in entries]
         self.assertIsInstance(entry_list[0], DiscussionTopic)
-        self.assertEquals(entry_list[0].id, 1)
-        self.assertEquals(entry_list[0].user_id, 1)
+        self.assertEqual(entry_list[0].id, 1)
+        self.assertEqual(entry_list[0].user_id, 1)
 
     # post_reply()
     def test_post_reply(self, m):
@@ -91,7 +92,7 @@ class TestDiscussionTopic(unittest.TestCase):
         message = "Message 1"
         reply = self.discussion_topic.post_reply(1)
         self.assertIsInstance(reply, DiscussionTopic)
-        self.assertEquals(reply.message, message)
+        self.assertEqual(reply.message, message)
         self.assertTrue(hasattr(reply, 'created_at'))
         self.assertTrue(hasattr(reply, 'message'))
 
@@ -102,7 +103,7 @@ class TestDiscussionTopic(unittest.TestCase):
         replies = self.discussion_topic.list_entry_replies(1)
         reply_list = [reply for reply in replies]
         self.assertIsInstance(reply_list[0], DiscussionTopic)
-        self.assertEquals(reply_list[0].id, 1)
+        self.assertEqual(reply_list[0].id, 1)
 
     # list_entries()
     def test_list_entries(self, m):
@@ -111,7 +112,7 @@ class TestDiscussionTopic(unittest.TestCase):
         entries = self.discussion_topic.list_entries()
         entry_list = [entry for entry in entries]
         self.assertIsInstance(entry_list[0], DiscussionTopic)
-        self.assertEquals(entry_list[0].id, 1)
+        self.assertEqual(entry_list[0].id, 1)
 
     # mark_as_read()
     def test_mark_as_read(self, m):
@@ -231,10 +232,10 @@ class TestDiscussionTopic(unittest.TestCase):
 
     # parent_id
     def test_parent_id_course(self, m):
-        self.assertEquals(self.discussion_topic.parent_id, 1)
+        self.assertEqual(self.discussion_topic.parent_id, 1)
 
     def test_parent_id_group(self, m):
-        self.assertEquals(self.discussion_topic_group.parent_id, 1)
+        self.assertEqual(self.discussion_topic_group.parent_id, 1)
 
     def test_parent_id_no_id(self, m):
         discussion = DiscussionTopic(self.canvas._Canvas__requester, {'id': 1})
@@ -243,10 +244,10 @@ class TestDiscussionTopic(unittest.TestCase):
 
     # parent_type
     def test_parent_type_course(self, m):
-        self.assertEquals(self.discussion_topic.parent_type, 'course')
+        self.assertEqual(self.discussion_topic.parent_type, 'course')
 
     def test_parent_type_group(self, m):
-        self.assertEquals(self.discussion_topic_group.parent_type, 'group')
+        self.assertEqual(self.discussion_topic_group.parent_type, 'group')
 
     def test_parent_type_no_id(self, m):
         discussion = DiscussionTopic(self.canvas._Canvas__requester, {'id': 1})

--- a/tests/test_enrollment.py
+++ b/tests/test_enrollment.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 import unittest
 
+from builtins import str
 import requests_mock
 
 from canvasapi.canvas import Canvas
@@ -11,7 +13,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestEnrollment(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/test_enrollment_term.py
+++ b/tests/test_enrollment_term.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 import unittest
 
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas
@@ -11,7 +13,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestEnrollmentTerm(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/test_external_feed.py
+++ b/tests/test_external_feed.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 import unittest
 
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas
@@ -10,7 +12,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestExternalFeed(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/test_external_tool.py
+++ b/tests/test_external_tool.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 import unittest
 
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas
@@ -14,7 +16,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestExternalTool(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
@@ -93,7 +94,7 @@ class TestExternalTool(unittest.TestCase):
         requires = {'external_tool': ['get_sessionless_launch_url_course']}
         register_uris(requires, m)
 
-        self.assertIsInstance(self.ext_tool_course.get_sessionless_launch_url(), (str, unicode))
+        self.assertIsInstance(self.ext_tool_course.get_sessionless_launch_url(), str)
 
     def test_get_sessionless_launch_url_no_url(self, m):
         requires = {

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 import unittest
 
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas
@@ -11,7 +13,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestFile(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/test_folder.py
+++ b/tests/test_folder.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 import unittest
 
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas
@@ -12,7 +14,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestFolder(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1,7 +1,9 @@
+from __future__ import unicode_literals
 import os
 import unittest
 import uuid
 
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas
@@ -20,7 +22,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestGroup(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
@@ -139,9 +140,9 @@ class TestGroup(unittest.TestCase):
     def test_upload(self, m):
         register_uris({'group': ['upload', 'upload_final']}, m)
 
-        filename = 'testfile_%s' % uuid.uuid4().hex
-        file = open(filename, 'w+')
-        response = self.group.upload(file)
+        filename = 'testfile_group_%s' % uuid.uuid4().hex
+        with open(filename, 'w+') as file:
+            response = self.group.upload(file)
         self.assertTrue(response[0])
         self.assertIsInstance(response[1], dict)
         self.assertIn('url', response[1])
@@ -207,8 +208,8 @@ class TestGroup(unittest.TestCase):
         discussion = self.group.get_discussion_topic(group_id)
         self.assertIsInstance(discussion, DiscussionTopic)
         self.assertTrue(hasattr(discussion, 'group_id'))
-        self.assertEquals(group_id, discussion.id)
-        self.assertEquals(discussion.group_id, 1)
+        self.assertEqual(group_id, discussion.id)
+        self.assertEqual(discussion.group_id, 1)
 
     # get_full_discussion_topic
     def test_get_full_discussion_topic(self, m):
@@ -219,7 +220,7 @@ class TestGroup(unittest.TestCase):
         self.assertIsInstance(discussion, DiscussionTopic)
         self.assertTrue(hasattr(discussion, 'view'))
         self.assertTrue(hasattr(discussion, 'participants'))
-        self.assertEquals(discussion.group_id, 1)
+        self.assertEqual(discussion.group_id, 1)
 
     # get_discussion_topics()
     def test_get_discussion_topics(self, m):
@@ -229,7 +230,7 @@ class TestGroup(unittest.TestCase):
         discussion_list = [discussion for discussion in response]
         self.assertIsInstance(discussion_list[0], DiscussionTopic)
         self.assertTrue(hasattr(discussion_list[0], 'group_id'))
-        self.assertEquals(2, len(discussion_list))
+        self.assertEqual(2, len(discussion_list))
 
     # create_discussion_topic()
     def test_create_discussion_topic(self, m):
@@ -239,8 +240,8 @@ class TestGroup(unittest.TestCase):
         discussion = self.group.create_discussion_topic()
         self.assertTrue(hasattr(discussion, 'group_id'))
         self.assertIsInstance(discussion, DiscussionTopic)
-        self.assertEquals(discussion.title, title)
-        self.assertEquals(discussion.group_id, 1)
+        self.assertEqual(discussion.title, title)
+        self.assertEqual(discussion.group_id, 1)
 
     # reorder_pinned_topics()
     def test_reorder_pinned_topics(self, m):
@@ -335,7 +336,6 @@ class TestGroup(unittest.TestCase):
 @requests_mock.Mocker()
 class TestGroupMembership(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
@@ -379,7 +379,6 @@ class TestGroupMembership(unittest.TestCase):
 @requests_mock.Mocker()
 class TestGroupCategory(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
         with requests_mock.Mocker() as m:

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 import unittest
 
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas
@@ -11,7 +13,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestLogin(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 import unittest
 
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas
@@ -12,7 +14,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestModule(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
@@ -112,7 +113,6 @@ class TestModule(unittest.TestCase):
 @requests_mock.Mocker()
 class TestModuleItem(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,11 +1,11 @@
 import unittest
-import settings
 
 import requests_mock
 
 from canvasapi import Canvas
 from canvasapi.exceptions import RequiredFieldMissing
 from canvasapi.module import Module, ModuleItem
+from tests import settings
 from tests.util import register_uris
 
 

--- a/tests/test_notification_preference.py
+++ b/tests/test_notification_preference.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 import unittest
 
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas
@@ -10,7 +12,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestNotificationPreference(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 import unittest
 
+from builtins import str
 import requests_mock
 
 from canvasapi.canvas import Canvas
@@ -13,7 +15,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestPage(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
@@ -136,7 +137,6 @@ class TestPage(unittest.TestCase):
 @requests_mock.Mocker()
 class TestPageRevision(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/test_page_view.py
+++ b/tests/test_page_view.py
@@ -4,7 +4,7 @@ import requests_mock
 
 from canvasapi import Canvas
 from tests import settings
-from util import register_uris
+from tests.util import register_uris
 
 
 @requests_mock.Mocker()

--- a/tests/test_page_view.py
+++ b/tests/test_page_view.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 import unittest
 
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas
@@ -10,7 +12,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestPageView(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/test_paginated_list.py
+++ b/tests/test_paginated_list.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 
 import requests_mock
@@ -12,7 +13,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestPaginatedList(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
         self.requester = self.canvas._Canvas__requester
@@ -100,7 +100,7 @@ class TestPaginatedList(unittest.TestCase):
         )
         list_1 = [item for item in pag_list]
         list_2 = [item for item in pag_list]
-        self.assertEqual(cmp(list_1, list_2), 0)
+        self.assertEqual(list_1, list_2)
 
     # get item
     def test_getitem_first(self, m):

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -2,10 +2,10 @@ import unittest
 
 import requests_mock
 
-import settings
 from canvasapi.canvas import Canvas
 from canvasapi.progress import Progress
-from util import register_uris
+from tests import settings
+from tests.util import register_uris
 
 
 @requests_mock.Mocker()

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 import unittest
 
+from builtins import str
 import requests_mock
 
 from canvasapi.canvas import Canvas
@@ -11,7 +13,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestProgress(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/test_quiz.py
+++ b/tests/test_quiz.py
@@ -1,10 +1,10 @@
 import unittest
-import settings
 
 import requests_mock
 
 from canvasapi import Canvas
 from canvasapi.quiz import Quiz
+from tests import settings
 from tests.util import register_uris
 
 

--- a/tests/test_quiz.py
+++ b/tests/test_quiz.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 import unittest
 
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas
@@ -11,7 +13,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestQuiz(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/test_requester.py
+++ b/tests/test_requester.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 
 import requests_mock
@@ -14,7 +15,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestRequester(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
         self.requester = self.canvas._Canvas__requester

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -1,4 +1,7 @@
+from __future__ import unicode_literals
 import unittest
+
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas
@@ -13,7 +16,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestSection(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -1,5 +1,4 @@
 import unittest
-import settings
 import requests_mock
 
 from canvasapi import Canvas
@@ -7,6 +6,7 @@ from canvasapi.enrollment import Enrollment
 from canvasapi.exceptions import RequiredFieldMissing
 from canvasapi.section import Section
 from canvasapi.submission import Submission
+from tests import settings
 from tests.util import register_uris
 
 

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 import unittest
 
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas
@@ -10,7 +12,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestSubmission(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/test_tab.py
+++ b/tests/test_tab.py
@@ -1,5 +1,7 @@
+from __future__ import unicode_literals
 import unittest
 
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas
@@ -10,7 +12,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestTab(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1,6 +1,7 @@
+from __future__ import unicode_literals
+import os
 import unittest
 import uuid
-import os
 
 import requests_mock
 
@@ -13,15 +14,15 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestUploader(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
         self.requester = self.canvas._Canvas__requester
 
-        self.filename = 'testfile_%s' % uuid.uuid4().hex
+        self.filename = 'testfile_uploader_%s' % uuid.uuid4().hex
         self.file = open(self.filename, 'w+')
 
     def tearDown(self):
+        self.file.close()
         # http://stackoverflow.com/a/10840586
         # Not as stupid as it looks.
         try:

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -23,6 +23,7 @@ class TestUploader(unittest.TestCase):
 
     def tearDown(self):
         self.file.close()
+
         # http://stackoverflow.com/a/10840586
         # Not as stupid as it looks.
         try:

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,7 +1,9 @@
+from __future__ import unicode_literals
+import os
 import unittest
 import uuid
-import os
 
+from builtins import str
 import requests_mock
 
 from canvasapi import Canvas
@@ -25,7 +27,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestUser(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
@@ -194,10 +195,9 @@ class TestUser(unittest.TestCase):
     def test_upload(self, m):
         register_uris({'user': ['upload', 'upload_final']}, m)
 
-        filename = 'testfile_%s' % uuid.uuid4().hex
-        file = open(filename, 'w+')
-
-        response = self.user.upload(file)
+        filename = 'testfile_user_%s' % uuid.uuid4().hex
+        with open(filename, 'w+') as file:
+            response = self.user.upload(file)
 
         self.assertTrue(response[0])
         self.assertIsInstance(response[1], dict)
@@ -360,7 +360,6 @@ class TestUser(unittest.TestCase):
 @requests_mock.Mocker()
 class TestUserDisplay(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 
 import requests_mock
@@ -13,7 +14,6 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestUtil(unittest.TestCase):
 
-    @classmethod
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import json
 
 import requests_mock
@@ -48,4 +49,4 @@ def register_uris(requirements, requests_mocker):
                     headers=obj.get('headers', {})
                 )
             except Exception as e:
-                print e
+                print(e)

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import json
 
 import requests_mock
@@ -15,10 +15,11 @@ def register_uris(requirements, requests_mocker):
     :param requirements: dict
     :param requests_mocker: requests_mock.mocker.Mocker
     """
-    for fixture, objects in requirements.iteritems():
+    for fixture, objects in requirements.items():
 
         try:
-            data = json.loads(open('tests/fixtures/{}.json'.format(fixture)).read())
+            with open('tests/fixtures/{}.json'.format(fixture)) as file:
+                data = json.loads(file.read())
         except IOError:
             raise ValueError('Fixture {}.json contains invalid JSON.'.format(fixture))
 


### PR DESCRIPTION
Adds support for Python 3.3, 3.4, 3.5, 3.6 while maintaining compatibility for Python 2.7.

Also fixes a previously unnoticed bug where files weren't always properly closed in the Uploader class.

Resolves #37 