### PR TITLE
Issue/43 broken kwargs

### DIFF
--- a/canvasapi/__init__.py
+++ b/canvasapi/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from canvasapi.canvas import Canvas
 

--- a/canvasapi/account.py
+++ b/canvasapi/account.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from builtins import str
 

--- a/canvasapi/account.py
+++ b/canvasapi/account.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from builtins import str
+from six import python_2_unicode_compatible
 
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.exceptions import RequiredFieldMissing
@@ -8,6 +8,7 @@ from canvasapi.paginated_list import PaginatedList
 from canvasapi.util import combine_kwargs, obj_or_id
 
 
+@python_2_unicode_compatible
 class Account(CanvasObject):
 
     def __str__(self):
@@ -920,25 +921,29 @@ class Account(CanvasObject):
         return SSOSettings(self._requester, response.json())
 
 
+@python_2_unicode_compatible
 class AccountNotification(CanvasObject):
 
     def __str__(self):  # pragma: no cover
-        return str(self.subject)
+        return "{}".format(self.subject)
 
 
+@python_2_unicode_compatible
 class AccountReport(CanvasObject):
 
     def __str__(self):  # pragma: no cover
         return "{} ({})".format(self.report, self.id)
 
 
+@python_2_unicode_compatible
 class Role(CanvasObject):
 
     def __str__(self):  # pragma: no cover
         return "{} ({})".format(self.label, self.base_role_type)
 
 
+@python_2_unicode_compatible
 class SSOSettings(CanvasObject):
 
-    def __str___(self):  # pragma: no cover
+    def __str__(self):  # pragma: no cover
         return"{} ({})".format(self.login_handle_name, self.change_password_url)

--- a/canvasapi/appointment_group.py
+++ b/canvasapi/appointment_group.py
@@ -6,6 +6,7 @@ from canvasapi.canvas_object import CanvasObject
 from canvasapi.exceptions import RequiredFieldMissing
 from canvasapi.util import combine_kwargs
 
+
 @python_2_unicode_compatible
 class AppointmentGroup(CanvasObject):
 

--- a/canvasapi/appointment_group.py
+++ b/canvasapi/appointment_group.py
@@ -1,11 +1,16 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from six import python_2_unicode_compatible
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.exceptions import RequiredFieldMissing
 from canvasapi.util import combine_kwargs
 
-
+@python_2_unicode_compatible
 class AppointmentGroup(CanvasObject):
+
+    def __str__(self):
+        return "{} ({})".format(self.title, self.id)
 
     def delete(self, **kwargs):
         """
@@ -49,6 +54,3 @@ class AppointmentGroup(CanvasObject):
             super(AppointmentGroup, self).set_attributes(response.json())
 
         return AppointmentGroup(self._requester, response.json())
-
-    def __str__(self):
-        return "{} ({})".format(self.title, self.id)

--- a/canvasapi/appointment_group.py
+++ b/canvasapi/appointment_group.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.exceptions import RequiredFieldMissing

--- a/canvasapi/assignment.py
+++ b/canvasapi/assignment.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from six import python_2_unicode_compatible
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 
 
+@python_2_unicode_compatible
 class Assignment(CanvasObject):
 
     def __str__(self):
@@ -45,6 +48,7 @@ class Assignment(CanvasObject):
         return Assignment(self._requester, response.json())
 
 
+@python_2_unicode_compatible
 class AssignmentGroup(CanvasObject):
 
     def __str__(self):

--- a/canvasapi/assignment.py
+++ b/canvasapi/assignment.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs

--- a/canvasapi/authentication_provider.py
+++ b/canvasapi/authentication_provider.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs

--- a/canvasapi/authentication_provider.py
+++ b/canvasapi/authentication_provider.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from six import python_2_unicode_compatible
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 
 
+@python_2_unicode_compatible
 class AuthenticationProvider(CanvasObject):
 
     def __str__(self):  # pragma: no cover

--- a/canvasapi/avatar.py
+++ b/canvasapi/avatar.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from builtins import str
 

--- a/canvasapi/avatar.py
+++ b/canvasapi/avatar.py
@@ -1,11 +1,12 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from builtins import str
+from six import python_2_unicode_compatible
 
 from canvasapi.canvas_object import CanvasObject
 
 
+@python_2_unicode_compatible
 class Avatar(CanvasObject):
 
     def __str__(self):  # pragma: no cover
-        return str(self.display_name)
+        return "{}".format(self.display_name)

--- a/canvasapi/bookmark.py
+++ b/canvasapi/bookmark.py
@@ -1,10 +1,16 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from six import python_2_unicode_compatible
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 
 
+@python_2_unicode_compatible
 class Bookmark(CanvasObject):
+
+    def __str__(self):
+        return "{} ({})".format(self.name, self.id)
 
     def delete(self):
         """
