### PR TITLE
Remove DeprecationWarning

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -44,6 +44,7 @@ Patches and Suggestions
 - Philip Austin [@phaustin](https://github.com/phaustin)
 - Philip Carter [@phillyc](https://github.com/phillyc)
 - Ralph Baird [@rmanbaird](https://github.com/rmanbaird)
+- [@Screeeech](https://github.com/Screeeech)
 - Sigurður Baldursson [@sigurdurb](https://github.com/sigurdurb)
 - Spencer Rogers [@spencer1248](https://github.com/spencer1248)
 - Stephen Woosley [@stephenwoosley](https://github.com/stephenwoosley)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### General
+
+- Removed overzealous global enabling of `DeprecationWarning`. (Thanks, [@Screeeech](https://github.com/Screeeech))
+    - *Note:* `DeprecationWarnings` are disabled by default, so you may need to run your code with `python -Wd` to see them.
+
 ## [0.13.0] - 2019-07-08
 
 ### New Endpoint Coverage

--- a/canvasapi/canvas.py
+++ b/canvasapi/canvas.py
@@ -17,9 +17,6 @@ from canvasapi.user import User
 from canvasapi.util import combine_kwargs, get_institution_url, obj_or_id
 
 
-warnings.simplefilter("always", DeprecationWarning)
-
-
 class Canvas(object):
     """
     The main class to be instantiated to provide access to Canvas's API.

--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -30,9 +30,6 @@ from canvasapi.util import (
 from canvasapi.rubric import Rubric
 
 
-warnings.simplefilter("always", DeprecationWarning)
-
-
 @python_2_unicode_compatible
 class Course(CanvasObject):
     def __str__(self):

--- a/canvasapi/section.py
+++ b/canvasapi/section.py
@@ -9,8 +9,6 @@ from canvasapi.progress import Progress
 from canvasapi.submission import GroupedSubmission, Submission
 from canvasapi.util import combine_kwargs, obj_or_id, normalize_bool
 
-warnings.simplefilter("always", DeprecationWarning)
-
 
 @python_2_unicode_compatible
 class Section(CanvasObject):

--- a/tests/test_course.py
+++ b/tests/test_course.py
@@ -45,6 +45,8 @@ from tests.util import cleanup_file, register_uris
 @requests_mock.Mocker()
 class TestCourse(unittest.TestCase):
     def setUp(self):
+        warnings.simplefilter("always", DeprecationWarning)
+
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -26,6 +26,8 @@ from tests.util import cleanup_file, register_uris
 @requests_mock.Mocker()
 class TestGroup(unittest.TestCase):
     def setUp(self):
+        warnings.simplefilter("always", DeprecationWarning)
+
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:

--- a/tests/test_outcome.py
+++ b/tests/test_outcome.py
@@ -13,6 +13,8 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestOutcome(unittest.TestCase):
     def setUp(self):
+        warnings.simplefilter("always", DeprecationWarning)
+
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -15,6 +15,8 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestPage(unittest.TestCase):
     def setUp(self):
+        warnings.simplefilter("always", DeprecationWarning)
+
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -18,6 +18,8 @@ from tests.util import register_uris
 @requests_mock.Mocker()
 class TestSection(unittest.TestCase):
     def setUp(self):
+        warnings.simplefilter("always", DeprecationWarning)
+
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -15,6 +15,8 @@ from tests.util import cleanup_file, register_uris
 @requests_mock.Mocker()
 class TestSubmission(unittest.TestCase):
     def setUp(self):
+        warnings.simplefilter("always", DeprecationWarning)
+
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -26,6 +26,8 @@ from tests.util import cleanup_file, register_uris
 @requests_mock.Mocker()
 class TestUser(unittest.TestCase):
     def setUp(self):
+        warnings.simplefilter("always", DeprecationWarning)
+
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:


### PR DESCRIPTION
# Proposed Changes

* Remove overzealous global enabling of `DeprecationWarning`
* Turns on `DeprecationWarning` for tests (Python 2.7 doesn't enable automatically)

Fixes #284.
