### PR TITLE
Grouped Submission Response

### DIFF
--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
+from warnings import warn
 
 from six import python_2_unicode_compatible
 
@@ -1134,12 +1135,15 @@ class Course(CanvasObject):
         :rtype: :class:`canvasapi.paginated_list.PaginatedList` of
             :class:`canvasapi.submission.Submission`
         """
+        if 'grouped' in kwargs:
+            warn("The `grouped` parameter must be empty. Removing kwarg `grouped`.")
+            del kwargs['grouped']
+
         return PaginatedList(
             Submission,
             self._requester,
             'GET',
             'courses/%s/students/submissions' % (self.id),
-            grouped=False,
             _kwargs=combine_kwargs(**kwargs)
         )
 

--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -1136,7 +1136,7 @@ class Course(CanvasObject):
             :class:`canvasapi.submission.Submission`
         """
         if 'grouped' in kwargs:
-            warn("The `grouped` parameter must be empty. Removing kwarg `grouped`.")
+            warn('The `grouped` parameter must be empty. Removing kwarg `grouped`.')
             del kwargs['grouped']
 
         return PaginatedList(

--- a/canvasapi/section.py
+++ b/canvasapi/section.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
+from warnings import warn
 
 from six import python_2_unicode_compatible
 
@@ -157,12 +158,15 @@ class Section(CanvasObject):
         :rtype: :class:`canvasapi.paginated_list.PaginatedList` of
             :class:`canvasapi.submission.Submission`
         """
+        if 'grouped' in kwargs:
+            warn("The `grouped` parameter must be empty. Removing kwarg `grouped`.")
+            del kwargs['grouped']
+
         return PaginatedList(
             Submission,
             self._requester,
             'GET',
             'sections/%s/students/submissions' % (self.id),
-            grouped=False,
             _kwargs=combine_kwargs(**kwargs)
         )
 

--- a/canvasapi/section.py
+++ b/canvasapi/section.py
@@ -159,7 +159,7 @@ class Section(CanvasObject):
             :class:`canvasapi.submission.Submission`
         """
         if 'grouped' in kwargs:
-            warn("The `grouped` parameter must be empty. Removing kwarg `grouped`.")
+            warn('The `grouped` parameter must be empty. Removing kwarg `grouped`.')
             del kwargs['grouped']
 
         return PaginatedList(

--- a/tests/test_course.py
+++ b/tests/test_course.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
+import os
 import unittest
 import uuid
-import os
+import warnings
 
 import requests_mock
 from six import text_type
@@ -646,6 +647,25 @@ class TestCourse(unittest.TestCase):
 
         self.assertEqual(len(submission_list), 2)
         self.assertIsInstance(submission_list[0], Submission)
+
+    def test_list_multiple_submissions_grouped_param(self, m):
+        register_uris({'course': ['list_multiple_submissions']}, m)
+
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter('always')
+            submissions = self.course.list_multiple_submissions(grouped=True)
+            submission_list = [submission for submission in submissions]
+
+            # Ensure using the `grouped` param raises a warning
+            self.assertEqual(len(warning_list), 1)
+            self.assertEqual(warning_list[-1].category, UserWarning)
+            self.assertEqual(
+                text_type(warning_list[-1].message),
+                'The `grouped` parameter must be empty. Removing kwarg `grouped`.'
+            )
+
+            self.assertEqual(len(submission_list), 2)
+            self.assertIsInstance(submission_list[0], Submission)
 
     # get_submission()
     def test_get_submission(self, m):

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
+import warnings
 
 import requests_mock
+from six import text_type
 
 from canvasapi import Canvas
 from canvasapi.enrollment import Enrollment
@@ -103,6 +105,25 @@ class TestSection(unittest.TestCase):
 
         self.assertEqual(len(submission_list), 2)
         self.assertIsInstance(submission_list[0], Submission)
+
+    def test_list_multiple_submissions_grouped_param(self, m):
+        register_uris({'section': ['list_multiple_submissions']}, m)
+
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter('always')
+            submissions = self.section.list_multiple_submissions(grouped=True)
+            submission_list = [submission for submission in submissions]
+
+            # Ensure using the `grouped` param raises a warning
+            self.assertEqual(len(warning_list), 1)
+            self.assertEqual(warning_list[-1].category, UserWarning)
+            self.assertEqual(
+                text_type(warning_list[-1].message),
+                'The `grouped` parameter must be empty. Removing kwarg `grouped`.'
+            )
+
+            self.assertEqual(len(submission_list), 2)
+            self.assertIsInstance(submission_list[0], Submission)
 
     # get_submission()
     def test_get_submission(self, m):


### PR DESCRIPTION
Added warning for using `grouped` param in submissions. Delete `grouped` param if used rather than overriding to `False` (which doesn't work due to Canvas' terrible boolean handling)

Resolves #61