@@ -40,6 +46,3 @@ class Bookmark(CanvasObject):
             super(Bookmark, self).set_attributes(response.json())
 
         return Bookmark(self._requester, response.json())
-
-    def __str__(self):
-        return "{} ({})".format(self.name, self.id)

--- a/canvasapi/bookmark.py
+++ b/canvasapi/bookmark.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs

--- a/canvasapi/calendar_event.py
+++ b/canvasapi/calendar_event.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs

--- a/canvasapi/calendar_event.py
+++ b/canvasapi/calendar_event.py
@@ -6,6 +6,9 @@ from canvasapi.util import combine_kwargs
 
 class CalendarEvent(CanvasObject):
 
+    def __str__(self):
+        return "{} ({})".format(self.title, self.id)
+
     def delete(self, **kwargs):
         """
         Delete this calendar event.
@@ -41,6 +44,3 @@ class CalendarEvent(CanvasObject):
             super(CalendarEvent, self).set_attributes(response.json())
 
         return CalendarEvent(self._requester, response.json())
-
-    def __str__(self):
-        return "{} ({})".format(self.title, self.id)

--- a/canvasapi/canvas.py
+++ b/canvasapi/canvas.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from builtins import object
-
 from canvasapi.account import Account
 from canvasapi.course import Course
 from canvasapi.exceptions import RequiredFieldMissing

--- a/canvasapi/canvas.py
+++ b/canvasapi/canvas.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from builtins import object
 

--- a/canvasapi/canvas_object.py
+++ b/canvasapi/canvas_object.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import json
 import re
 
-from builtins import str, object
+from six import text_type
 
 DATE_PATTERN = re.compile('[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z')
 
@@ -68,6 +68,6 @@ class CanvasObject(object):
             self.__setattr__(attribute, value)
 
             # datetime field
-            if DATE_PATTERN.match(str(value)):
+            if DATE_PATTERN.match(text_type(value)):
                 date = datetime.strptime(value, '%Y-%m-%dT%H:%M:%SZ')
                 self.__setattr__(attribute + '_date', date)

--- a/canvasapi/canvas_object.py
+++ b/canvasapi/canvas_object.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 from datetime import datetime
 import json
 import re

--- a/canvasapi/communication_channel.py
+++ b/canvasapi/communication_channel.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.notification_preference import NotificationPreference

--- a/canvasapi/communication_channel.py
+++ b/canvasapi/communication_channel.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from six import python_2_unicode_compatible
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.notification_preference import NotificationPreference
 
 
+@python_2_unicode_compatible
 class CommunicationChannel(CanvasObject):
 
     def __str__(self):

--- a/canvasapi/conversation.py
+++ b/canvasapi/conversation.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from six import python_2_unicode_compatible
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 
 
+@python_2_unicode_compatible
 class Conversation(CanvasObject):
 
     def __str__(self):

--- a/canvasapi/conversation.py
+++ b/canvasapi/conversation.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs

--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.discussion_topic import DiscussionTopic

--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from six import python_2_unicode_compatible
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.discussion_topic import DiscussionTopic
 from canvasapi.exceptions import RequiredFieldMissing
@@ -13,6 +15,7 @@ from canvasapi.user import UserDisplay
 from canvasapi.util import combine_kwargs
 
 
+@python_2_unicode_compatible
 class Course(CanvasObject):
 
     def __str__(self):
@@ -1409,6 +1412,7 @@ class Course(CanvasObject):
         return Tab(self._requester, response.json())
 
 
+@python_2_unicode_compatible
 class CourseNickname(CanvasObject):
 
     def __str__(self):

--- a/canvasapi/discussion_topic.py
+++ b/canvasapi/discussion_topic.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.paginated_list import PaginatedList

--- a/canvasapi/discussion_topic.py
+++ b/canvasapi/discussion_topic.py
@@ -1,10 +1,13 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from six import python_2_unicode_compatible
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.paginated_list import PaginatedList
 from canvasapi.util import combine_kwargs
 
 
+@python_2_unicode_compatible
 class DiscussionTopic(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.title, self.id)

--- a/canvasapi/enrollment.py
+++ b/canvasapi/enrollment.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from canvasapi.canvas_object import CanvasObject
 

--- a/canvasapi/enrollment.py
+++ b/canvasapi/enrollment.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from six import python_2_unicode_compatible
+
 from canvasapi.canvas_object import CanvasObject
 
 
+@python_2_unicode_compatible
 class Enrollment(CanvasObject):
 
     def __str__(self):

--- a/canvasapi/enrollment_term.py
+++ b/canvasapi/enrollment_term.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs

--- a/canvasapi/enrollment_term.py
+++ b/canvasapi/enrollment_term.py
@@ -1,10 +1,16 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from six import python_2_unicode_compatible
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 
 
+@python_2_unicode_compatible
 class EnrollmentTerm(CanvasObject):
+
+    def __str__(self):
+        return "{} ({})".format(self.name, self.id)
 
     def delete(self):
         """
