### PR TITLE
Create Conversation Fix

### DIFF
--- a/canvasapi/canvas.py
+++ b/canvasapi/canvas.py
@@ -472,20 +472,19 @@ class Canvas(object):
         :type recipients: `list` of `str`
         :param body: The body of the message being added.
         :type body: `str`
-        :rtype: :class:`canvasapi.paginated_list.PaginatedList` of
-            :class:`canvasapi.conversation.Conversation`
+        :rtype: list of :class:`canvasapi.conversation.Conversation`
         """
         from canvasapi.conversation import Conversation
 
-        return PaginatedList(
-            Conversation,
-            self.__requester,
+        kwargs['recipients'] = recipients
+        kwargs['body'] = body
+
+        response = self.__requester.request(
             'POST',
             'conversations',
-            recipients=recipients,
-            body=body,
             _kwargs=combine_kwargs(**kwargs)
         )
+        return [Conversation(self.__requester, convo) for convo in response.json()]
 
     def get_conversation(self, conversation, **kwargs):
         """

--- a/tests/fixtures/conversation.json
+++ b/tests/fixtures/conversation.json
@@ -53,16 +53,56 @@
     "create_conversation": {
         "method": "POST",
         "endpoint": "conversations",
-        "data": [
-            {
-                "recipients": ["1", "2"],
-                "body": "Test Conversation Body"
+        "data": [{
+            "id": 1,
+            "subject": "A Conversation",
+            "workflow_state": "unread",
+            "last_message": "Hello, World!",
+            "last_message_at": "2018-01-01T00:00:00Z",
+            "last_authored_message": "Hello, World!",
+            "last_authored_message_at": "2018-01-01T00:00:00Z",
+            "message_count": 1,
+            "subscribed": true,
+            "private": true,
+            "starred": false,
+            "properties": ["last_author"],
+            "messages": [{
+                "id": 8,
+                "author_id": 1,
+                "created_at": "2018-01-01T00:00:00Z",
+                "generated": false,
+                "body": "Hello, World!",
+                "forwarded_messages": [],
+                "attachments": [],
+                "media_comment": null,
+                "participating_user_ids": [1, 2]
+            }],
+            "audience": [2],
+            "audience_contexts": {
+                "courses": {
+                    "1": ["StudentEnrollment"]
+                },
+                "groups": {}
             },
-            {
-                "recipients": ["3", "4"],
-                "body": "Test Conversation Body 2"
-            }
-        ],
+            "participants": [
+                {
+                    "id": 1,
+                    "name": "John",
+                    "common_courses": {},
+                    "common_groups": {}
+                },
+                {
+                    "id": 2,
+                    "name": "Joe",
+                    "common_courses": {
+                        "1": ["StudentEnrollment"]
+                    },
+                    "common_groups": {}
+                }
+            ],
+            "visible": true,
+            "context_code": null
+        }],
         "status_code": 200
     },
     "edit_conversation": {

--- a/tests/fixtures/conversation.json
+++ b/tests/fixtures/conversation.json
@@ -67,7 +67,7 @@
             "starred": false,
             "properties": ["last_author"],
             "messages": [{
-                "id": 8,
+                "id": 1,
                 "author_id": 1,
                 "created_at": "2018-01-01T00:00:00Z",
                 "generated": false,
@@ -103,6 +103,113 @@
             "visible": true,
             "context_code": null
         }],
+        "status_code": 200
+    },
+    "create_conversation_multiple": {
+        "method": "POST",
+        "endpoint": "conversations",
+        "data": [
+            {
+                "id": 1,
+                "subject": "A Conversation",
+                "workflow_state": "unread",
+                "last_message": "Hey guys!",
+                "last_message_at": "2018-01-01T00:00:00Z",
+                "last_authored_message": "Hey guys!",
+                "last_authored_message_at": "2018-01-01T00:00:00Z",
+                "message_count": 1,
+                "subscribed": true,
+                "private": true,
+                "starred": false,
+                "properties": ["last_author"],
+                "messages": [{
+                    "id": 1,
+                    "author_id": 1,
+                    "created_at": "2018-01-01T00:00:00Z",
+                    "generated": false,
+                    "body": "Hey guys!",
+                    "forwarded_messages": [],
+                    "attachments": [],
+                    "media_comment": null,
+                    "participating_user_ids": [1, 2]
+                }],
+                "audience": [2],
+                "audience_contexts": {
+                    "courses": {
+                        "1": ["StudentEnrollment"]
+                    },
+                    "groups": {}
+                },
+                "participants": [
+                    {
+                        "id": 1,
+                        "name": "John",
+                        "common_courses": {},
+                        "common_groups": {}
+                    },
+                    {
+                        "id": 2,
+                        "name": "Joe",
+                        "common_courses": {
+                            "1": ["StudentEnrollment"]
+                        },
+                        "common_groups": {}
+                    }
+                ],
+                "visible": true,
+                "context_code": null
+            },
+            {
+                "id": 2,
+                "subject": "A Conversation",
+                "workflow_state": "unread",
+                "last_message": "Hey guys!",
+                "last_message_at": "2018-01-01T00:00:00Z",
+                "last_authored_message": "Hey guys!",
+                "last_authored_message_at": "2018-01-01T00:00:00Z",
+                "message_count": 1,
+                "subscribed": true,
+                "private": true,
+                "starred": false,
+                "properties": ["last_author"],
+                "messages": [{
+                    "id": 2,
+                    "author_id": 1,
+                    "created_at": "2018-01-01T00:00:00Z",
+                    "generated": false,
+                    "body": "Hey guys!",
+                    "forwarded_messages": [],
+                    "attachments": [],
+                    "media_comment": null,
+                    "participating_user_ids": [1, 3]
+                }],
+                "audience": [3],
+                "audience_contexts": {
+                    "courses": {
+                        "1": ["StudentEnrollment"]
+                    },
+                    "groups": {}
+                },
+                "participants": [
+                    {
+                        "id": 1,
+                        "name": "John",
+                        "common_courses": {},
+                        "common_groups": {}
+                    },
+                    {
+                        "id": 3,
+                        "name": "Jack",
+                        "common_courses": {
+                            "1": ["StudentEnrollment"]
+                        },
+                        "common_groups": {}
+                    }
+                ],
+                "visible": true,
+                "context_code": null
+            }
+        ],
         "status_code": 200
     },
     "edit_conversation": {

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -331,14 +331,18 @@ class TestCanvas(unittest.TestCase):
     def test_create_conversation(self, m):
         register_uris({'conversation': ['create_conversation']}, m)
 
-        recipients = ['1', '2']
-        body = 'Test Conversation Body'
+        recipients = ['2']
+        body = 'Hello, World!'
 
-        conversations = self.canvas.create_conversation(recipients=recipients, body=body)
-        conversation_list = [conversation for conversation in conversations]
-
-        self.assertIsInstance(conversation_list[0], Conversation)
-        self.assertEqual(len(conversation_list), 2)
+        conversations = self.canvas.create_conversation(
+            recipients=recipients,
+            body=body
+        )
+        self.assertIsInstance(conversations, list)
+        self.assertEqual(len(conversations), 1)
+        self.assertIsInstance(conversations[0], Conversation)
+        self.assertTrue(hasattr(conversations[0], 'last_message'))
+        self.assertEqual(conversations[0].last_message, body)
 
     # get_conversation()
     def test_get_conversation(self, m):

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -344,6 +344,27 @@ class TestCanvas(unittest.TestCase):
         self.assertTrue(hasattr(conversations[0], 'last_message'))
         self.assertEqual(conversations[0].last_message, body)
 
+    def test_create_conversation_multiple_people(self, m):
+        register_uris({'conversation': ['create_conversation_multiple']}, m)
+
+        recipients = ['2', '3']
+        body = 'Hey guys!'
+
+        conversations = self.canvas.create_conversation(
+            recipients=recipients,
+            body=body
+        )
+        self.assertIsInstance(conversations, list)
+        self.assertEqual(len(conversations), 2)
+
+        self.assertIsInstance(conversations[0], Conversation)
+        self.assertTrue(hasattr(conversations[0], 'last_message'))
+        self.assertEqual(conversations[0].last_message, body)
+
+        self.assertIsInstance(conversations[1], Conversation)
+        self.assertTrue(hasattr(conversations[1], 'last_message'))
+        self.assertEqual(conversations[1].last_message, body)
+
     # get_conversation()
     def test_get_conversation(self, m):
         register_uris({'conversation': ['get_by_id']}, m)


### PR DESCRIPTION
Fixes an issue where the `create_conversation` method wouldn't actually create the conversation until the results were iterated over.

Instead of returning a PaginatedList (which is unnecessary), am just returning a `list` of `Conversation` objects directly.

Resolves #102 