### PR TITLE
Issue/332 list assignments

### DIFF
--- a/canvasapi/assignment.py
+++ b/canvasapi/assignment.py
@@ -202,6 +202,26 @@ class Assignment(CanvasObject):
             _kwargs=combine_kwargs(**kwargs),
         )
 
+    def submissions_bulk_update(self, **kwargs):
+        """
+        Update the grading and comments on multiple student's assignment
+        submissions in an asynchronous job.
+
+        :calls: `POST /api/v1/courses/:course_id/assignments/:assignment_id/ \
+            submissions/update_grades \
+        <https://canvas.instructure.com/doc/api/submissions.html#method.submissions_api.bulk_update>`_
+
+        :rtype: :class:`canvasapi.progress.Progress`
+        """
+        response = self._requester.request(
+            "POST",
+            "courses/{}/assignments/{}/submissions/update_grades".format(
+                self.course_id, self.id
+            ),
+            _kwargs=combine_kwargs(**kwargs),
+        )
+        return Progress(self._requester, response.json())
+
     def submit(self, submission, file=None, **kwargs):
         """
         Makes a submission for an assignment.
@@ -246,26 +266,6 @@ class Assignment(CanvasObject):
 
         return Submission(self._requester, response_json)
 
-    def submissions_bulk_update(self, **kwargs):
-        """
-        Update the grading and comments on multiple student's assignment
-        submissions in an asynchronous job.
-
-        :calls: `POST /api/v1/courses/:course_id/assignments/:assignment_id/ \
-            submissions/update_grades \
-        <https://canvas.instructure.com/doc/api/submissions.html#method.submissions_api.bulk_update>`_
-
-        :rtype: :class:`canvasapi.progress.Progress`
-        """
-        response = self._requester.request(
-            "POST",
-            "courses/{}/assignments/{}/submissions/update_grades".format(
-                self.course_id, self.id
-            ),
-            _kwargs=combine_kwargs(**kwargs),
-        )
-        return Progress(self._requester, response.json())
-
     def upload_to_submission(self, file, user="self", **kwargs):
         """
         Upload a file to a submission.
@@ -301,6 +301,22 @@ class AssignmentGroup(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.name, self.id)
 
+    def delete(self, **kwargs):
+        """
+        Delete this assignment.
+
+        :calls: `DELETE /api/v1/courses/:course_id/assignment_groups/:assignment_group_id \
+        <https://canvas.instructure.com/doc/api/assignment_groups.html#method.assignment_groups_api.destroy>`_
+
+        :rtype: :class:`canvasapi.assignment.AssignmentGroup`
+        """
+        response = self._requester.request(
+            "DELETE",
+            "courses/{}/assignment_groups/{}".format(self.course_id, self.id),
+            _kwargs=combine_kwargs(**kwargs),
+        )
+        return AssignmentGroup(self._requester, response.json())
+
     def edit(self, **kwargs):
         """
         Modify this assignment group.
@@ -319,22 +335,6 @@ class AssignmentGroup(CanvasObject):
         if "name" in response.json():
             super(AssignmentGroup, self).set_attributes(response.json())
 
-        return AssignmentGroup(self._requester, response.json())
-
-    def delete(self, **kwargs):
-        """
-        Delete this assignment.
-
-        :calls: `DELETE /api/v1/courses/:course_id/assignment_groups/:assignment_group_id \
-        <https://canvas.instructure.com/doc/api/assignment_groups.html#method.assignment_groups_api.destroy>`_
-
-        :rtype: :class:`canvasapi.assignment.AssignmentGroup`
-        """
-        response = self._requester.request(
-            "DELETE",
-            "courses/{}/assignment_groups/{}".format(self.course_id, self.id),
-            _kwargs=combine_kwargs(**kwargs),
-        )
         return AssignmentGroup(self._requester, response.json())
 
 

--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -4,6 +4,7 @@ import warnings
 
 from six import python_2_unicode_compatible, text_type, string_types
 
+from canvasapi.assignment import Assignment, AssignmentGroup
 from canvasapi.blueprint import BlueprintSubscription
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.collaboration import Collaboration
@@ -728,6 +729,34 @@ class Course(CanvasObject):
             self._requester,
             "GET",
             "courses/{}/assignments".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
+        )
+
+    def get_assignments_for_group(self, assignment_group, **kwargs):
+        """
+        Returns a paginated list of assignments for the given assignment group
+
+        :calls: `GET /api/v1/courses/:course_id/assignment_groups/:assignment_group_id/assignments\
+        <https://canvas.instructure.com/doc/api/assignments.html#method.assignments_api.index>`
+
+        :param assignment_group: The object or id of the assignment group
+        :type assignment_group: :class: `canvasapi.assignment.AssignmentGroup` or int
+
+        :rtype: :class: `canvasapi.paginated_list.PaginatedList` of
+            :class: `canvasapi.assignment.Assignment`
+        """
+
+        assignment_group_id = obj_or_id(
+            assignment_group, "assignment_group", (AssignmentGroup,)
+        )
+
+        return PaginatedList(
+            Assignment,
+            self._requester,
+            "GET",
+            "courses/{}/assignment_groups/{}/assignments".format(
+                self.id, assignment_group_id
+            ),
             _kwargs=combine_kwargs(**kwargs),
         )
 

--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -737,13 +737,13 @@ class Course(CanvasObject):
         Returns a paginated list of assignments for the given assignment group
 
         :calls: `GET /api/v1/courses/:course_id/assignment_groups/:assignment_group_id/assignments\
-        <https://canvas.instructure.com/doc/api/assignments.html#method.assignments_api.index>`
+        <https://canvas.instructure.com/doc/api/assignments.html#method.assignments_api.index>`_
 
         :param assignment_group: The object or id of the assignment group
         :type assignment_group: :class: `canvasapi.assignment.AssignmentGroup` or int
 
-        :rtype: :class: `canvasapi.paginated_list.PaginatedList` of
-            :class: `canvasapi.assignment.Assignment`
+        :rtype: :class:`canvasapi.paginated_list.PaginatedList` of
+            :class:`canvasapi.assignment.Assignment`
         """
 
         assignment_group_id = obj_or_id(

--- a/tests/fixtures/course.json
+++ b/tests/fixtures/course.json
@@ -146,6 +146,25 @@
 		},
 		"status_code": 200
 	},
