### PR TITLE
Correct the git command used to create and check out a new branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ Now that you've selected an issue to work on, you'll need to set up an environme
 
 1. Clone our repository by executing `git clone git@github.com:ucfopen/canvasapi.git`
 2. Pull the latest commit from the **master** branch: `git pull origin master`
-3. Create a new branch with the format **issue/[issue_number]-[issue-title]**: `git branch -b issue/1-test-issue-for-documentation`
+3. Create a new branch with the format **issue/[issue_number]-[issue-title]**: `git checkout -b issue/1-test-issue-for-documentation`
 4. Set up a new virtual environment ( `virtualenv env` ) and activate it (`source env/bin/activate`)
 5. Install the required dependencies with `pip install -r dev_requirements.txt`
 


### PR DESCRIPTION
`git branch` does not take a `-b` flag.  To create a new branch and check it out, one should use `git checkout -b`, not `git branch -b`.