### PR TITLE
Upgrade docutils

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,6 +1,6 @@
 -r tests_requirements.txt
 
-docutils==0.15.1
+docutils==0.15.2
 pre-commit; python_version >= '3.6'
 Sphinx
 sphinx-rtd-theme

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,6 +1,6 @@
 -r tests_requirements.txt
 
+docutils==0.15.1
 pre-commit; python_version >= '3.6'
 Sphinx
 sphinx-rtd-theme
-svn+https://svn.code.sf.net/p/docutils/code/trunk/docutils#egg=docutils


### PR DESCRIPTION
# Proposed Changes
* Remove svn install of `docutils` in favor of the (finally) updated version on PyPI.