### PR TITLE
Add `get all quiz submissions` endpoint

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -28,6 +28,7 @@ Patches and Suggestions
 - John Raible [@rebelaide](https://github.com/rebelaide)
 - Mark Lalor [@MarkLalor](https://github.com/MarkLalor)
 - Nathan Dabu [@nathaned](https://github.com/nathaned)
+- Petar Nikolovski [@petarGitNik](https://github.com/petarGitNik)
 - Philip Carter [@phillyc](https://github.com/phillyc)
 - Ralph Baird [@rmanbaird](https://github.com/rmanbaird)
 - Sigurður Baldursson [@sigurdurb](https://github.com/sigurdurb)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### New Endpoint Coverage
+
+- Get all quiz submissions (Thanks, [@petarGitNik](https://github.com/petarGitNik))
+
 ### General
 
 - Added a warning when using HTTP for the base url instead of HTTPS. This should help prevent some confusing behavior that Canvas exhibits when making HTTP requests to an HTTPS-enabled instance.

--- a/canvasapi/quiz.py
+++ b/canvasapi/quiz.py
@@ -235,6 +235,31 @@ class Quiz(CanvasObject):
         extension_list = response.json()['quiz_extensions']
         return [QuizExtension(self._requester, extension) for extension in extension_list]
 
+    def get_all_quiz_submissions(self, **kwargs):
+        """
+        Get a list of all submissions for this quiz.
+
+        :calls: `GET /api/v1/courses/:course_id/quizzes/:quiz_id/submissions \
+        <https://canvas.instructure.com/doc/api/quiz_submissions.html#method.quizzes/quiz_submissions_api.index>`
+
+        :rtype: list of :class:`canvasapi.quiz.QuizSubmission`
+        """
+        response = self._requester.request(
+            'GET',
+            'courses/{}/quizzes/{}/submissions'.format(self.course_id, self.id),
+            _kwargs=combine_kwargs(**kwargs)
+        )
+        submission_list = response.json()['quiz_submissions']
+
+        return [QuizSubmission(self._requester, submission) for submission in submission_list]
+
+
+@python_2_unicode_compatible
+class QuizSubmission(CanvasObject):
+
+    def __str__(self):
+        return "{}-{}".format(self.quiz_id, self.user_id)
+
 
 @python_2_unicode_compatible
 class QuizExtension(CanvasObject):

--- a/docs/quiz-ref.rst
+++ b/docs/quiz-ref.rst
@@ -4,3 +4,24 @@ Quiz
 
 .. autoclass:: canvasapi.quiz.Quiz
     :members:
+
+=============
+QuizExtension
+=============
+
+.. autoclass:: canvasapi.quiz.QuizExtension
+    :members:
+
+============
+QuizQuestion
+============
+
+.. autoclass:: canvasapi.quiz.QuizQuestion
+    :members:
+
+==============
+QuizSubmission
+==============
+
+.. autoclass:: canvasapi.quiz.QuizSubmission
+    :members:

--- a/tests/fixtures/quiz.json
+++ b/tests/fixtures/quiz.json
@@ -166,5 +166,31 @@
 				}
 			]
 		}
+	},
+	"get_all_quiz_submissions": {
+		"method": "GET",
+		"endpoint": "courses/1/quizzes/1/submissions",
+		"data": {
+			"quiz_submissions": [
+				{
+						"id": 1,
+						"quiz_id": 1,
+						"user_id": 1,
+						"submission_id": 1,
+						"attempt": 3,
+						"manually_unlocked": null,
+						"score": 7
+				},
+				{
+						"id": 2,
+						"quiz_id": 1,
+						"user_id": 1,
+						"submission_id": 2,
+						"attempt": 3,
+						"manually_unlocked": null,
+						"score": 5
+				}
+			]
+		}
 	}
 }

--- a/tests/test_quiz.py
+++ b/tests/test_quiz.py
@@ -218,7 +218,9 @@ class TestQuizSubmission(unittest.TestCase):
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
-        self.submission = QuizSubmission(self.canvas._Canvas__requester, {
+        self.submission = QuizSubmission(
+            self.canvas._Canvas__requester,
+            {
                 'id': 1,
                 'quiz_id': 1,
                 'user_id': 1,
@@ -226,7 +228,8 @@ class TestQuizSubmission(unittest.TestCase):
                 'attempt': 3,
                 'manually_unlocked': None,
                 'score': 7
-            })
+            }
+        )
 
     # __str__()
     def test__str__(self, m):

--- a/tests/test_quiz.py
+++ b/tests/test_quiz.py
@@ -5,7 +5,7 @@ import requests_mock
 
 from canvasapi import Canvas
 from canvasapi.exceptions import RequiredFieldMissing
-from canvasapi.quiz import Quiz, QuizQuestion, QuizExtension
+from canvasapi.quiz import Quiz, QuizSubmission, QuizQuestion, QuizExtension
 from canvasapi.quiz_group import QuizGroup
 from tests import settings
 from tests.util import register_uris
@@ -193,6 +193,45 @@ class TestQuiz(unittest.TestCase):
     def test_set_extensions_missing_key(self, m):
         with self.assertRaises(RequiredFieldMissing):
             self.quiz.set_extensions([{'extra_time': 60, 'extra_attempts': 3}])
+
+    # get_all_quiz_submissions()
+    def test_get_all_quiz_submissions(self, m):
+        register_uris({'quiz': ['get_all_quiz_submissions']}, m)
+        submission = self.quiz.get_all_quiz_submissions()
+
+        self.assertIsInstance(submission, list)
+        self.assertEqual(len(submission), 2)
+
+        self.assertIsInstance(submission[0], QuizSubmission)
+        self.assertEqual(submission[0].id, 1)
+        self.assertTrue(hasattr(submission[0], 'attempt'))
+        self.assertEqual(submission[0].attempt, 3)
+
+        self.assertIsInstance(submission[1], QuizSubmission)
+        self.assertEqual(submission[1].id, 2)
+        self.assertTrue(hasattr(submission[1], 'score'))
+        self.assertEqual(submission[1].score, 5)
+
+
+@requests_mock.Mocker()
+class TestQuizSubmission(unittest.TestCase):
+    def setUp(self):
+        self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
+
+        self.submission = QuizSubmission(self.canvas._Canvas__requester, {
+                'id': 1,
+                'quiz_id': 1,
+                'user_id': 1,
+                'submission_id': 1,
+                'attempt': 3,
+                'manually_unlocked': None,
+                'score': 7
+            })
+
+    # __str__()
+    def test__str__(self, m):
+        string = str(self.submission)
+        self.assertIsInstance(string, str)
 
 
 @requests_mock.Mocker()


### PR DESCRIPTION
Hi, I've added [`get all quiz submissions`][1] endpoint, and updated tests.

[1]: https://canvas.instructure.com/doc/api/quiz_submissions.html#method.quizzes/quiz_submissions_api.index