### PR TITLE
#301 Spaces in API_KEY throw ValueError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bugfixes
 
-- Fixed an issue where `util.clean_headers()` would throw a `ValueError` if a user accidentally included a space in their API token. (Thanks, [Keegan](https://github.com/keeeeeegan))
+- Fixed an issue where `util.clean_headers()` would throw a `ValueError` if a user accidentally included a space in their API token. (Thanks, [@keeeeeegan](https://github.com/keeeeeegan))
 
 ## [0.14.0] - 2019-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Bugfixes
+
+- Fixed an issue where `util.clean_headers()` would throw a `ValueError` if a user accidentally included a space in their API token. (Thanks, [Keegan](https://github.com/keeeeeegan))
+
 ## [0.14.0] - 2019-08-20
 
 ### New Endpoint Coverage

--- a/canvasapi/canvas.py
+++ b/canvasapi/canvas.py
@@ -58,6 +58,11 @@ class Canvas(object):
                 UserWarning,
             )
 
+        # Ensure that the user-supplied access token contains no leading or
+        # trailing spaces that may cause issues when communicating with
+        # the API.
+        access_token = access_token.strip()
+
         base_url = new_url + "/api/v1/"
 
         self.__requester = Requester(base_url, access_token)

--- a/canvasapi/util.py
+++ b/canvasapi/util.py
@@ -244,7 +244,7 @@ def clean_headers(headers):
 
     authorization_header = headers.get("Authorization")
     if authorization_header:
-        sanitized = "****" + authorization_header[-4:]    
+        sanitized = "****" + authorization_header[-4:]
         cleaned_headers["Authorization"] = sanitized
 
     return cleaned_headers

--- a/canvasapi/util.py
+++ b/canvasapi/util.py
@@ -244,12 +244,7 @@ def clean_headers(headers):
 
     authorization_header = headers.get("Authorization")
     if authorization_header:
-        # Grab the actual token (not the "Bearer" prefix)
-        _, token = authorization_header.split(" ")
-
-        # Trim all but the last four characters
-        sanitized = "****" + token[-4:]
-
+        sanitized = "****" + authorization_header[-4:]    
         cleaned_headers["Authorization"] = sanitized
 
     return cleaned_headers

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -70,6 +70,10 @@ class TestCanvas(unittest.TestCase):
                 ),
             )
 
+    def test_init_strips_extra_spaces_in_api_key(self, m):
+        client = Canvas(settings.BASE_URL, " 12345 ")
+        self.assertEqual(client._Canvas__requester.access_token, "12345")
+
     # create_account()
     def test_create_account(self, m):
         register_uris({"account": ["create"]}, m)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -579,3 +579,9 @@ class TestUtil(unittest.TestCase):
 
         cleaned_headers = clean_headers(headers)
         self.assertIsNot(cleaned_headers, headers)
+
+    def test_clean_headers_strips_malformed_keys_correctly(self, m):
+        headers = {"Authorization": "Bearer  123,45"}
+
+        cleaned_headers = clean_headers(headers)
+        self.assertEqual(cleaned_headers, "****3,45")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -584,4 +584,4 @@ class TestUtil(unittest.TestCase):
         headers = {"Authorization": "Bearer  123,45"}
 
         cleaned_headers = clean_headers(headers)
-        self.assertEqual(cleaned_headers, "****3,45")
+        self.assertEqual(cleaned_headers["Authorization"], "****3,45")


### PR DESCRIPTION
This PR fixes a bug introduced in [!281](https://github.com/ucfopen/canvasapi/pull/281/), where accidental trailing spaces would trigger a ValueError in `util.clean_headers()`.

# Proposed Changes

* Add a sanitization step in `Canvas.__init__()` to strip leading and trailing spaces from API keys.
* Update `util.clean_headers()` to remove the offending call to `split()`, returning the last four digits of the `Authorization` header regardless of its contents.

Fixes #301. 
