### PR TITLE
Ignore Eclipse and PyDev project metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 .DS_Store
 /*.egg-info
 /.coverage
+/.project
+/.pyproject
 /_build/
 /_static/
 /_templates/


### PR DESCRIPTION
Per closed pull request #67, the maintainers’ consensus is that such configuration files should be excluded from source control.