### PR TITLE
Issue #168 Update Tab

### DIFF
--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -1583,12 +1583,17 @@ class Course(CanvasObject):
             self._requester,
             'GET',
             'courses/{}/tabs'.format(self.id),
+            {'course_id': self.id},
             _kwargs=combine_kwargs(**kwargs)
         )
 
     def update_tab(self, tab_id, **kwargs):
         """
         Update a tab for a course.
+
+        .. warning::
+            .. deprecated:: 0.10.0
+                Use :func:`canvasapi.tab.Tab.update` instead.
 
         :calls: `PUT /api/v1/courses/:course_id/tabs/:tab_id \
         <https://canvas.instructure.com/doc/api/tabs.html#method.tabs.update>`_
@@ -1598,13 +1603,17 @@ class Course(CanvasObject):
 
         :rtype: :class:`canvasapi.tab.Tab`
         """
-        response = self._requester.request(
-            'PUT',
-            'courses/{}/tabs/{}'.format(self.id, tab_id),
-            _kwargs=combine_kwargs(**kwargs)
+        warnings.warn(
+            "`Course.update_tab()` is being deprecated and will be removed in "
+            "a future version. Use `Tab.update()` instead",
+            DeprecationWarning
         )
 
-        return Tab(self._requester, response.json())
+        tab = Tab(self._requester, {
+            'course_id': self.id,
+            'id': tab_id
+        })
+        return tab.update(**kwargs)
 
     def get_rubric(self, rubric_id, **kwargs):
         """

--- a/canvasapi/group.py
+++ b/canvasapi/group.py
@@ -664,6 +664,7 @@ class Group(CanvasObject):
             self._requester,
             'GET',
             'groups/{}/tabs'.format(self.id),
+            {'group_id': self.id},
             _kwargs=combine_kwargs(**kwargs)
         )
 

--- a/canvasapi/tab.py
+++ b/canvasapi/tab.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from six import python_2_unicode_compatible
 
 from canvasapi.canvas_object import CanvasObject
+from canvasapi.util import combine_kwargs
 
 
 @python_2_unicode_compatible
@@ -10,3 +11,30 @@ class Tab(CanvasObject):
 
     def __str__(self):
         return "{} ({})".format(self.label, self.id)
+
+    def update(self, **kwargs):
+        """
+        Update a tab for a course.
+
+        Note: Home and Settings tabs are not manageable, and can't be
+        hidden or moved.
+
+        :calls: `PUT /api/v1/courses/:course_id/tabs/:tab_id \
+        <https://canvas.instructure.com/doc/api/tabs.html#method.tabs.update>`_
+
+        :rtype: :class:`canvasapi.tab.Tab`
+        """
+        if not hasattr(self, 'course_id'):
+            raise ValueError('Can only update tabs from a Course.')
+
+        response = self._requester.request(
+            'PUT',
+            'courses/{}/tabs/{}'.format(self.course_id, self.id),
+            _kwargs=combine_kwargs(**kwargs)
+        )
+        response_json = response.json()
+        response_json.update({'course_id': self.course_id})
+
+        super(Tab, self).set_attributes(response.json())
+
+        return self

--- a/docs/class-reference.rst
+++ b/docs/class-reference.rst
@@ -29,5 +29,6 @@ Class Reference
     rubric-ref
     section-ref
     submission-ref
+    tab-ref
     upload-ref
     user-ref

--- a/docs/class-reference.rst
+++ b/docs/class-reference.rst
@@ -18,6 +18,7 @@ Class Reference
     current-user-ref
     discussion-entry-ref
     discussion-topic-ref
+    enrollment-ref
     enrollment-term-ref
     external-tool-ref
     file-ref

--- a/docs/enrollment-ref.rst
+++ b/docs/enrollment-ref.rst
@@ -1,0 +1,6 @@
+==========
+Enrollment
+==========
+
+.. autoclass:: canvasapi.enrollment.Enrollment
+    :members:

--- a/docs/tab-ref.rst
+++ b/docs/tab-ref.rst
@@ -1,0 +1,6 @@
+===
+Tab
+===
+
+.. autoclass:: canvasapi.tab.Tab
+    :members:

--- a/tests/test_course.py
+++ b/tests/test_course.py
@@ -1026,10 +1026,15 @@ class TestCourse(unittest.TestCase):
 
         tab_id = "pages"
         new_position = 3
-        tab = self.course.update_tab(tab_id, position=new_position)
 
-        self.assertIsInstance(tab, Tab)
-        self.assertEqual(tab.position, 3)
+        with warnings.catch_warnings(record=True) as warning_list:
+            tab = self.course.update_tab(tab_id, position=new_position)
+
+            self.assertIsInstance(tab, Tab)
+            self.assertEqual(tab.position, 3)
+
+            self.assertEqual(len(warning_list), 1)
+            self.assertEqual(warning_list[-1].category, DeprecationWarning)
 
     # get_rubric
     def test_get_rubric(self, m):

--- a/tests/test_tab.py
+++ b/tests/test_tab.py
@@ -4,6 +4,7 @@ import unittest
 import requests_mock
 
 from canvasapi import Canvas
+from canvasapi.tab import Tab
 from tests import settings
 from tests.util import register_uris
 
@@ -16,17 +17,33 @@ class TestTab(unittest.TestCase):
 
         with requests_mock.Mocker() as m:
             register_uris({
-                'course': ['get_by_id', 'list_tabs']
+                'course': ['get_by_id', 'list_tabs'],
+                'group': ['get_by_id', 'list_tabs']
             }, m)
 
             self.course = self.canvas.get_course(1)
-
             tabs = self.course.list_tabs()
-            tab_list = [tab for tab in tabs]
+            self.tab = tabs[1]
 
-            self.tab = tab_list[0]
+            self.group = self.canvas.get_group(1)
+            group_tabs = self.group.list_tabs()
+            self.tab_group = group_tabs[1]
 
     # __str__()
     def test__str__(self, m):
         string = str(self.tab)
         self.assertIsInstance(string, str)
+
+    # update()
+    def test_update_course(self, m):
+        register_uris({'course': ['update_tab']}, m)
+
+        new_position = 3
+        self.tab.update(position=new_position)
+
+        self.assertIsInstance(self.tab, Tab)
+        self.assertEqual(self.tab.position, 3)
+
+    def test_update_group(self, m):
+        with self.assertRaises(ValueError):
+            self.tab_group.update(position=1)


### PR DESCRIPTION
Per #168, deprecate `Course.update_tab` and move method to `Tab.update()`. Added docs.