### PR TITLE
Issue #94: Generalize repeated "param[]=..." support to all iterables

### DIFF
--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -13,7 +13,7 @@ from canvasapi.tab import Tab
 from canvasapi.submission import Submission
 from canvasapi.upload import Uploader
 from canvasapi.user import UserDisplay
-from canvasapi.util import combine_kwargs
+from canvasapi.util import combine_kwargs, is_multivalued
 
 
 @python_2_unicode_compatible
@@ -900,13 +900,13 @@ class Course(CanvasObject):
 
         :param order: The ids of the pinned discussion topics in the desired order.
             e.g. [104, 102, 103], (104, 102, 103), or "104,102,103"
-        :type order: list, tuple, or string
+        :type order: string or iterable sequence of values
 
         :rtype: :class:`canvasapi.paginated_list.PaginatedList` of
             :class:`canvasapi.discussion_topic.DiscussionTopic`
         """
-        # Convert list or tuple to comma-separated string
-        if isinstance(order, (list, tuple)):
+        # Convert iterable sequence to comma-separated string
+        if is_multivalued(order):
             order = ",".join([text_type(topic_id) for topic_id in order])
 
         # Check if is a string with commas

--- a/canvasapi/group.py
+++ b/canvasapi/group.py
@@ -8,7 +8,7 @@ from canvasapi.folder import Folder
 from canvasapi.exceptions import RequiredFieldMissing
 from canvasapi.paginated_list import PaginatedList
 from canvasapi.tab import Tab
-from canvasapi.util import combine_kwargs
+from canvasapi.util import combine_kwargs, is_multivalued
 
 
 @python_2_unicode_compatible
@@ -469,13 +469,13 @@ class Group(CanvasObject):
 
         :param order: The ids of the pinned discussion topics in the desired order.
             e.g. [104, 102, 103]
-        :type order: list
+        :type order: iterable sequence of values
 
         :rtype: :class:`canvasapi.paginated_list.PaginatedList` of
             :class:`canvasapi.discussion_topic.DiscussionTopic`
         """
         # Convert list or tuple to comma-separated string
-        if isinstance(order, (list, tuple)):
+        if is_multivalued(order):
             order = ",".join([text_type(topic_id) for topic_id in order])
 
         # Check if is a string with commas

--- a/canvasapi/util.py
+++ b/canvasapi/util.py
@@ -1,6 +1,29 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from six import text_type
+from collections import Iterable
+from six import binary_type, string_types, text_type
+
+
+def is_multivalued(value):
+    """
+    Determine whether the given value should be treated as a sequence
+    of multiple values when used as a request parameter.
+
+    In general anything that is iterable is multivalued.  For example,
+    `list` and `tuple` instances are multivalued.  Generators are
+    multivalued, as are the iterable objects returned by `zip`,
+    `itertools.chain`, etc.  However, a simple `int` is single-valued.
+    `str` and `bytes` are special cases: although these are iterable,
+    we treat each as a single value rather than as a sequence of
+    isolated characters or bytes.
+    """
+
+    # special cases: iterable, but not multivalued
+    if isinstance(value, (string_types, binary_type)):
+        return False
+
+    # general rule: multivalued if iterable
+    return isinstance(value, Iterable)
 
 
 def combine_kwargs(**kwargs):
@@ -26,7 +49,7 @@ def combine_kwargs(**kwargs):
             for k, v in arg.items():
                 for tup in flatten_kwarg(k, v):
                     combined_kwargs.append(('{}{}'.format(kw, tup[0]), tup[1]))
-        elif isinstance(arg, (list, tuple)):
+        elif is_multivalued(arg):
             for i in arg:
                 for tup in flatten_kwarg('', i):
                     combined_kwargs.append(('{}{}'.format(kw, tup[0]), tup[1]))
@@ -62,7 +85,7 @@ def flatten_kwarg(key, obj):
                 new_list.append(('[{}]{}'.format(key, tup[0]), tup[1]))
         return new_list
 
-    elif isinstance(obj, (list, tuple)):
+    elif is_multivalued(obj):
         # Add empty brackets (i.e. "[]")
         new_list = []
         for i in obj:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -65,6 +65,35 @@ class TestUtil(unittest.TestCase):
             < result.index(('foo[]', 'bar4'))
         )
 