@@ -37,6 +43,3 @@ class EnrollmentTerm(CanvasObject):
         )
 
         return EnrollmentTerm(self._requester, response.json())
-
-    def __str__(self):
-        return "{} ({})".format(self.name, self.id)

--- a/canvasapi/exceptions.py
+++ b/canvasapi/exceptions.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from builtins import str
+from six import python_2_unicode_compatible, text_type
 
 
+@python_2_unicode_compatible
 class CanvasException(Exception):  # pragma: no cover
     """
     Base class for all errors returned by the Canvas API.
@@ -13,14 +14,14 @@ class CanvasException(Exception):  # pragma: no cover
 
             errors = message.get('errors', False)
             if errors:
-                self.message = str(errors)
+                self.message = errors
             else:
                 self.message = ('Something went wrong. ', message)
         else:
             self.message = message
 
     def __str__(self):
-        return self.message
+        return text_type(self.message)
 
 
 class BadRequest(CanvasException):

--- a/canvasapi/exceptions.py
+++ b/canvasapi/exceptions.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from builtins import str
 

--- a/canvasapi/external_feed.py
+++ b/canvasapi/external_feed.py
@@ -5,6 +5,7 @@ from six import python_2_unicode_compatible
 from canvasapi.canvas_object import CanvasObject
 
 
+@python_2_unicode_compatible
 class ExternalFeed(CanvasObject):
 
     def __str__(self):

--- a/canvasapi/external_feed.py
+++ b/canvasapi/external_feed.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from builtins import str
 

--- a/canvasapi/external_feed.py
+++ b/canvasapi/external_feed.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from builtins import str
+from six import python_2_unicode_compatible
 
 from canvasapi.canvas_object import CanvasObject
 
@@ -8,4 +8,4 @@ from canvasapi.canvas_object import CanvasObject
 class ExternalFeed(CanvasObject):
 
     def __str__(self):
-        return str(self.display_name)
+        return "{}".format(self.display_name)

--- a/canvasapi/external_tool.py
+++ b/canvasapi/external_tool.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.exceptions import CanvasException

--- a/canvasapi/external_tool.py
+++ b/canvasapi/external_tool.py
@@ -1,10 +1,13 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from six import python_2_unicode_compatible
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.exceptions import CanvasException
 from canvasapi.util import combine_kwargs
 
 
+@python_2_unicode_compatible
 class ExternalTool(CanvasObject):
 
     def __str__(self):

--- a/canvasapi/file.py
+++ b/canvasapi/file.py
@@ -1,14 +1,15 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from builtins import str
+from six import python_2_unicode_compatible
 
 from canvasapi.canvas_object import CanvasObject
 
 
+@python_2_unicode_compatible
 class File(CanvasObject):
 
     def __str__(self):
-        return str(self.display_name)
+        return "{}".format(self.display_name)
 
     def delete(self):
         """