+	"get_assignments_for_group": {
+		"method": "GET",
+		"endpoint": "courses/1/assignment_groups/5/assignments",
+		"data": [
+			{
+				"id": 3,
+				"course_id": 1,
+				"name": "Assignment 1",
+				"description": "Do this assignment"
+			},
+			{
+				"id": 4,
+				"course_id": 1,
+				"name": "Assignment 2",
+				"description": "Do this assignment too"
+			}
+		],
+		"status_code": 200
+	},
 	"get_blueprint": {
 		"method": "GET",
 		"endpoint": "courses/1/blueprint_templates/1",

--- a/tests/test_course.py
+++ b/tests/test_course.py
@@ -721,6 +721,43 @@ class TestCourse(unittest.TestCase):
         self.assertTrue(hasattr(assignment_group_by_obj, "course_id"))
         self.assertEqual(assignment_group_by_obj.course_id, 1)
 
+    # get_assignments_for_group()
+    def test_get_assignments_for_group(self, m):
+        register_uris(
+            {
+                "course": ["get_assignments_for_group"],
+                "assignment": ["get_assignment_group"],
+            },
+            m,
+        )
+
+        assignment_group_obj = self.course.get_assignment_group(5)
+        response = self.course.get_assignments_for_group(5)
+        assignments = [assignment for assignment in response]
+
+        self.assertIsInstance(response, PaginatedList)
+
+        for assignment in assignments:
+            self.assertIsInstance(assignment, Assignment)
+            self.assertTrue(hasattr(assignment, "id"))
+            self.assertTrue(hasattr(assignment, "name"))
+            self.assertTrue(hasattr(assignment, "course_id"))
+            self.assertTrue(hasattr(assignment, "description"))
+            self.assertEqual(assignment.course_id, self.course.id)
+
+        response = self.course.get_assignments_for_group(assignment_group_obj)
+        assignments = [assignment for assignment in response]
+
+        self.assertIsInstance(response, PaginatedList)
+
+        for assignment in assignments:
+            self.assertIsInstance(assignment, Assignment)
+            self.assertTrue(hasattr(assignment, "id"))
+            self.assertTrue(hasattr(assignment, "name"))
+            self.assertTrue(hasattr(assignment, "course_id"))
+            self.assertTrue(hasattr(assignment, "description"))
+            self.assertEqual(assignment.course_id, self.course.id)
+
     # list_assignment_groups()
     def test_list_assignment_groups(self, m):
         register_uris(


### PR DESCRIPTION
Covers the endpoint to list assignments for a given assignment group:
https://canvas.instructure.com/doc/api/assignments.html#method.assignments_api.index

Fixes #332 .
