### PR TITLE
Never allow negative indexing of the PaginatedList

### DIFF
--- a/canvasapi/paginated_list.py
+++ b/canvasapi/paginated_list.py
@@ -11,6 +11,8 @@ class PaginatedList(object):
     def __getitem__(self, index):
         assert isinstance(index, (int, slice))
         if isinstance(index, int):
+            if index < 0:
+                raise IndexError("Cannot negative index a PaginatedList")
             self._get_up_to_index(index)
             return self._elements[index]
         else:
@@ -104,6 +106,9 @@ class PaginatedList(object):
             self._start = the_slice.start or 0
             self._stop = the_slice.stop
             self._step = the_slice.step or 1
+
+            if self._start < 0 or self._stop < 0:
+                raise IndexError("Cannot negative index a PaginatedList slice")
 
         def __iter__(self):
             index = self._start

--- a/tests/test_paginated_list.py
+++ b/tests/test_paginated_list.py
@@ -170,3 +170,36 @@ class TestPaginatedList(unittest.TestCase):
         )
 
         self.assertIsInstance(pag_list[0], EnrollmentTerm)
+
+    def test_negative_index(self, m):
+        # Regression test for https://github.com/ucfopen/canvasapi/issues/305
+        # Ensure that we can't use negative indexing, even after loading a page
+
+        register_uris({"paginated_list": ["4_2_pages_p1", "4_2_pages_p2"]}, m)
+        pag_list = PaginatedList(User, self.requester, "GET", "four_objects_two_pages")
+        pag_list[0]
+
+        with self.assertRaises(IndexError):
+            pag_list[-1]
+
+    def test_negative_index_for_slice_start(self, m):
+        # Regression test for https://github.com/ucfopen/canvasapi/issues/305
+        # Ensure that we can't slice using a negative index as the start item
+
+        register_uris({"paginated_list": ["4_2_pages_p1", "4_2_pages_p2"]}, m)
+        pag_list = PaginatedList(User, self.requester, "GET", "four_objects_two_pages")
+        pag_list[0]
+
+        with self.assertRaises(IndexError):
+            pag_list[-1:1]
+
+    def test_negative_index_for_slice_end(self, m):
+        # Regression test for https://github.com/ucfopen/canvasapi/issues/305
+        # Ensure that we can't slice using a negative index as the end item
+
+        register_uris({"paginated_list": ["4_2_pages_p1", "4_2_pages_p2"]}, m)
+        pag_list = PaginatedList(User, self.requester, "GET", "four_objects_two_pages")
+        pag_list[0]
+
+        with self.assertRaises(IndexError):
+            pag_list[:-1]


### PR DESCRIPTION
# Proposed Changes

* Fix https://github.com/ucfopen/canvasapi/issues/305 by throwingIndexError whenever a negative index is requested.
* As a bonus, do the same when a slice is requested rather than when it's used.

Fixes #305.