--- a/canvasapi/file.py
+++ b/canvasapi/file.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from builtins import str
 

--- a/canvasapi/folder.py
+++ b/canvasapi/folder.py
@@ -1,16 +1,17 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from builtins import str
+from six import python_2_unicode_compatible
 
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.paginated_list import PaginatedList
 from canvasapi.util import combine_kwargs
 
 
+@python_2_unicode_compatible
 class Folder(CanvasObject):
 
     def __str__(self):
-        return str(self.full_name)
+        return "{}".format(self.full_name)
 
     def list_files(self, **kwargs):
         """

--- a/canvasapi/folder.py
+++ b/canvasapi/folder.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from builtins import str
 

--- a/canvasapi/group.py
+++ b/canvasapi/group.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.discussion_topic import DiscussionTopic

--- a/canvasapi/group.py
+++ b/canvasapi/group.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from six import python_2_unicode_compatible
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.discussion_topic import DiscussionTopic
 from canvasapi.folder import Folder
@@ -9,6 +11,7 @@ from canvasapi.tab import Tab
 from canvasapi.util import combine_kwargs
 
 
+@python_2_unicode_compatible
 class Group(CanvasObject):
 
     def __str__(self):
@@ -636,6 +639,7 @@ class Group(CanvasObject):
         )
 
 
+@python_2_unicode_compatible
 class GroupMembership(CanvasObject):
 
     def __str__(self):
@@ -698,6 +702,7 @@ class GroupMembership(CanvasObject):
         return response.json()
 
 
+@python_2_unicode_compatible
 class GroupCategory(CanvasObject):
 
     def __str__(self):

--- a/canvasapi/login.py
+++ b/canvasapi/login.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from six import python_2_unicode_compatible
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 
 
+@python_2_unicode_compatible
 class Login(CanvasObject):
 
     def __str__(self):

--- a/canvasapi/login.py
+++ b/canvasapi/login.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs

--- a/canvasapi/module.py
+++ b/canvasapi/module.py
@@ -1,11 +1,14 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from six import python_2_unicode_compatible
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.exceptions import RequiredFieldMissing
 from canvasapi.paginated_list import PaginatedList
 from canvasapi.util import combine_kwargs
 
 
+@python_2_unicode_compatible
 class Module(CanvasObject):
 
     def __str__(self):
@@ -139,6 +142,7 @@ class Module(CanvasObject):
         return ModuleItem(self._requester, module_item_json)
 
 
+@python_2_unicode_compatible
 class ModuleItem(CanvasObject):
 
     def __str__(self):

--- a/canvasapi/module.py
+++ b/canvasapi/module.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.exceptions import RequiredFieldMissing

--- a/canvasapi/notification_preference.py
+++ b/canvasapi/notification_preference.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from canvasapi.canvas_object import CanvasObject
 

--- a/canvasapi/notification_preference.py
+++ b/canvasapi/notification_preference.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from six import python_2_unicode_compatible
+
 from canvasapi.canvas_object import CanvasObject
 
 
+@python_2_unicode_compatible
 class NotificationPreference(CanvasObject):
 
     def __str__(self):

--- a/canvasapi/page.py
+++ b/canvasapi/page.py
@@ -1,10 +1,13 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from six import python_2_unicode_compatible
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 from canvasapi.paginated_list import PaginatedList
 
 
+@python_2_unicode_compatible
 class Page(CanvasObject):
 
     def __str__(self):
@@ -188,6 +191,7 @@ class Page(CanvasObject):
         return PageRevision(self._requester, pagerev_json)
 
 
+@python_2_unicode_compatible
 class PageRevision(CanvasObject):
 
     def __str__(self):

--- a/canvasapi/page.py
+++ b/canvasapi/page.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs

--- a/canvasapi/page_view.py
+++ b/canvasapi/page_view.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from canvasapi.canvas_object import CanvasObject
 

--- a/canvasapi/page_view.py
+++ b/canvasapi/page_view.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from six import python_2_unicode_compatible
+
 from canvasapi.canvas_object import CanvasObject
 
 
+@python_2_unicode_compatible
 class PageView(CanvasObject):
 
     def __str__(self):

--- a/canvasapi/paginated_list.py
+++ b/canvasapi/paginated_list.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import re
 
-from builtins import object
-
 
 class PaginatedList(object):
     """