+    def test_combine_kwargs_single_generator_empty(self, m):
+        result = combine_kwargs(var=(value for value in ()))
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 0)
+
+    def test_combine_kwargs_single_generator_single_item(self, m):
+        result = combine_kwargs(var=(value for value in ('test',)))
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertIn(('var[]', 'test'), result)
+
+    def test_combine_kwargs_single_generator_multiple_items(self, m):
+        result = combine_kwargs(foo=(value for value in ('bar1', 'bar2', 'bar3', 'bar4')))
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 4)
+
+        self.assertIn(('foo[]', 'bar1'), result)
+        self.assertIn(('foo[]', 'bar2'), result)
+        self.assertIn(('foo[]', 'bar3'), result)
+        self.assertIn(('foo[]', 'bar4'), result)
+
+        # Ensure kwargs are in correct order
+        self.assertTrue(
+            result.index(('foo[]', 'bar1'))
+            < result.index(('foo[]', 'bar2'))
+            < result.index(('foo[]', 'bar3'))
+            < result.index(('foo[]', 'bar4'))
+        )
+
     def test_combine_kwargs_multiple_dicts(self, m):
         result = combine_kwargs(
             var1={'foo': 'bar'},
@@ -207,10 +236,11 @@ class TestUtil(unittest.TestCase):
                 ['1a', '1b'],
                 ['2a', '2b'],
                 ['3a', '3b']
-            ]
+            ],
+            generator=(v for v in ('g1', 'g2', 'g3')),
         )
         self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 34)
+        self.assertEqual(len(result), 37)
 
         # Check that all keys were generated correctly
         self.assertIn(('foo', 'bar'), result)
@@ -247,6 +277,9 @@ class TestUtil(unittest.TestCase):
         self.assertIn(('nest_list[][]', '2b'), result)
         self.assertIn(('nest_list[][]', '3a'), result)
         self.assertIn(('nest_list[][]', '3b'), result)
+        self.assertIn(('generator[]', 'g1'), result)
+        self.assertIn(('generator[]', 'g2'), result)
+        self.assertIn(('generator[]', 'g3'), result)
 
         # Ensure list kwargs are in correct order
         self.assertTrue(
@@ -268,6 +301,11 @@ class TestUtil(unittest.TestCase):
             < result.index(('nest_list[][]', '2b'))
             < result.index(('nest_list[][]', '3a'))
             < result.index(('nest_list[][]', '3b'))
+        )
+        self.assertTrue(
+            result.index(('generator[]', 'g1'))
+            < result.index(('generator[]', 'g2'))
+            < result.index(('generator[]', 'g3'))
         )
 
     # obj_or_id()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -9,15 +9,9 @@ from canvasapi.user import User
 from canvasapi.util import combine_kwargs, is_multivalued, obj_or_id
 from itertools import chain
 from six import integer_types, iterkeys, itervalues, iteritems
+from six.moves import zip
 from tests import settings
 from tests.util import register_uris
-
-try:
-    # in Python 2.x, iterator-returning zip function is "itertools.izip"
-    from itertools import izip as zip
-except ImportError:
-    # in Python 3.x, iterator-returning zip function is "zip" built-in
-    pass
 
 
 @requests_mock.Mocker()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,7 +8,7 @@ from canvasapi.course import CourseNickname
 from canvasapi.user import User
 from canvasapi.util import combine_kwargs, is_multivalued, obj_or_id
 from itertools import chain
-from six import integer_types
+from six import integer_types, iterkeys, itervalues, iteritems
 from tests import settings
 from tests.util import register_uris
 
@@ -68,13 +68,13 @@ class TestUtil(unittest.TestCase):
         self.assertTrue(is_multivalued(iter({'key': 'value'})))
 
     def test_is_multivalued_dict_keys(self, m):
-        self.assertTrue(is_multivalued({'key': 'value'}.keys()))
+        self.assertTrue(is_multivalued(iterkeys({'key': 'value'})))
 
     def test_is_multivalued_dict_values(self, m):
-        self.assertTrue(is_multivalued({'key': 'value'}.values()))
+        self.assertTrue(is_multivalued(itervalues({'key': 'value'})))
 
     def test_is_multivalued_dict_items(self, m):
-        self.assertTrue(is_multivalued({'key': 'value'}.items()))
+        self.assertTrue(is_multivalued(iteritems({'key': 'value'})))
 
     def test_is_multivalued_generator_expr(self, m):
         self.assertTrue(is_multivalued(item for item in ('item',)))


### PR DESCRIPTION
Following the fix of issue #55 by pull request #63, canvasapi parameter handling treated any `list` or `tuple` as a sequence of multiple values.  When a caller provide multiple values in this way, they are be turned into repeated `param[]=...` parameters in an eventual Canvas API call.

The current pull request generalizes that support to *any* iterable collection of values, not just list and tuple.  One can now pass multiple values using `list` or `tuple` as before, but also `set`, generators, iterable objects returned by `zip` and `ichain`, etc. Strings and byte sequences are special cases.  Although these are iterable, each is treated a single value rather than as a sequence of isolated characters or bytes.

If accepted, this pull request will resolve issue #94.