### PR TITLE
Use flake8 instead of pyflakes and pycodestyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ python:
 install:
   - pip install -r tests_requirements.txt
   - pip install coveralls
+  - pip install flake8
   - gem install mdl
 script:
   - coverage run -m unittest discover
-  - pycodestyle canvasapi tests
-  - pyflakes canvasapi tests
+  - flake8 canvasapi tests
   - mdl *.md
 after_success:
   - coveralls

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [coverage:run]
 source = canvasapi/
 
-[pycodestyle]
+[flake8]
 max-line-length = 99


### PR DESCRIPTION
`flake8` is a wrapper around `pyflakes`, `pycodestyle`, and `mccabe`, and also can be further extended using third-party plugins.  The Travis-CI tests were already running `pyflakes` and `pycodestyle`.  We may as well unify both of those under the `flake8` umbrella so that we have a single place to manage configuration, unified output of any complaints, etc.

Note: if the `canvasapi` developers want to support `flake8` but prefer to retain the option of running `pycodestyle` directly as well, then my changes to `setup.cfg` should be changed slightly. Instead of renaming the `[pycodestyle]` section to `[flake8]`, there should instead be two sections, one named `[pycodestyle]` and one named `[flake8]`, both with the same `max-line-length = 99` content. I am happy to revise this pull request in this manner if asked.

By the way, bravo to the `canvasapi` developers for maintaining such a clean code base!