--- a/canvasapi/paginated_list.py
+++ b/canvasapi/paginated_list.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import re
 
 from builtins import object

--- a/canvasapi/progress.py
+++ b/canvasapi/progress.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from canvasapi.canvas_object import CanvasObject
 

--- a/canvasapi/progress.py
+++ b/canvasapi/progress.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from six import python_2_unicode_compatible
+
 from canvasapi.canvas_object import CanvasObject
 
 
+@python_2_unicode_compatible
 class Progress(CanvasObject):
 
     def __str__(self):

--- a/canvasapi/quiz.py
+++ b/canvasapi/quiz.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from six import python_2_unicode_compatible
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 
 
+@python_2_unicode_compatible
 class Quiz(CanvasObject):
 
     def __str__(self):

--- a/canvasapi/quiz.py
+++ b/canvasapi/quiz.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs

--- a/canvasapi/requester.py
+++ b/canvasapi/requester.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from builtins import object
 import requests

--- a/canvasapi/requester.py
+++ b/canvasapi/requester.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from builtins import object
 import requests
 
 from canvasapi.exceptions import (

--- a/canvasapi/section.py
+++ b/canvasapi/section.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.exceptions import RequiredFieldMissing

--- a/canvasapi/section.py
+++ b/canvasapi/section.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from six import python_2_unicode_compatible
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.exceptions import RequiredFieldMissing
 from canvasapi.paginated_list import PaginatedList
@@ -7,6 +9,7 @@ from canvasapi.submission import Submission
 from canvasapi.util import combine_kwargs
 
 
+@python_2_unicode_compatible
 class Section(CanvasObject):
 
     def __str__(self):

--- a/canvasapi/submission.py
+++ b/canvasapi/submission.py
@@ -1,11 +1,12 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from builtins import str
+from six import python_2_unicode_compatible
 
 from canvasapi.canvas_object import CanvasObject
 
 
+@python_2_unicode_compatible
 class Submission(CanvasObject):
 
     def __str__(self):
-        return str(self.id)
+        return "{}".format(self.id)

--- a/canvasapi/submission.py
+++ b/canvasapi/submission.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from builtins import str
 

--- a/canvasapi/tab.py
+++ b/canvasapi/tab.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from canvasapi.canvas_object import CanvasObject
 

--- a/canvasapi/tab.py
+++ b/canvasapi/tab.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from six import python_2_unicode_compatible
+
 from canvasapi.canvas_object import CanvasObject
 
 
+@python_2_unicode_compatible
 class Tab(CanvasObject):
 
     def __str__(self):

--- a/canvasapi/upload.py
+++ b/canvasapi/upload.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 
 from builtins import object, str

--- a/canvasapi/upload.py
+++ b/canvasapi/upload.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 
-from builtins import object, str
+from six import string_types
 
 from canvasapi.util import combine_kwargs
 
@@ -20,7 +20,7 @@ class Uploader(object):
         :param file: A file handler or path of the file to upload.
         :type file: file or str
         """
-        if isinstance(file, str):
+        if isinstance(file, string_types):
             if not os.path.exists(file):
                 raise IOError('File ' + file + ' does not exist.')
             self._using_filename = True

--- a/canvasapi/user.py
+++ b/canvasapi/user.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from builtins import str
+from six import python_2_unicode_compatible
 
 from canvasapi.bookmark import Bookmark
 from canvasapi.calendar_event import CalendarEvent
@@ -12,6 +12,7 @@ from canvasapi.upload import Uploader
 from canvasapi.util import combine_kwargs, obj_or_id
 
 
+@python_2_unicode_compatible
 class User(CanvasObject):
 
     def __str__(self):
@@ -611,7 +612,8 @@ class User(CanvasObject):
         return User(self._requester, response.json())
 
 
+@python_2_unicode_compatible
 class UserDisplay(CanvasObject):
 
     def __str__(self):
-        return str(self.display_name)
+        return "{}".format(self.display_name)

--- a/canvasapi/user.py
+++ b/canvasapi/user.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from builtins import str
 

--- a/canvasapi/util.py
+++ b/canvasapi/util.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from builtins import str
+from six import text_type
 
 
 def combine_kwargs(**kwargs):
@@ -10,7 +10,7 @@ def combine_kwargs(**kwargs):
     :rtype: dict
     """
     def flatten_dict(prefix, key, value):
-        new_prefix = prefix + '[' + str(key) + ']'
+        new_prefix = prefix + '[' + text_type(key) + ']'
         if isinstance(value, dict):
             d = {}
             for k, v in value.items():
@@ -26,9 +26,9 @@ def combine_kwargs(**kwargs):
         if isinstance(arg, dict):
             # If the argument is a dictionary, flatten it.
             for key, value in arg.items():
-                combined_kwargs.update(flatten_dict(str(kw), key, value))
+                combined_kwargs.update(flatten_dict(text_type(kw), key, value))
         else:
-            combined_kwargs.update({str(kw): arg})
+            combined_kwargs.update({text_type(kw): arg})
     return combined_kwargs
 
 

--- a/canvasapi/util.py
+++ b/canvasapi/util.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from builtins import str
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,13 +1,13 @@
 -r tests_requirements.txt
 
-alabaster==0.7.8
-Babel==2.3.4
-docutils==0.12
-imagesize==0.7.1
-Jinja2==2.8
-MarkupSafe==0.23
-Pygments==2.1.3
-pytz==2016.4
-snowballstemmer==1.2.1
-Sphinx==1.4.4
-sphinx-rtd-theme==0.1.9
+alabaster
+Babel
+docutils
+imagesize
+Jinja2
+MarkupSafe
+Pygments
+pytz
+snowballstemmer
+Sphinx
+sphinx-rtd-theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-future==0.16.0
-requests==2.10.0
-six==1.10.0
+requests
+six

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     license='MIT License',
     packages=['canvasapi'],
     include_package_data=True,
-    install_requires=['requests', 'future'],
+    install_requires=['requests', 'six'],
     zip_safe=False,
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import re
 from setuptools import setup
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 BASE_URL = 'http://example.com/api/v1/'
 API_KEY = '123'

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import datetime
 import unittest
 

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import datetime
 import unittest
 
-from builtins import str
 import requests_mock
 
 from canvasapi import Canvas

--- a/tests/test_appointment_group.py
+++ b/tests/test_appointment_group.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 from builtins import str

--- a/tests/test_appointment_group.py
+++ b/tests/test_appointment_group.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
-from builtins import str
 import requests_mock
 
 from canvasapi import Canvas

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 from builtins import str

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
-from builtins import str
 import requests_mock
 
 from canvasapi import Canvas

--- a/tests/test_authentication_providers.py
+++ b/tests/test_authentication_providers.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 from builtins import str

--- a/tests/test_authentication_providers.py
+++ b/tests/test_authentication_providers.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
-from builtins import str
 import requests_mock
 
 from canvasapi import Canvas

--- a/tests/test_bookmark.py
+++ b/tests/test_bookmark.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 from builtins import str

--- a/tests/test_bookmark.py
+++ b/tests/test_bookmark.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
-from builtins import str
 import requests_mock
 
 from canvasapi import Canvas

--- a/tests/test_calendar_event.py
+++ b/tests/test_calendar_event.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 from builtins import str

--- a/tests/test_calendar_event.py
+++ b/tests/test_calendar_event.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
-from builtins import str
 import requests_mock
 
 from canvasapi import Canvas

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 from datetime import datetime
 
-from builtins import str
 import requests_mock
+from six import text_type
 
 from canvasapi import Canvas
 from canvasapi.account import Account
@@ -88,7 +88,7 @@ class TestCanvas(unittest.TestCase):
         course = self.canvas.get_course(2)
 
         self.assertTrue(hasattr(course, 'start_at'))
-        self.assertIsInstance(course.start_at, str)
+        self.assertIsInstance(course.start_at, text_type)
         self.assertTrue(hasattr(course, 'start_at_date'))
         self.assertIsInstance(course.start_at_date, datetime)
 

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 from datetime import datetime
 

--- a/tests/test_canvas_object.py
+++ b/tests/test_canvas_object.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 from canvasapi.canvas_object import CanvasObject

--- a/tests/test_communication_channel.py
+++ b/tests/test_communication_channel.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 from builtins import str

--- a/tests/test_communication_channel.py
+++ b/tests/test_communication_channel.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
-from builtins import str
 import requests_mock
 
 from canvasapi import Canvas

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 from builtins import str

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
-from builtins import str
 import requests_mock
 
 from canvasapi import Canvas

--- a/tests/test_course.py
+++ b/tests/test_course.py
@@ -3,8 +3,8 @@ import unittest
 import uuid
 import os
 
-from builtins import str
 import requests_mock
+from six import text_type
 
 from canvasapi import Canvas
 from canvasapi.assignment import Assignment, AssignmentGroup
@@ -136,7 +136,7 @@ class TestCourse(unittest.TestCase):
         html_str = "<script></script><p>hello</p>"
         prev_html = self.course.preview_html(html_str)
 
-        self.assertIsInstance(prev_html, str)
+        self.assertIsInstance(prev_html, text_type)
         self.assertEqual(prev_html, "<p>hello</p>")
 
     # get_settings()

--- a/tests/test_course.py
+++ b/tests/test_course.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 import uuid
 import os

--- a/tests/test_discussion_topic.py
+++ b/tests/test_discussion_topic.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 from builtins import str

--- a/tests/test_discussion_topic.py
+++ b/tests/test_discussion_topic.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
-from builtins import str
 import requests_mock
 
 from canvasapi import Canvas

--- a/tests/test_enrollment.py
+++ b/tests/test_enrollment.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 from builtins import str

--- a/tests/test_enrollment.py
+++ b/tests/test_enrollment.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
-from builtins import str
 import requests_mock
 
 from canvasapi.canvas import Canvas

--- a/tests/test_enrollment_term.py
+++ b/tests/test_enrollment_term.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 from builtins import str

--- a/tests/test_enrollment_term.py
+++ b/tests/test_enrollment_term.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
-from builtins import str
 import requests_mock
 
 from canvasapi import Canvas

--- a/tests/test_external_feed.py
+++ b/tests/test_external_feed.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 from builtins import str

--- a/tests/test_external_feed.py
+++ b/tests/test_external_feed.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
-from builtins import str
 import requests_mock
 
 from canvasapi import Canvas

--- a/tests/test_external_tool.py
+++ b/tests/test_external_tool.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 from builtins import str

--- a/tests/test_external_tool.py
+++ b/tests/test_external_tool.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
-from builtins import str
 import requests_mock
+from six import text_type
 
 from canvasapi import Canvas
 from canvasapi.account import Account
@@ -94,7 +94,7 @@ class TestExternalTool(unittest.TestCase):
         requires = {'external_tool': ['get_sessionless_launch_url_course']}
         register_uris(requires, m)
 
-        self.assertIsInstance(self.ext_tool_course.get_sessionless_launch_url(), str)
+        self.assertIsInstance(self.ext_tool_course.get_sessionless_launch_url(), text_type)
 
     def test_get_sessionless_launch_url_no_url(self, m):
         requires = {

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 from builtins import str

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
-from builtins import str
 import requests_mock
 
 from canvasapi import Canvas

--- a/tests/test_folder.py
+++ b/tests/test_folder.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 from builtins import str

--- a/tests/test_folder.py
+++ b/tests/test_folder.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
-from builtins import str
 import requests_mock
 
 from canvasapi import Canvas

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import unittest
 import uuid

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -3,7 +3,6 @@ import os
 import unittest
 import uuid
 
-from builtins import str
 import requests_mock
 
 from canvasapi import Canvas

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 from builtins import str

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
-from builtins import str
 import requests_mock
 
 from canvasapi import Canvas

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 from builtins import str

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
-from builtins import str
 import requests_mock
 
 from canvasapi import Canvas

--- a/tests/test_notification_preference.py
+++ b/tests/test_notification_preference.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 from builtins import str

--- a/tests/test_notification_preference.py
+++ b/tests/test_notification_preference.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
-from builtins import str
 import requests_mock
 
 from canvasapi import Canvas

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 from builtins import str

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
-from builtins import str
 import requests_mock
 
 from canvasapi.canvas import Canvas

--- a/tests/test_page_view.py
+++ b/tests/test_page_view.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 from builtins import str

--- a/tests/test_page_view.py
+++ b/tests/test_page_view.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
-from builtins import str
 import requests_mock
 
 from canvasapi import Canvas

--- a/tests/test_paginated_list.py
+++ b/tests/test_paginated_list.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 from builtins import str

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
-from builtins import str
 import requests_mock
 
 from canvasapi.canvas import Canvas

--- a/tests/test_quiz.py
+++ b/tests/test_quiz.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 from builtins import str

--- a/tests/test_quiz.py
+++ b/tests/test_quiz.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
-from builtins import str
 import requests_mock
 
 from canvasapi import Canvas

--- a/tests/test_requester.py
+++ b/tests/test_requester.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 from builtins import str

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
-from builtins import str
 import requests_mock
 
 from canvasapi import Canvas

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 from builtins import str

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
-from builtins import str
 import requests_mock
 
 from canvasapi import Canvas

--- a/tests/test_tab.py
+++ b/tests/test_tab.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 from builtins import str

--- a/tests/test_tab.py
+++ b/tests/test_tab.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
-from builtins import str
 import requests_mock
 
 from canvasapi import Canvas

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import unittest
 import uuid

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import unittest
 import uuid

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -3,7 +3,6 @@ import os
 import unittest
 import uuid
 
-from builtins import str
 import requests_mock
 
 from canvasapi import Canvas

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import json
 
 import requests_mock

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
-coverage==4.1
-pycodestyle==2.3.0
-pyflakes==1.5.0
-requests-mock==1.2.0
+coverage
+pycodestyle
+pyflakes
+requests-mock


### PR DESCRIPTION
Fixed an issue where kwargs in Python 2.7 weren't properly being translated into url parameters. For example, `include='syllabus_body'` was being changed into `?b%27include%27=syllabus_body`, when it should read `?include=syllabus_body`.

Dropped use of the `future` package (specifically, using it to monkey-patch `str`) in favor of using `six` to handle unicode weirdness.

Also "un-pinned" specific versions of requirements.

Resolves #43 