### PR TITLE
Issue #109 get user self

### DIFF
--- a/canvasapi/canvas.py
+++ b/canvasapi/canvas.py
@@ -164,8 +164,9 @@ class Canvas(object):
         :rtype: :class:`canvasapi.user.User`
         """
         if id_type:
-            user_id = user
-            uri = 'users/{}:{}'.format(id_type, user_id)
+            uri = 'users/{}:{}'.format(id_type, user)
+        elif user == 'self':
+            uri = 'users/self'
         else:
             user_id = obj_or_id(user, "user", (User,))
             uri = 'users/{}'.format(user_id)

--- a/tests/fixtures/user.json
+++ b/tests/fixtures/user.json
@@ -226,6 +226,14 @@
 			"name": "John Doe"
 		}
 	},
+	"get_by_id_self": {
+		"method": "GET",
+		"endpoint": "users/self",
+		"data": {
+			"id": 1,
+			"name": "John Doe"
+		}
+	},
 	"get_file": {
 		"method": "GET",
 		"endpoint": "users/1/files/1",

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -149,6 +149,14 @@ class TestCanvas(unittest.TestCase):
         self.assertIsInstance(user, User)
         self.assertTrue(hasattr(user, 'name'))
 
+    def test_get_user_self(self, m):
+        register_uris({'user': ['get_by_id_self']}, m)
+
+        user = self.canvas.get_user('self')
+
+        self.assertIsInstance(user, User)
+        self.assertTrue(hasattr(user, 'name'))
+
     def test_get_user_fail(self, m):
         register_uris({'generic': ['not_found']}, m)
 


### PR DESCRIPTION
Fixes an issue where `Canvas.get_user()` stopped accepting `'self'` as a valid value for the `user` param.

Resolves #109 