### PR TITLE
Issue/328 quiz submission user list

### DIFF
--- a/canvasapi/__init__.py
+++ b/canvasapi/__init__.py
@@ -6,4 +6,4 @@ from canvasapi.canvas import Canvas
 
 __all__ = ["Canvas"]
 
-__version__ = '0.11.0'
+__version__ = "0.11.0"

--- a/canvasapi/account.py
+++ b/canvasapi/account.py
@@ -14,7 +14,6 @@ from canvasapi.util import combine_kwargs, obj_or_id
 
 @python_2_unicode_compatible
 class Account(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.name, self.id)
 
@@ -39,8 +38,10 @@ class Account(CanvasObject):
         notif_id = obj_or_id(notification, "notification", (AccountNotification,))
 
         response = self._requester.request(
-            'DELETE',
-            'accounts/{}/users/{}/account_notifications/{}'.format(self.id, user_id, notif_id)
+            "DELETE",
+            "accounts/{}/users/{}/account_notifications/{}".format(
+                self.id, user_id, notif_id
+            ),
         )
         return AccountNotification(self._requester, response.json())
 
@@ -54,9 +55,9 @@ class Account(CanvasObject):
         :rtype: :class:`canvasapi.account.Account`
         """
         response = self._requester.request(
-            'POST',
-            'accounts/{}/root_accounts'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "accounts/{}/root_accounts".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return Account(self._requester, response.json())
 
@@ -70,11 +71,12 @@ class Account(CanvasObject):
         :rtype: :class:`canvasapi.course.Course`
         """
         from canvasapi.course import Course
+
         response = self._requester.request(
-            'POST',
-            'accounts/{}/courses'.format(self.id),
+            "POST",
+            "accounts/{}/courses".format(self.id),
             account_id=self.id,
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         return Course(self._requester, response.json())
 
@@ -90,15 +92,15 @@ class Account(CanvasObject):
 
         :rtype: :class:`canvasapi.account.Account`
         """
-        if isinstance(account, dict) and 'name' in account:
-            kwargs['account'] = account
+        if isinstance(account, dict) and "name" in account:
+            kwargs["account"] = account
         else:
             raise RequiredFieldMissing("Dictionary with key 'name' is required.")
 
         response = self._requester.request(
-            'POST',
-            'accounts/{}/sub_accounts'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "accounts/{}/sub_accounts".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return Account(self._requester, response.json())
 
@@ -115,15 +117,15 @@ class Account(CanvasObject):
         """
         from canvasapi.user import User
 
-        if isinstance(pseudonym, dict) and 'unique_id' in pseudonym:
-            kwargs['pseudonym'] = pseudonym
+        if isinstance(pseudonym, dict) and "unique_id" in pseudonym:
+            kwargs["pseudonym"] = pseudonym
         else:
             raise RequiredFieldMissing("Dictionary with key 'unique_id' is required.")
 
         response = self._requester.request(
-            'POST',
-            'accounts/{}/users'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "accounts/{}/users".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return User(self._requester, response.json())
 
@@ -138,21 +140,25 @@ class Account(CanvasObject):
         :type account_notification: dict
         :rtype: :class:`canvasapi.account.AccountNotification`
         """
-        required_key_list = ['subject', 'message', 'start_at', 'end_at']
-        required_keys_present = all((x in account_notification for x in required_key_list))
+        required_key_list = ["subject", "message", "start_at", "end_at"]
+        required_keys_present = all(
+            (x in account_notification for x in required_key_list)
+        )
 
         if isinstance(account_notification, dict) and required_keys_present:
-            kwargs['account_notification'] = account_notification
+            kwargs["account_notification"] = account_notification
         else:
-            raise RequiredFieldMissing((
-                "account_notification must be a dictionary with keys "
-                "'subject', 'message', 'start_at', and 'end_at'."
-            ))
+            raise RequiredFieldMissing(
+                (
+                    "account_notification must be a dictionary with keys "
+                    "'subject', 'message', 'start_at', and 'end_at'."
+                )
+            )
 
         response = self._requester.request(
-            'POST',
-            'accounts/{}/account_notifications'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "accounts/{}/account_notifications".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return AccountNotification(self._requester, response.json())
 
@@ -169,15 +175,15 @@ class Account(CanvasObject):
         :returns: True if successfully deleted; False otherwise.
         :rtype: bool
         """
-        if not hasattr(self, 'parent_account_id') or not self.parent_account_id:
+        if not hasattr(self, "parent_account_id") or not self.parent_account_id:
             raise CanvasException("Cannot delete a root account.")
 
         response = self._requester.request(
-            'DELETE',
-            'accounts/{}/sub_accounts/{}'.format(self.parent_account_id, self.id)
+            "DELETE",
+            "accounts/{}/sub_accounts/{}".format(self.parent_account_id, self.id),
         )
 
-        return response.json().get('workflow_state') == 'deleted'
+        return response.json().get("workflow_state") == "deleted"
 
     def delete_user(self, user):
         """
@@ -204,8 +210,7 @@ class Account(CanvasObject):
         user_id = obj_or_id(user, "user", (User,))
 
         response = self._requester.request(
-            'DELETE',
-            'accounts/{}/users/{}'.format(self.id, user_id)
+            "DELETE", "accounts/{}/users/{}".format(self.id, user_id)
         )
         return User(self._requester, response.json())
 
@@ -224,9 +229,9 @@ class Account(CanvasObject):
         return PaginatedList(
             Course,
             self._requester,
-            'GET',
-            'accounts/{}/courses'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "accounts/{}/courses".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_external_tool(self, tool):
@@ -244,11 +249,10 @@ class Account(CanvasObject):
         tool_id = obj_or_id(tool, "tool", (ExternalTool,))
 
         response = self._requester.request(
-            'GET',
-            'accounts/{}/external_tools/{}'.format(self.id, tool_id),
+            "GET", "accounts/{}/external_tools/{}".format(self.id, tool_id)
         )
         tool_json = response.json()
-        tool_json.update({'account_id': self.id})
+        tool_json.update({"account_id": self.id})
 
         return ExternalTool(self._requester, tool_json)
 
@@ -265,10 +269,10 @@ class Account(CanvasObject):
         return PaginatedList(
             ExternalTool,
             self._requester,
-            'GET',
-            'accounts/{}/external_tools'.format(self.id),
-            {'account_id': self.id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "accounts/{}/external_tools".format(self.id),
+            {"account_id": self.id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_index_of_reports(self, report_type):
@@ -286,8 +290,8 @@ class Account(CanvasObject):
         return PaginatedList(
             AccountReport,
             self._requester,
-            'GET',
-            'accounts/{}/reports/{}'.format(self.id, report_type)
+            "GET",
+            "accounts/{}/reports/{}".format(self.id, report_type),
         )
 
     def get_reports(self):
@@ -301,10 +305,7 @@ class Account(CanvasObject):
             :class:`canvasapi.account.AccountReport`
         """
         return PaginatedList(
-            AccountReport,
-            self._requester,
-            'GET',
-            'accounts/{}/reports'.format(self.id)
+            AccountReport, self._requester, "GET", "accounts/{}/reports".format(self.id)
         )
 
     def get_subaccounts(self, recursive=False):
@@ -323,9 +324,9 @@ class Account(CanvasObject):
         return PaginatedList(
             Account,
             self._requester,
-            'GET',
-            'accounts/{}/sub_accounts'.format(self.id),
-            recursive=recursive
+            "GET",
+            "accounts/{}/sub_accounts".format(self.id),
+            recursive=recursive,
         )
 
     def get_users(self, **kwargs):
@@ -342,9 +343,9 @@ class Account(CanvasObject):
         return PaginatedList(
             User,
             self._requester,
-            'GET',
-            'accounts/{}/users'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "accounts/{}/users".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_user_notifications(self, user):
@@ -369,8 +370,8 @@ class Account(CanvasObject):
         return PaginatedList(
             AccountNotification,
             self._requester,
-            'GET',
-            'accounts/{}/users/{}/account_notifications'.format(self.id, user_id)
+            "GET",
+            "accounts/{}/users/{}/account_notifications".format(self.id, user_id),
         )
 
     def update(self, **kwargs):
@@ -384,12 +385,10 @@ class Account(CanvasObject):
         :rtype: bool
         """
         response = self._requester.request(
-            'PUT',
-            'accounts/{}'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT", "accounts/{}".format(self.id), _kwargs=combine_kwargs(**kwargs)
         )
 
-        if 'name' in response.json():
+        if "name" in response.json():
             super(Account, self).set_attributes(response.json())
             return True
         else:
@@ -412,7 +411,7 @@ class Account(CanvasObject):
         warnings.warn(
             "`list_roles` is being deprecated and will be removed in a future version."
             " Use `get_roles` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_roles(**kwargs)
@@ -431,9 +430,9 @@ class Account(CanvasObject):
         return PaginatedList(
             Role,
             self._requester,
-            'GET',
-            'accounts/{}/roles'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "accounts/{}/roles".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_role(self, role):
@@ -451,8 +450,7 @@ class Account(CanvasObject):
         role_id = obj_or_id(role, "role", (Role,))
 
         response = self._requester.request(
-            'GET',
-            'accounts/{}/roles/{}'.format(self.id, role_id)
+            "GET", "accounts/{}/roles/{}".format(self.id, role_id)
         )
         return Role(self._requester, response.json())
 
@@ -468,10 +466,10 @@ class Account(CanvasObject):
         :rtype: :class:`canvasapi.account.Role`
         """
         response = self._requester.request(
-            'POST',
-            'accounts/{}/roles'.format(self.id),
+            "POST",
+            "accounts/{}/roles".format(self.id),
             label=label,
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         return Role(self._requester, response.json())
 
@@ -490,9 +488,9 @@ class Account(CanvasObject):
         role_id = obj_or_id(role, "role", (Role,))
 
         response = self._requester.request(
-            'DELETE',
-            'accounts/{}/roles/{}'.format(self.id, role_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "DELETE",
+            "accounts/{}/roles/{}".format(self.id, role_id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return Role(self._requester, response.json())
 
@@ -510,9 +508,9 @@ class Account(CanvasObject):
         role_id = obj_or_id(role, "role", (Role,))
 
         response = self._requester.request(
-            'POST',
-            'accounts/{}/roles/{}/activate'.format(self.id, role_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "accounts/{}/roles/{}/activate".format(self.id, role_id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return Role(self._requester, response.json())
 
@@ -531,9 +529,9 @@ class Account(CanvasObject):
         role_id = obj_or_id(role, "role", (Role,))
 
         response = self._requester.request(
-            'PUT',
-            'accounts/{}/roles/{}'.format(self.id, role_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "accounts/{}/roles/{}".format(self.id, role_id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return Role(self._requester, response.json())
 
@@ -554,9 +552,9 @@ class Account(CanvasObject):
         enrollment_id = obj_or_id(enrollment, "enrollment", (Enrollment,))
 
         response = self._requester.request(
-            'GET',
-            'accounts/{}/enrollments/{}'.format(self.id, enrollment_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "accounts/{}/enrollments/{}".format(self.id, enrollment_id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return Enrollment(self._requester, response.json())
 
@@ -576,7 +574,7 @@ class Account(CanvasObject):
         warnings.warn(
             "`list_groups` is being deprecated and will be removed in a future version."
             " Use `get_groups` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_groups(**kwargs)
@@ -591,12 +589,13 @@ class Account(CanvasObject):
         :rtype: :class:`canvasapi.paginated_list.PaginatedList` of :class:`canvasapi.group.Group`
         """
         from canvasapi.group import Group
+
         return PaginatedList(
             Group,
             self._requester,
-            'GET',
-            'accounts/{}/groups'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "accounts/{}/groups".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def create_group_category(self, name, **kwargs):
@@ -613,10 +612,10 @@ class Account(CanvasObject):
         from canvasapi.group import GroupCategory
 
         response = self._requester.request(
-            'POST',
-            'accounts/{}/group_categories'.format(self.id),
+            "POST",
+            "accounts/{}/group_categories".format(self.id),
             name=name,
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         return GroupCategory(self._requester, response.json())
 
@@ -637,7 +636,7 @@ class Account(CanvasObject):
         warnings.warn(
             "`list_group_categories` is being deprecated and will be removed "
             "in a future version. Use `get_group_categories` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_group_categories(**kwargs)
@@ -657,12 +656,14 @@ class Account(CanvasObject):
         return PaginatedList(
             GroupCategory,
             self._requester,
-            'GET',
-            'accounts/{}/group_categories'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "accounts/{}/group_categories".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
-    def create_external_tool(self, name, privacy_level, consumer_key, shared_secret, **kwargs):
+    def create_external_tool(
+        self, name, privacy_level, consumer_key, shared_secret, **kwargs
+    ):
         """
         Create an external tool in the current account.
 
@@ -683,12 +684,12 @@ class Account(CanvasObject):
         from canvasapi.external_tool import ExternalTool
 
         response = self._requester.request(
-            'POST',
-            'accounts/{}/external_tools'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "accounts/{}/external_tools".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         response_json = response.json()
-        response_json.update({'account_id': self.id})
+        response_json.update({"account_id": self.id})
 
         return ExternalTool(self._requester, response_json)
 
@@ -704,12 +705,12 @@ class Account(CanvasObject):
         from canvasapi.enrollment_term import EnrollmentTerm
 
         response = self._requester.request(
-            'POST',
-            'accounts/{}/terms'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "accounts/{}/terms".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         enrollment_term_json = response.json()
-        enrollment_term_json.update({'account_id': self.id})
+        enrollment_term_json.update({"account_id": self.id})
 
         return EnrollmentTerm(self._requester, enrollment_term_json)
 
@@ -730,7 +731,7 @@ class Account(CanvasObject):
         warnings.warn(
             "`list_enrollment_terms` is being deprecated and will be removed "
             "in a future version. Use `get_enrollment_terms` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_enrollment_terms(**kwargs)
@@ -750,11 +751,11 @@ class Account(CanvasObject):
         return PaginatedList(
             EnrollmentTerm,
             self._requester,
-            'GET',
-            'accounts/{}/terms'.format(self.id),
-            {'account_id': self.id},
-            _root='enrollment_terms',
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "accounts/{}/terms".format(self.id),
+            {"account_id": self.id},
+            _root="enrollment_terms",
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def list_user_logins(self, **kwargs):
@@ -774,7 +775,7 @@ class Account(CanvasObject):
         warnings.warn(
             "`list_user_logins` is being deprecated and will be removed in a "
             "future version. Use `get_user_logins` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_user_logins(**kwargs)
@@ -794,9 +795,9 @@ class Account(CanvasObject):
         return PaginatedList(
             Login,
             self._requester,
-            'GET',
-            'accounts/{}/logins'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "accounts/{}/logins".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def create_user_login(self, user, login, **kwargs):
@@ -814,26 +815,22 @@ class Account(CanvasObject):
         """
         from canvasapi.login import Login
 
-        if isinstance(user, dict) and 'id' in user:
-            kwargs['user'] = user
+        if isinstance(user, dict) and "id" in user:
+            kwargs["user"] = user
         else:
-            raise RequiredFieldMissing((
-                "user must be a dictionary with keys "
-                "'id'."
-            ))
+            raise RequiredFieldMissing(("user must be a dictionary with keys " "'id'."))
 
-        if isinstance(login, dict) and 'unique_id' in login:
-            kwargs['login'] = login
+        if isinstance(login, dict) and "unique_id" in login:
+            kwargs["login"] = login
         else:
-            raise RequiredFieldMissing((
-                "login must be a dictionary with keys "
-                "'unique_id'."
-            ))
+            raise RequiredFieldMissing(
+                ("login must be a dictionary with keys " "'unique_id'.")
+            )
 
         response = self._requester.request(
-            'POST',
-            'accounts/{}/logins'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "accounts/{}/logins".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return Login(self._requester, response.json())
 
@@ -851,8 +848,7 @@ class Account(CanvasObject):
         """
 
         response = self._requester.request(
-            'GET',
-            'accounts/{}/analytics/terms/{}/activity'.format(self.id, term_id)
+            "GET", "accounts/{}/analytics/terms/{}/activity".format(self.id, term_id)
         )
         return response.json()
 
@@ -867,8 +863,7 @@ class Account(CanvasObject):
         """
 
         response = self._requester.request(
-            'GET',
-            'accounts/{}/analytics/current/activity'.format(self.id)
+            "GET", "accounts/{}/analytics/current/activity".format(self.id)
         )
         return response.json()
 
@@ -883,8 +878,7 @@ class Account(CanvasObject):
         """
 
         response = self._requester.request(
-            'GET',
-            'accounts/{}/analytics/completed/activity'.format(self.id)
+            "GET", "accounts/{}/analytics/completed/activity".format(self.id)
         )
         return response.json()
 
@@ -902,8 +896,7 @@ class Account(CanvasObject):
         """
 
         response = self._requester.request(
-            'GET',
-            'accounts/{}/analytics/terms/{}/grades'.format(self.id, term_id)
+            "GET", "accounts/{}/analytics/terms/{}/grades".format(self.id, term_id)
         )
         return response.json()
 
@@ -918,8 +911,7 @@ class Account(CanvasObject):
         """
 
         response = self._requester.request(
-            'GET',
-            'accounts/{}/analytics/current/grades'.format(self.id)
+            "GET", "accounts/{}/analytics/current/grades".format(self.id)
         )
         return response.json()
 
@@ -934,8 +926,7 @@ class Account(CanvasObject):
         """
 
         response = self._requester.request(
-            'GET',
-            'accounts/{}/analytics/completed/grades'.format(self.id)
+            "GET", "accounts/{}/analytics/completed/grades".format(self.id)
         )
         return response.json()
 
@@ -953,8 +944,7 @@ class Account(CanvasObject):
         """
 
         response = self._requester.request(
-            'GET',
-            'accounts/{}/analytics/terms/{}/statistics'.format(self.id, term_id)
+            "GET", "accounts/{}/analytics/terms/{}/statistics".format(self.id, term_id)
         )
         return response.json()
 
@@ -969,8 +959,7 @@ class Account(CanvasObject):
         """
 
         response = self._requester.request(
-            'GET',
-            'accounts/{}/analytics/current/statistics'.format(self.id)
+            "GET", "accounts/{}/analytics/current/statistics".format(self.id)
         )
         return response.json()
 
@@ -985,8 +974,7 @@ class Account(CanvasObject):
         """
 
         response = self._requester.request(
-            'GET',
-            'accounts/{}/analytics/completed/statistics'.format(self.id)
+            "GET", "accounts/{}/analytics/completed/statistics".format(self.id)
         )
         return response.json()
 
@@ -1002,12 +990,12 @@ class Account(CanvasObject):
         from canvasapi.authentication_provider import AuthenticationProvider
 
         response = self._requester.request(
-            'POST',
-            'accounts/{}/authentication_providers'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "accounts/{}/authentication_providers".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         authentication_providers_json = response.json()
-        authentication_providers_json.update({'account_id': self.id})
+        authentication_providers_json.update({"account_id": self.id})
 
         return AuthenticationProvider(self._requester, authentication_providers_json)
 
@@ -1029,7 +1017,7 @@ class Account(CanvasObject):
             "`list_authentication_providers` is being deprecated and will be "
             "removed in a future version. Use `get_authentication_providers` "
             "instead.",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_authentication_providers(**kwargs)
@@ -1049,10 +1037,10 @@ class Account(CanvasObject):
         return PaginatedList(
             AuthenticationProvider,
             self._requester,
-            'GET',
-            'accounts/{}/authentication_providers'.format(self.id),
-            {'account_id': self.id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "accounts/{}/authentication_providers".format(self.id),
+            {"account_id": self.id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_authentication_provider(self, authentication_provider, **kwargs):
@@ -1069,16 +1057,19 @@ class Account(CanvasObject):
         :rtype: :class:`canvasapi.authentication_provider.AuthenticationProvider`
         """
         from canvasapi.authentication_provider import AuthenticationProvider
+
         authentication_providers_id = obj_or_id(
-            authentication_provider, "authentication provider", (
-                AuthenticationProvider,
-            )
+            authentication_provider,
+            "authentication provider",
+            (AuthenticationProvider,),
         )
 
         response = self._requester.request(
-            'GET',
-            'accounts/{}/authentication_providers/{}'.format(self.id, authentication_providers_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "accounts/{}/authentication_providers/{}".format(
+                self.id, authentication_providers_id
+            ),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         return AuthenticationProvider(self._requester, response.json())
@@ -1094,9 +1085,9 @@ class Account(CanvasObject):
         """
 
         response = self._requester.request(
-            'GET',
-            'accounts/{}/sso_settings'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "accounts/{}/sso_settings".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         return SSOSettings(self._requester, response.json())
@@ -1112,9 +1103,9 @@ class Account(CanvasObject):
         """
 
         response = self._requester.request(
-            'PUT',
-            'accounts/{}/sso_settings'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "accounts/{}/sso_settings".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         return SSOSettings(self._requester, response.json())
@@ -1132,8 +1123,7 @@ class Account(CanvasObject):
         from canvasapi.outcome import OutcomeGroup
 
         response = self._requester.request(
-            'GET',
-            'accounts/{}/root_outcome_group'.format(self.id)
+            "GET", "accounts/{}/root_outcome_group".format(self.id)
         )
         return OutcomeGroup(self._requester, response.json())
 
@@ -1154,8 +1144,7 @@ class Account(CanvasObject):
 
         outcome_group_id = obj_or_id(group, "outcome group", (OutcomeGroup,))
         response = self._requester.request(
-            'GET',
-            'accounts/{}/outcome_groups/{}'.format(self.id, outcome_group_id)
+            "GET", "accounts/{}/outcome_groups/{}".format(self.id, outcome_group_id)
         )
 
         return OutcomeGroup(self._requester, response.json())
@@ -1176,8 +1165,8 @@ class Account(CanvasObject):
         return PaginatedList(
             OutcomeGroup,
             self._requester,
-            'GET',
-            'accounts/{}/outcome_groups'.format(self.id)
+            "GET",
+            "accounts/{}/outcome_groups".format(self.id),
         )
 
     def get_all_outcome_links_in_context(self):
@@ -1196,8 +1185,8 @@ class Account(CanvasObject):
         return PaginatedList(
             OutcomeLink,
             self._requester,
-            'GET',
-            'accounts/{}/outcome_group_links'.format(self.id)
+            "GET",
+            "accounts/{}/outcome_group_links".format(self.id),
         )
 
     def add_grading_standards(self, title, grading_scheme_entry, **kwargs):
@@ -1220,14 +1209,16 @@ class Account(CanvasObject):
             if not isinstance(entry, dict):
                 raise ValueError("grading_scheme_entry must consist of dictionaries.")
             if "name" not in entry or "value" not in entry:
-                raise ValueError("Dictionaries with keys 'name' and 'value' are required.")
+                raise ValueError(
+                    "Dictionaries with keys 'name' and 'value' are required."
+                )
         kwargs["grading_scheme_entry"] = grading_scheme_entry
 
         response = self._requester.request(
-            'POST',
-            'accounts/%s/grading_standards' % (self.id),
+            "POST",
+            "accounts/%s/grading_standards" % (self.id),
             title=title,
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         return GradingStandard(self._requester, response.json())
@@ -1246,9 +1237,9 @@ class Account(CanvasObject):
         return PaginatedList(
             GradingStandard,
             self._requester,
-            'GET',
-            'accounts/%s/grading_standards' % (self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "accounts/%s/grading_standards" % (self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_single_grading_standard(self, grading_standard_id, **kwargs):
@@ -1265,8 +1256,8 @@ class Account(CanvasObject):
 
         response = self._requester.request(
             "GET",
-            'accounts/%s/grading_standards/%d' % (self.id, grading_standard_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "accounts/%s/grading_standards/%d" % (self.id, grading_standard_id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return GradingStandard(self._requester, response.json())
 
@@ -1282,9 +1273,9 @@ class Account(CanvasObject):
         :rtype: :class:`canvasapi.rubric.Rubric`
         """
         response = self._requester.request(
-            'GET',
-            'accounts/%s/rubrics/%s' % (self.id, rubric_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "accounts/%s/rubrics/%s" % (self.id, rubric_id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         return Rubric(self._requester, response.json())
@@ -1306,7 +1297,7 @@ class Account(CanvasObject):
         warnings.warn(
             "`list_rubrics` is being deprecated and will be removed in a "
             "future version. Use `get_rubrics` instead.",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_rubrics(**kwargs)
@@ -1324,9 +1315,9 @@ class Account(CanvasObject):
         return PaginatedList(
             Rubric,
             self._requester,
-            'GET',
-            'accounts/%s/rubrics' % (self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "accounts/%s/rubrics" % (self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def create_content_migration(self, migration_type, **kwargs):
@@ -1344,20 +1335,20 @@ class Account(CanvasObject):
         from canvasapi.content_migration import ContentMigration, Migrator
 
         if isinstance(migration_type, Migrator):
-            kwargs['migration_type'] = migration_type.type
+            kwargs["migration_type"] = migration_type.type
         elif isinstance(migration_type, string_types):
-            kwargs['migration_type'] = migration_type
+            kwargs["migration_type"] = migration_type
         else:
-            raise TypeError('Parameter migration_type must be of type Migrator or str')
+            raise TypeError("Parameter migration_type must be of type Migrator or str")
 
         response = self._requester.request(
-            'POST',
-            'accounts/{}/content_migrations'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "accounts/{}/content_migrations".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         response_json = response.json()
-        response_json.update({'account_id': self.id})
+        response_json.update({"account_id": self.id})
 
         return ContentMigration(self._requester, response_json)
 
@@ -1375,16 +1366,18 @@ class Account(CanvasObject):
         """
         from canvasapi.content_migration import ContentMigration
 
-        migration_id = obj_or_id(content_migration, "content_migration", (ContentMigration,))
+        migration_id = obj_or_id(
+            content_migration, "content_migration", (ContentMigration,)
+        )
 
         response = self._requester.request(
-            'GET',
-            'accounts/{}/content_migrations/{}'.format(self.id, migration_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "accounts/{}/content_migrations/{}".format(self.id, migration_id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         response_json = response.json()
-        response_json.update({'account_id': self.id})
+        response_json.update({"account_id": self.id})
 
         return ContentMigration(self._requester, response_json)
 
@@ -1403,10 +1396,10 @@ class Account(CanvasObject):
         return PaginatedList(
             ContentMigration,
             self._requester,
-            'GET',
-            'accounts/{}/content_migrations'.format(self.id),
-            {'account_id': self.id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "accounts/{}/content_migrations".format(self.id),
+            {"account_id": self.id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_migration_systems(self, **kwargs):
@@ -1424,10 +1417,10 @@ class Account(CanvasObject):
         return PaginatedList(
             Migrator,
             self._requester,
-            'GET',
-            'accounts/{}/content_migrations/migrators'.format(self.id),
-            {'account_id': self.id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "accounts/{}/content_migrations/migrators".format(self.id),
+            {"account_id": self.id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_admins(self, **kwargs):
@@ -1444,42 +1437,37 @@ class Account(CanvasObject):
         return PaginatedList(
             Admin,
             self._requester,
-            'GET',
-            'accounts/{}/admins'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "accounts/{}/admins".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
 
 @python_2_unicode_compatible
 class AccountNotification(CanvasObject):
-
     def __str__(self):  # pragma: no cover
         return "{}".format(self.subject)
 
 
 @python_2_unicode_compatible
 class AccountReport(CanvasObject):
-
     def __str__(self):  # pragma: no cover
         return "{} ({})".format(self.report, self.id)
 
 
 @python_2_unicode_compatible
 class Role(CanvasObject):
-
     def __str__(self):  # pragma: no cover
         return "{} ({})".format(self.label, self.base_role_type)
 
 
 @python_2_unicode_compatible
 class SSOSettings(CanvasObject):
-
     def __str__(self):  # pragma: no cover
-        return"{} ({})".format(self.login_handle_name, self.change_password_url)
+        return "{} ({})".format(self.login_handle_name, self.change_password_url)
 
 
 @python_2_unicode_compatible
 class Admin(CanvasObject):
-
     def __str__(self):  # pragma: no cover
-        return "{}".format(self.user['login_id'])
+        return "{}".format(self.user["login_id"])

--- a/canvasapi/appointment_group.py
+++ b/canvasapi/appointment_group.py
@@ -9,7 +9,6 @@ from canvasapi.util import combine_kwargs
 
 @python_2_unicode_compatible
 class AppointmentGroup(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.title, self.id)
 
@@ -23,9 +22,9 @@ class AppointmentGroup(CanvasObject):
         :rtype: :class:`canvasapi.appointment_group.AppointmentGroup`
         """
         response = self._requester.request(
-            'DELETE',
-            'appointment_groups/{}'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "DELETE",
+            "appointment_groups/{}".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return AppointmentGroup(self._requester, response.json())
 
@@ -41,20 +40,20 @@ class AppointmentGroup(CanvasObject):
 
         :rtype: :class:`canvasapi.appointment_group.AppointmentGroup`
         """
-        if isinstance(appointment_group, dict) and 'context_codes' in appointment_group:
-            kwargs['appointment_group'] = appointment_group
+        if isinstance(appointment_group, dict) and "context_codes" in appointment_group:
+            kwargs["appointment_group"] = appointment_group
         else:
             raise RequiredFieldMissing(
                 "Dictionary with key 'context_codes' is required."
             )
 
         response = self._requester.request(
-            'PUT',
-            'appointment_groups/{}'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "appointment_groups/{}".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
-        if 'title' in response.json():
+        if "title" in response.json():
             super(AppointmentGroup, self).set_attributes(response.json())
 
         return AppointmentGroup(self._requester, response.json())

--- a/canvasapi/assignment.py
+++ b/canvasapi/assignment.py
@@ -15,7 +15,6 @@ from canvasapi.util import combine_kwargs, obj_or_id
 
 @python_2_unicode_compatible
 class Assignment(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.name, self.id)
 
@@ -29,9 +28,9 @@ class Assignment(CanvasObject):
         :rtype: :class:`canvasapi.assignment.AssignmentOverride`
         """
         response = self._requester.request(
-            'POST',
-            'courses/{}/assignments/{}/overrides'.format(self.course_id, self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "courses/{}/assignments/{}/overrides".format(self.course_id, self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         response_json = response.json()
         response_json.update(course_id=self.course_id)
@@ -47,9 +46,9 @@ class Assignment(CanvasObject):
         :rtype: :class:`canvasapi.assignment.Assignment`
         """
         response = self._requester.request(
-            'DELETE',
-            'courses/{}/assignments/{}'.format(self.course_id, self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "DELETE",
+            "courses/{}/assignments/{}".format(self.course_id, self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return Assignment(self._requester, response.json())
 
@@ -63,12 +62,12 @@ class Assignment(CanvasObject):
         :rtype: :class:`canvasapi.assignment.Assignment`
         """
         response = self._requester.request(
-            'PUT',
-            'courses/{}/assignments/{}'.format(self.course_id, self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "courses/{}/assignments/{}".format(self.course_id, self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
-        if 'name' in response.json():
+        if "name" in response.json():
             super(Assignment, self).set_attributes(response.json())
 
         return Assignment(self._requester, response.json())
@@ -86,10 +85,12 @@ class Assignment(CanvasObject):
         return PaginatedList(
             UserDisplay,
             self._requester,
-            'GET',
-            'courses/{}/assignments/{}/gradeable_students'.format(self.course_id, self.id),
-            {'course_id': self.course_id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/assignments/{}/gradeable_students".format(
+                self.course_id, self.id
+            ),
+            {"course_id": self.course_id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_override(self, override, **kwargs):
@@ -107,13 +108,11 @@ class Assignment(CanvasObject):
         override_id = obj_or_id(override, "override", (AssignmentOverride,))
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/assignments/{}/overrides/{}'.format(
-                self.course_id,
-                self.id,
-                override_id
+            "GET",
+            "courses/{}/assignments/{}/overrides/{}".format(
+                self.course_id, self.id, override_id
             ),
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         response_json = response.json()
         response_json.update(course_id=self.course_id)
@@ -133,10 +132,10 @@ class Assignment(CanvasObject):
         return PaginatedList(
             AssignmentOverride,
             self._requester,
-            'GET',
-            'courses/{}/assignments/{}/overrides'.format(self.course_id, self.id),
-            {'course_id': self.course_id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/assignments/{}/overrides".format(self.course_id, self.id),
+            {"course_id": self.course_id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_submission(self, user, **kwargs):
@@ -154,9 +153,11 @@ class Assignment(CanvasObject):
         user_id = obj_or_id(user, "user", (User,))
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/assignments/{}/submissions/{}'.format(self.course_id, self.id, user_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/assignments/{}/submissions/{}".format(
+                self.course_id, self.id, user_id
+            ),
+            _kwargs=combine_kwargs(**kwargs),
         )
         response_json = response.json()
         response_json.update(course_id=self.course_id)
@@ -176,10 +177,10 @@ class Assignment(CanvasObject):
         return PaginatedList(
             Submission,
             self._requester,
-            'GET',
-            'courses/{}/assignments/{}/submissions'.format(self.course_id, self.id),
-            {'course_id': self.course_id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/assignments/{}/submissions".format(self.course_id, self.id),
+            {"course_id": self.course_id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def submit(self, submission, file=None, **kwargs):
@@ -197,29 +198,29 @@ class Assignment(CanvasObject):
 
         :rtype: :class:`canvasapi.submission.Submission`
         """
-        if isinstance(submission, dict) and 'submission_type' in submission:
-            kwargs['submission'] = submission
+        if isinstance(submission, dict) and "submission_type" in submission:
+            kwargs["submission"] = submission
         else:
             raise RequiredFieldMissing(
                 "Dictionary with key 'submission_type' is required."
             )
 
         if file:
-            if submission.get('submission_type') != 'online_upload':
+            if submission.get("submission_type") != "online_upload":
                 raise ValueError(
                     "To upload a file, `submission['submission_type']` must be `online_upload`."
                 )
 
             upload_response = self.upload_to_submission(file, **kwargs)
             if upload_response[0]:
-                kwargs['submission']['file_ids'] = [upload_response[1]['id']]
+                kwargs["submission"]["file_ids"] = [upload_response[1]["id"]]
             else:
-                raise CanvasException('File upload failed. Not submitting.')
+                raise CanvasException("File upload failed. Not submitting.")
 
         response = self._requester.request(
-            'POST',
-            'courses/{}/assignments/{}/submissions'.format(self.course_id, self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "courses/{}/assignments/{}/submissions".format(self.course_id, self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         response_json = response.json()
         response_json.update(course_id=self.course_id)
@@ -238,16 +239,15 @@ class Assignment(CanvasObject):
         :rtype: :class:`canvasapi.progress.Progress`
         """
         response = self._requester.request(
-            'POST',
-            'courses/{}/assignments/{}/submissions/update_grades'.format(
-                self.course_id,
-                self.id
+            "POST",
+            "courses/{}/assignments/{}/submissions/update_grades".format(
+                self.course_id, self.id
             ),
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         return Progress(self._requester, response.json())
 
-    def upload_to_submission(self, file, user='self', **kwargs):
+    def upload_to_submission(self, file, user="self", **kwargs):
         """
         Upload a file to a submission.
 
@@ -269,10 +269,8 @@ class Assignment(CanvasObject):
 
         return Uploader(
             self._requester,
-            'courses/{}/assignments/{}/submissions/{}/files'.format(
-                self.course_id,
-                self.id,
-                user_id
+            "courses/{}/assignments/{}/submissions/{}/files".format(
+                self.course_id, self.id, user_id
             ),
             file,
             **kwargs
@@ -281,7 +279,6 @@ class Assignment(CanvasObject):
 
 @python_2_unicode_compatible
 class AssignmentGroup(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.name, self.id)
 
@@ -295,12 +292,12 @@ class AssignmentGroup(CanvasObject):
         :rtype: :class:`canvasapi.assignment.AssignmentGroup`
         """
         response = self._requester.request(
-            'PUT',
-            'courses/{}/assignment_groups/{}'.format(self.course_id, self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "courses/{}/assignment_groups/{}".format(self.course_id, self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
-        if 'name' in response.json():
+        if "name" in response.json():
             super(AssignmentGroup, self).set_attributes(response.json())
 
         return AssignmentGroup(self._requester, response.json())
@@ -315,16 +312,15 @@ class AssignmentGroup(CanvasObject):
         :rtype: :class:`canvasapi.assignment.AssignmentGroup`
         """
         response = self._requester.request(
-            'DELETE',
-            'courses/{}/assignment_groups/{}'.format(self.course_id, self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "DELETE",
+            "courses/{}/assignment_groups/{}".format(self.course_id, self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return AssignmentGroup(self._requester, response.json())
 
 
 @python_2_unicode_compatible
 class AssignmentOverride(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.title, self.id)
 
@@ -339,12 +335,10 @@ class AssignmentOverride(CanvasObject):
         :rtype: :class:`canvasapi.assignment.AssignmentGroup`
         """
         response = self._requester.request(
-            'DELETE',
-            'courses/{}/assignments/{}/overrides/{}'.format(
-                self.course_id,
-                self.assignment_id,
-                self.id
-            )
+            "DELETE",
+            "courses/{}/assignments/{}/overrides/{}".format(
+                self.course_id, self.assignment_id, self.id
+            ),
         )
 
         response_json = response.json()
@@ -364,17 +358,15 @@ class AssignmentOverride(CanvasObject):
         :rtype: :class:`canvasapi.assignment.AssignmentOverride`
         """
         response = self._requester.request(
-            'PUT',
-            'courses/{}/assignments/{}/overrides/{}'.format(
-                self.course_id,
-                self.assignment_id,
-                self.id
-            )
+            "PUT",
+            "courses/{}/assignments/{}/overrides/{}".format(
+                self.course_id, self.assignment_id, self.id
+            ),
         )
 
         response_json = response.json()
         response_json.update(course_id=self.course_id)
-        if 'title' in response_json:
+        if "title" in response_json:
             super(AssignmentOverride, self).set_attributes(response_json)
 
         return self

--- a/canvasapi/authentication_provider.py
+++ b/canvasapi/authentication_provider.py
@@ -8,7 +8,6 @@ from canvasapi.util import combine_kwargs
 
 @python_2_unicode_compatible
 class AuthenticationProvider(CanvasObject):
-
     def __str__(self):  # pragma: no cover
         return "{} ({})".format(self.auth_type, self.position)
 
@@ -22,15 +21,15 @@ class AuthenticationProvider(CanvasObject):
         :rtype: :class:`canvasapi.authentication_provider.AuthenticationProvider`
         """
         response = self._requester.request(
-            'PUT',
-            'accounts/{}/authentication_providers/{}'.format(self.account_id, self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "accounts/{}/authentication_providers/{}".format(self.account_id, self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
-        if response.json().get('auth_type'):
+        if response.json().get("auth_type"):
             super(AuthenticationProvider, self).set_attributes(response.json())
 
-        return response.json().get('auth_type')
+        return response.json().get("auth_type")
 
     def delete(self):
         """
@@ -42,7 +41,7 @@ class AuthenticationProvider(CanvasObject):
         :rtype: :class:`canvasapi.authentication_provider.AuthenticationProvider`
         """
         response = self._requester.request(
-            'DELETE',
-            'accounts/{}/authentication_providers/{}'.format(self.account_id, self.id)
+            "DELETE",
+            "accounts/{}/authentication_providers/{}".format(self.account_id, self.id),
         )
         return AuthenticationProvider(self._requester, response.json())

--- a/canvasapi/avatar.py
+++ b/canvasapi/avatar.py
@@ -7,6 +7,5 @@ from canvasapi.canvas_object import CanvasObject
 
 @python_2_unicode_compatible
 class Avatar(CanvasObject):
-
     def __str__(self):  # pragma: no cover
         return "{}".format(self.display_name)

--- a/canvasapi/bookmark.py
+++ b/canvasapi/bookmark.py
@@ -8,7 +8,6 @@ from canvasapi.util import combine_kwargs
 
 @python_2_unicode_compatible
 class Bookmark(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.name, self.id)
 
@@ -22,8 +21,7 @@ class Bookmark(CanvasObject):
         :rtype: :class:`canvasapi.bookmark.Bookmark`
         """
         response = self._requester.request(
-            'DELETE',
-            'users/self/bookmarks/{}'.format(self.id)
+            "DELETE", "users/self/bookmarks/{}".format(self.id)
         )
         return Bookmark(self._requester, response.json())
 
@@ -37,12 +35,12 @@ class Bookmark(CanvasObject):
         :rtype: :class:`canvasapi.bookmark.Bookmark`
         """
         response = self._requester.request(
-            'PUT',
-            'users/self/bookmarks/{}'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "users/self/bookmarks/{}".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
-        if 'name' in response.json() and 'url' in response.json():
+        if "name" in response.json() and "url" in response.json():
             super(Bookmark, self).set_attributes(response.json())
 
         return Bookmark(self._requester, response.json())

--- a/canvasapi/calendar_event.py
+++ b/canvasapi/calendar_event.py
@@ -5,7 +5,6 @@ from canvasapi.util import combine_kwargs
 
 
 class CalendarEvent(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.title, self.id)
 
@@ -19,9 +18,9 @@ class CalendarEvent(CanvasObject):
         :rtype: :class:`canvasapi.calendar_event.CalendarEvent`
         """
         response = self._requester.request(
-            'DELETE',
-            'calendar_events/{}'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "DELETE",
+            "calendar_events/{}".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return CalendarEvent(self._requester, response.json())
 
@@ -35,12 +34,12 @@ class CalendarEvent(CanvasObject):
         :rtype: :class:`canvasapi.calendar_event.CalendarEvent`
         """
         response = self._requester.request(
-            'PUT',
-            'calendar_events/{}'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "calendar_events/{}".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
-        if 'title' in response.json():
+        if "title" in response.json():
             super(CalendarEvent, self).set_attributes(response.json())
 
         return CalendarEvent(self._requester, response.json())

--- a/canvasapi/canvas.py
+++ b/canvasapi/canvas.py
@@ -16,7 +16,7 @@ from canvasapi.user import User
 from canvasapi.util import combine_kwargs, get_institution_url, obj_or_id
 
 
-warnings.simplefilter('always', DeprecationWarning)
+warnings.simplefilter("always", DeprecationWarning)
 
 
 class Canvas(object):
@@ -33,20 +33,20 @@ class Canvas(object):
         """
         new_url = get_institution_url(base_url)
 
-        if 'api/v1' in base_url:
+        if "api/v1" in base_url:
             warnings.warn(
                 "`base_url` no longer requires an API version be specified. "
                 "Rewriting `base_url` to {}".format(new_url),
-                DeprecationWarning
+                DeprecationWarning,
             )
 
-        if 'http://' in base_url:
+        if "http://" in base_url:
             warnings.warn(
                 "Canvas may respond unexpectedly when making requests to HTTP "
                 "URLs. If possible, please use HTTPS.",
-                UserWarning
+                UserWarning,
             )
-        base_url = new_url + '/api/v1/'
+        base_url = new_url + "/api/v1/"
 
         self.__requester = Requester(base_url, access_token)
 
@@ -60,9 +60,7 @@ class Canvas(object):
         :rtype: :class:`canvasapi.account.Account`
         """
         response = self.__requester.request(
-            'POST',
-            'accounts',
-            _kwargs=combine_kwargs(**kwargs)
+            "POST", "accounts", _kwargs=combine_kwargs(**kwargs)
         )
         return Account(self.__requester, response.json())
 
@@ -83,15 +81,13 @@ class Canvas(object):
         """
         if use_sis_id:
             account_id = account
-            uri_str = 'accounts/sis_account_id:{}'
+            uri_str = "accounts/sis_account_id:{}"
         else:
             account_id = obj_or_id(account, "account", (Account,))
-            uri_str = 'accounts/{}'
+            uri_str = "accounts/{}"
 
         response = self.__requester.request(
-            'GET',
-            uri_str.format(account_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET", uri_str.format(account_id), _kwargs=combine_kwargs(**kwargs)
         )
         return Account(self.__requester, response.json())
 
@@ -112,9 +108,9 @@ class Canvas(object):
         return PaginatedList(
             Account,
             self.__requester,
-            'GET',
-            'accounts',
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "accounts",
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_course_accounts(self):
@@ -131,12 +127,7 @@ class Canvas(object):
         :rtype: :class:`canvasapi.paginated_list.PaginatedList` of
             :class:`canvasapi.account.Account`
         """
-        return PaginatedList(
-            Account,
-            self.__requester,
-            'GET',
-            'course_accounts',
-        )
+        return PaginatedList(Account, self.__requester, "GET", "course_accounts")
 
     def get_course(self, course, use_sis_id=False, **kwargs):
         """
@@ -155,15 +146,13 @@ class Canvas(object):
         """
         if use_sis_id:
             course_id = course
-            uri_str = 'courses/sis_course_id:{}'
+            uri_str = "courses/sis_course_id:{}"
         else:
             course_id = obj_or_id(course, "course", (Course,))
-            uri_str = 'courses/{}'
+            uri_str = "courses/{}"
 
         response = self.__requester.request(
-            'GET',
-            uri_str.format(course_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET", uri_str.format(course_id), _kwargs=combine_kwargs(**kwargs)
         )
         return Course(self.__requester, response.json())
 
@@ -187,17 +176,14 @@ class Canvas(object):
         :rtype: :class:`canvasapi.user.User`
         """
         if id_type:
-            uri = 'users/{}:{}'.format(id_type, user)
-        elif user == 'self':
-            uri = 'users/self'
+            uri = "users/{}:{}".format(id_type, user)
+        elif user == "self":
+            uri = "users/self"
         else:
             user_id = obj_or_id(user, "user", (User,))
-            uri = 'users/{}'.format(user_id)
+            uri = "users/{}".format(user_id)
 
-        response = self.__requester.request(
-            'GET',
-            uri
-        )
+        response = self.__requester.request("GET", uri)
         return User(self.__requester, response.json())
 
     def get_current_user(self):
@@ -214,11 +200,7 @@ class Canvas(object):
             :class:`canvasapi.course.Course`
         """
         return PaginatedList(
-            Course,
-            self.__requester,
-            'GET',
-            'courses',
-            _kwargs=combine_kwargs(**kwargs)
+            Course, self.__requester, "GET", "courses", _kwargs=combine_kwargs(**kwargs)
         )
 
     def get_activity_stream_summary(self):
@@ -230,10 +212,7 @@ class Canvas(object):
 
         :rtype: dict
         """
-        response = self.__requester.request(
-            'GET',
-            'users/self/activity_stream/summary'
-        )
+        response = self.__requester.request("GET", "users/self/activity_stream/summary")
         return response.json()
 
     def get_todo_items(self):
@@ -245,10 +224,7 @@ class Canvas(object):
 
         :rtype: dict
         """
-        response = self.__requester.request(
-            'GET',
-            'users/self/todo'
-        )
+        response = self.__requester.request("GET", "users/self/todo")
         return response.json()
 
     def get_upcoming_events(self):
@@ -261,10 +237,7 @@ class Canvas(object):
 
         :rtype: dict
         """
-        response = self.__requester.request(
-            'GET',
-            'users/self/upcoming_events'
-        )
+        response = self.__requester.request("GET", "users/self/upcoming_events")
         return response.json()
 
     def get_course_nicknames(self):
@@ -280,10 +253,7 @@ class Canvas(object):
         from canvasapi.course import CourseNickname
 
         return PaginatedList(
-            CourseNickname,
-            self.__requester,
-            'GET',
-            'users/self/course_nicknames'
+            CourseNickname, self.__requester, "GET", "users/self/course_nicknames"
         )
 
     def get_course_nickname(self, course):
@@ -303,8 +273,7 @@ class Canvas(object):
         course_id = obj_or_id(course, "course", (Course,))
 
         response = self.__requester.request(
-            'GET',
-            'users/self/course_nicknames/{}'.format(course_id)
+            "GET", "users/self/course_nicknames/{}".format(course_id)
         )
         return CourseNickname(self.__requester, response.json())
 
@@ -325,15 +294,13 @@ class Canvas(object):
         """
         if use_sis_id:
             section_id = section
-            uri_str = 'sections/sis_section_id:{}'
+            uri_str = "sections/sis_section_id:{}"
         else:
             section_id = obj_or_id(section, "section", (Section,))
-            uri_str = 'sections/{}'
+            uri_str = "sections/{}"
 
         response = self.__requester.request(
-            'GET',
-            uri_str.format(section_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET", uri_str.format(section_id), _kwargs=combine_kwargs(**kwargs)
         )
         return Section(self.__requester, response.json())
 
@@ -358,9 +325,7 @@ class Canvas(object):
         course_id = obj_or_id(course, "course", (Course,))
 
         response = self.__requester.request(
-            'PUT',
-            'users/self/course_nicknames/{}'.format(course_id),
-            nickname=nickname
+            "PUT", "users/self/course_nicknames/{}".format(course_id), nickname=nickname
         )
         return CourseNickname(self.__requester, response.json())
 
@@ -376,11 +341,8 @@ class Canvas(object):
         :rtype: bool
         """
 
-        response = self.__requester.request(
-            'DELETE',
-            'users/self/course_nicknames'
-        )
-        return response.json().get('message') == 'OK'
+        response = self.__requester.request("DELETE", "users/self/course_nicknames")
+        return response.json().get("message") == "OK"
 
     def search_accounts(self, **kwargs):
         """
@@ -393,9 +355,7 @@ class Canvas(object):
         :rtype: dict
         """
         response = self.__requester.request(
-            'GET',
-            'accounts/search',
-            _kwargs=combine_kwargs(**kwargs)
+            "GET", "accounts/search", _kwargs=combine_kwargs(**kwargs)
         )
         return response.json()
 
@@ -409,9 +369,7 @@ class Canvas(object):
         :rtype: :class:`canvasapi.group.Group`
         """
         response = self.__requester.request(
-            'POST',
-            'groups',
-            _kwargs=combine_kwargs(**kwargs)
+            "POST", "groups", _kwargs=combine_kwargs(**kwargs)
         )
         return Group(self.__requester, response.json())
 
@@ -435,15 +393,13 @@ class Canvas(object):
 
         if use_sis_id:
             group_id = group
-            uri_str = 'groups/sis_group_id:{}'
+            uri_str = "groups/sis_group_id:{}"
         else:
             group_id = obj_or_id(group, "group", (Group,))
-            uri_str = 'groups/{}'
+            uri_str = "groups/{}"
 
         response = self.__requester.request(
-            'GET',
-            uri_str.format(group_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET", uri_str.format(group_id), _kwargs=combine_kwargs(**kwargs)
         )
         return Group(self.__requester, response.json())
 
@@ -462,8 +418,7 @@ class Canvas(object):
         category_id = obj_or_id(category, "category", (GroupCategory,))
 
         response = self.__requester.request(
-            'GET',
-            'group_categories/{}'.format(category_id)
+            "GET", "group_categories/{}".format(category_id)
         )
         return GroupCategory(self.__requester, response.json())
 
@@ -485,13 +440,11 @@ class Canvas(object):
         """
         from canvasapi.conversation import Conversation
 
-        kwargs['recipients'] = recipients
-        kwargs['body'] = body
+        kwargs["recipients"] = recipients
+        kwargs["body"] = body
 
         response = self.__requester.request(
-            'POST',
-            'conversations',
-            _kwargs=combine_kwargs(**kwargs)
+            "POST", "conversations", _kwargs=combine_kwargs(**kwargs)
         )
         return [Conversation(self.__requester, convo) for convo in response.json()]
 
@@ -512,9 +465,9 @@ class Canvas(object):
         conversation_id = obj_or_id(conversation, "conversation", (Conversation,))
 
         response = self.__requester.request(
-            'GET',
-            'conversations/{}'.format(conversation_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "conversations/{}".format(conversation_id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return Conversation(self.__requester, response.json())
 
@@ -533,9 +486,9 @@ class Canvas(object):
         return PaginatedList(
             Conversation,
             self.__requester,
-            'GET',
-            'conversations',
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "conversations",
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def conversations_mark_all_as_read(self):
@@ -547,10 +500,7 @@ class Canvas(object):
 
         :rtype: `bool`
         """
-        response = self.__requester.request(
-            'POST',
-            'conversations/mark_all_as_read'
-        )
+        response = self.__requester.request("POST", "conversations/mark_all_as_read")
         return response.json() == {}
 
     def conversations_unread_count(self):
@@ -563,10 +513,7 @@ class Canvas(object):
         :returns: simple object with unread_count, example: {'unread_count': '7'}
         :rtype: `dict`
         """
-        response = self.__requester.request(
-            'GET',
-            'conversations/unread_count'
-        )
+        response = self.__requester.request("GET", "conversations/unread_count")
 
         return response.json()
 
@@ -583,10 +530,7 @@ class Canvas(object):
         :rtype: `dict`
         """
 
-        response = self.__requester.request(
-            'GET',
-            'conversations/batches'
-        )
+        response = self.__requester.request("GET", "conversations/batches")
 
         return response.json()
 
@@ -606,33 +550,32 @@ class Canvas(object):
         from canvasapi.progress import Progress
 
         ALLOWED_EVENTS = [
-            'mark_as_read',
-            'mark_as_unread',
-            'star',
-            'unstar',
-            'archive',
-            'destroy'
+            "mark_as_read",
+            "mark_as_unread",
+            "star",
+            "unstar",
+            "archive",
+            "destroy",
         ]
 
         try:
             if event not in ALLOWED_EVENTS:
                 raise ValueError(
-                    '{} is not a valid action. Please use one of the following: {}'.format(
-                        event,
-                        ','.join(ALLOWED_EVENTS)
+                    "{} is not a valid action. Please use one of the following: {}".format(
+                        event, ",".join(ALLOWED_EVENTS)
                     )
                 )
 
             if len(conversation_ids) > 500:
                 raise ValueError(
-                    'You have requested {} updates, which exceeds the limit of 500'.format(
+                    "You have requested {} updates, which exceeds the limit of 500".format(
                         len(conversation_ids)
                     )
                 )
 
             response = self.__requester.request(
-                'PUT',
-                'conversations',
+                "PUT",
+                "conversations",
                 event=event,
                 **{"conversation_ids[]": conversation_ids}
             )
@@ -655,17 +598,15 @@ class Canvas(object):
         """
         from canvasapi.calendar_event import CalendarEvent
 
-        if isinstance(calendar_event, dict) and 'context_code' in calendar_event:
-            kwargs['calendar_event'] = calendar_event
+        if isinstance(calendar_event, dict) and "context_code" in calendar_event:
+            kwargs["calendar_event"] = calendar_event
         else:
             raise RequiredFieldMissing(
                 "Dictionary with key 'context_codes' is required."
             )
 
         response = self.__requester.request(
-            'POST',
-            'calendar_events',
-            _kwargs=combine_kwargs(**kwargs)
+            "POST", "calendar_events", _kwargs=combine_kwargs(**kwargs)
         )
 
         return CalendarEvent(self.__requester, response.json())
@@ -687,7 +628,7 @@ class Canvas(object):
         warnings.warn(
             "`list_calendar_events` is being deprecated and will be removed "
             "in a future version. Use `get_calendar_events` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_calendar_events(**kwargs)
@@ -707,9 +648,9 @@ class Canvas(object):
         return PaginatedList(
             CalendarEvent,
             self.__requester,
-            'GET',
-            'calendar_events',
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "calendar_events",
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_calendar_event(self, calendar_event):
@@ -726,11 +667,12 @@ class Canvas(object):
         """
         from canvasapi.calendar_event import CalendarEvent
 
-        calendar_event_id = obj_or_id(calendar_event, "calendar_event", (CalendarEvent,))
+        calendar_event_id = obj_or_id(
+            calendar_event, "calendar_event", (CalendarEvent,)
+        )
 
         response = self.__requester.request(
-            'GET',
-            'calendar_events/{}'.format(calendar_event_id)
+            "GET", "calendar_events/{}".format(calendar_event_id)
         )
         return CalendarEvent(self.__requester, response.json())
 
@@ -751,19 +693,19 @@ class Canvas(object):
         """
         from canvasapi.calendar_event import CalendarEvent
 
-        calendar_event_id = obj_or_id(calendar_event, "calendar_event", (CalendarEvent,))
+        calendar_event_id = obj_or_id(
+            calendar_event, "calendar_event", (CalendarEvent,)
+        )
 
         if participant_id:
-            uri = 'calendar_events/{}/reservations/{}'.format(
+            uri = "calendar_events/{}/reservations/{}".format(
                 calendar_event_id, participant_id
             )
         else:
-            uri = 'calendar_events/{}/reservations'.format(calendar_event_id)
+            uri = "calendar_events/{}/reservations".format(calendar_event_id)
 
         response = self.__requester.request(
-            'POST',
-            uri,
-            _kwargs=combine_kwargs(**kwargs)
+            "POST", uri, _kwargs=combine_kwargs(**kwargs)
         )
         return CalendarEvent(self.__requester, response.json())
 
@@ -784,7 +726,7 @@ class Canvas(object):
         warnings.warn(
             "`list_appointment_groups` is being deprecated and will be removed"
             " in a future version. Use `get_appointment_groups` instead.",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_appointment_groups(**kwargs)
@@ -804,9 +746,9 @@ class Canvas(object):
         return PaginatedList(
             AppointmentGroup,
             self.__requester,
-            'GET',
-            'appointment_groups',
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "appointment_groups",
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_appointment_group(self, appointment_group):
@@ -828,8 +770,7 @@ class Canvas(object):
         )
 
         response = self.__requester.request(
-            'GET',
-            'appointment_groups/{}'.format(appointment_group_id)
+            "GET", "appointment_groups/{}".format(appointment_group_id)
         )
         return AppointmentGroup(self.__requester, response.json())
 
@@ -849,27 +790,25 @@ class Canvas(object):
         from canvasapi.appointment_group import AppointmentGroup
 
         if (
-                isinstance(appointment_group, dict) and
-                'context_codes' in appointment_group and
-                'title' in appointment_group
+            isinstance(appointment_group, dict)
+            and "context_codes" in appointment_group
+            and "title" in appointment_group
         ):
-            kwargs['appointment_group'] = appointment_group
+            kwargs["appointment_group"] = appointment_group
 
         elif (
-            isinstance(appointment_group, dict) and
-            'context_codes' not in appointment_group
+            isinstance(appointment_group, dict)
+            and "context_codes" not in appointment_group
         ):
             raise RequiredFieldMissing(
                 "Dictionary with key 'context_codes' is missing."
             )
 
-        elif isinstance(appointment_group, dict) and 'title' not in appointment_group:
+        elif isinstance(appointment_group, dict) and "title" not in appointment_group:
             raise RequiredFieldMissing("Dictionary with key 'title' is missing.")
 
         response = self.__requester.request(
-            'POST',
-            'appointment_groups',
-            _kwargs=combine_kwargs(**kwargs)
+            "POST", "appointment_groups", _kwargs=combine_kwargs(**kwargs)
         )
 
         return AppointmentGroup(self.__requester, response.json())
@@ -893,7 +832,7 @@ class Canvas(object):
         warnings.warn(
             "`list_user_participants` is being deprecated and will be removed in a future version."
             " Use `get_user_participants` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_user_participants(appointment_group, **kwargs)
@@ -920,9 +859,9 @@ class Canvas(object):
         return PaginatedList(
             User,
             self.__requester,
-            'GET',
-            'appointment_groups/{}/users'.format(appointment_group_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "appointment_groups/{}/users".format(appointment_group_id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def list_group_participants(self, appointment_group, **kwargs):
@@ -944,7 +883,7 @@ class Canvas(object):
         warnings.warn(
             "`list_group_participants` is being deprecated and will be removed "
             "in a future version. Use `get_group_participants` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_group_participants(appointment_group, **kwargs)
@@ -971,9 +910,9 @@ class Canvas(object):
         return PaginatedList(
             Group,
             self.__requester,
-            'GET',
-            'appointment_groups/{}/groups'.format(appointment_group_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "appointment_groups/{}/groups".format(appointment_group_id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_file(self, file, **kwargs):
@@ -991,9 +930,7 @@ class Canvas(object):
         file_id = obj_or_id(file, "file", (File,))
 
         response = self.__requester.request(
-            'GET',
-            'files/{}'.format(file_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET", "files/{}".format(file_id), _kwargs=combine_kwargs(**kwargs)
         )
         return File(self.__requester, response.json())
 
@@ -1011,10 +948,7 @@ class Canvas(object):
         """
         folder_id = obj_or_id(folder, "folder", (Folder,))
 
-        response = self.__requester.request(
-            'GET',
-            'folders/{}'.format(folder_id)
-        )
+        response = self.__requester.request("GET", "folders/{}".format(folder_id))
         return Folder(self.__requester, response.json())
 
     def search_recipients(self, **kwargs):
@@ -1028,13 +962,11 @@ class Canvas(object):
 
         :rtype: `list`
         """
-        if 'search' not in kwargs:
-            kwargs['search'] = ' '
+        if "search" not in kwargs:
+            kwargs["search"] = " "
 
         response = self.__requester.request(
-            'GET',
-            'search/recipients',
-            _kwargs=combine_kwargs(**kwargs)
+            "GET", "search/recipients", _kwargs=combine_kwargs(**kwargs)
         )
         return response.json()
 
@@ -1049,9 +981,7 @@ class Canvas(object):
         :rtype: `list`
         """
         response = self.__requester.request(
-            'GET',
-            'search/all_courses',
-            _kwargs=combine_kwargs(**kwargs)
+            "GET", "search/all_courses", _kwargs=combine_kwargs(**kwargs)
         )
         return response.json()
 
@@ -1071,10 +1001,7 @@ class Canvas(object):
         from canvasapi.outcome import Outcome
 
         outcome_id = obj_or_id(outcome, "outcome", (Outcome,))
-        response = self.__requester.request(
-            'GET',
-            'outcomes/{}'.format(outcome_id)
-        )
+        response = self.__requester.request("GET", "outcomes/{}".format(outcome_id))
         return Outcome(self.__requester, response.json())
 
     def get_root_outcome_group(self):
@@ -1089,10 +1016,7 @@ class Canvas(object):
         """
         from canvasapi.outcome import OutcomeGroup
 
-        response = self.__requester.request(
-            'GET',
-            'global/root_outcome_group'
-        )
+        response = self.__requester.request("GET", "global/root_outcome_group")
         return OutcomeGroup(self.__requester, response.json())
 
     def get_outcome_group(self, group):
@@ -1113,8 +1037,7 @@ class Canvas(object):
         outcome_group_id = obj_or_id(group, "group", (OutcomeGroup,))
 
         response = self.__requester.request(
-            'GET',
-            'global/outcome_groups/{}'.format(outcome_group_id)
+            "GET", "global/outcome_groups/{}".format(outcome_group_id)
         )
 
         return OutcomeGroup(self.__requester, response.json())
@@ -1137,9 +1060,7 @@ class Canvas(object):
         progress_id = obj_or_id(progress, "progress", (Progress,))
 
         response = self.__requester.request(
-            'GET',
-            'progress/{}'.format(progress_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET", "progress/{}".format(progress_id), _kwargs=combine_kwargs(**kwargs)
         )
         return Progress(self.__requester, response.json())
 
@@ -1154,10 +1075,11 @@ class Canvas(object):
                 :class:`canvasapi.discussion_topic.DiscussionTopic`
         """
         from canvasapi.discussion_topic import DiscussionTopic
+
         return PaginatedList(
             DiscussionTopic,
             self.__requester,
-            'GET',
-            'announcements',
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "announcements",
+            _kwargs=combine_kwargs(**kwargs),
         )

--- a/canvasapi/canvas_object.py
+++ b/canvasapi/canvas_object.py
@@ -6,7 +6,7 @@ import re
 
 from six import text_type
 
-DATE_PATTERN = re.compile('[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z')
+DATE_PATTERN = re.compile("[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z")
 
 
 class CanvasObject(object):
@@ -29,8 +29,14 @@ class CanvasObject(object):
 
     def __repr__(self):  # pragma: no cover
         classname = self.__class__.__name__
-        attrs = ', '.join(['{}={}'.format(attr, val) for attr, val in self.__dict__.items() if attr != 'attributes'])  # noqa
-        return '{}({})'.format(classname, attrs)
+        attrs = ", ".join(
+            [
+                "{}={}".format(attr, val)
+                for attr, val in self.__dict__.items()
+                if attr != "attributes"
+            ]
+        )  # noqa
+        return "{}({})".format(classname, attrs)
 
     def to_json(self):
         """
@@ -70,6 +76,6 @@ class CanvasObject(object):
 
             # datetime field
             if DATE_PATTERN.match(text_type(value)):
-                naive = datetime.strptime(value, '%Y-%m-%dT%H:%M:%SZ')
+                naive = datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
                 aware = naive.replace(tzinfo=pytz.utc)
-                self.__setattr__(attribute + '_date', aware)
+                self.__setattr__(attribute + "_date", aware)

--- a/canvasapi/communication_channel.py
+++ b/canvasapi/communication_channel.py
@@ -11,7 +11,6 @@ from canvasapi.util import combine_kwargs
 
 @python_2_unicode_compatible
 class CommunicationChannel(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.address, self.id)
 
@@ -34,7 +33,7 @@ class CommunicationChannel(CanvasObject):
         warnings.warn(
             "`list_preferences` is being deprecated and will be removed in a future version."
             " Use `get_preferences` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_preferences(**kwargs)
@@ -51,15 +50,14 @@ class CommunicationChannel(CanvasObject):
         :rtype: `list`
         """
         response = self._requester.request(
-            'GET',
-            'users/{}/communication_channels/{}/notification_preferences'.format(
-                self.user_id,
-                self.id
+            "GET",
+            "users/{}/communication_channels/{}/notification_preferences".format(
+                self.user_id, self.id
             ),
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
 
-        return response.json()['notification_preferences']
+        return response.json()["notification_preferences"]
 
     def list_preference_categories(self, **kwargs):
         """
@@ -83,7 +81,7 @@ class CommunicationChannel(CanvasObject):
             "`list_preference_categories`"
             " is being deprecated and will be removed in a future version."
             " Use `get_preference_categories` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_preference_categories(**kwargs)
@@ -101,14 +99,13 @@ class CommunicationChannel(CanvasObject):
         :rtype: `list`
         """
         response = self._requester.request(
-            'GET',
-            'users/{}/communication_channels/{}/notification_preference_categories'.format(
-                self.user_id,
-                self.id
+            "GET",
+            "users/{}/communication_channels/{}/notification_preference_categories".format(
+                self.user_id, self.id
             ),
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
-        return response.json()['categories']
+        return response.json()["categories"]
 
     def get_preference(self, notification):
         """
@@ -125,14 +122,12 @@ class CommunicationChannel(CanvasObject):
         :rtype: :class:`canvasapi.notification_preference.NotificationPreference`
         """
         response = self._requester.request(
-            'GET',
-            'users/{}/communication_channels/{}/notification_preferences/{}'.format(
-                self.user_id,
-                self.id,
-                notification
-            )
+            "GET",
+            "users/{}/communication_channels/{}/notification_preferences/{}".format(
+                self.user_id, self.id, notification
+            ),
         )
-        data = response.json()['notification_preferences'][0]
+        data = response.json()["notification_preferences"][0]
         return NotificationPreference(self._requester, data)
 
     def update_preference(self, notification, frequency, **kwargs):
@@ -152,16 +147,15 @@ class CommunicationChannel(CanvasObject):
 
         :rtype: :class:`canvasapi.notification_preference.NotificationPreference`
         """
-        kwargs['notification_preferences[frequency]'] = frequency
+        kwargs["notification_preferences[frequency]"] = frequency
         response = self._requester.request(
-            'PUT',
-            'users/self/communication_channels/{}/notification_preferences/{}'.format(
-                self.id,
-                notification
+            "PUT",
+            "users/self/communication_channels/{}/notification_preferences/{}".format(
+                self.id, notification
             ),
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
-        data = response.json()['notification_preferences'][0]
+        data = response.json()["notification_preferences"][0]
         return NotificationPreference(self._requester, data)
 
     def update_preferences_by_catagory(self, category, frequency, **kwargs):
@@ -183,16 +177,15 @@ class CommunicationChannel(CanvasObject):
 
         :rtype: :class:`canvasapi.notification_preference.NotificationPreference`
         """
-        kwargs['notification_preferences[frequency]'] = frequency
+        kwargs["notification_preferences[frequency]"] = frequency
         response = self._requester.request(
-            'PUT',
-            'users/self/communication_channels/{}/notification_preference_categories/{}'.format(
-                self.id,
-                category
+            "PUT",
+            "users/self/communication_channels/{}/notification_preference_categories/{}".format(
+                self.id, category
             ),
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
-        return response.json()['notification_preferences']
+        return response.json()["notification_preferences"]
 
     def update_multiple_preferences(self, notification_preferences, **kwargs):
         """
@@ -214,18 +207,18 @@ class CommunicationChannel(CanvasObject):
 
             for key, value in notification_preferences.items():
                 try:
-                    if not value['frequency']:
+                    if not value["frequency"]:
                         return False
                 except KeyError:
                     return False
 
-            kwargs['notification_preferences'] = notification_preferences
+            kwargs["notification_preferences"] = notification_preferences
             response = self._requester.request(
-                'PUT',
-                'users/self/communication_channels/{}/notification_preferences'.format(
+                "PUT",
+                "users/self/communication_channels/{}/notification_preferences".format(
                     self.id
                 ),
-                _kwargs=combine_kwargs(**kwargs)
+                _kwargs=combine_kwargs(**kwargs),
             )
-            return response.json()['notification_preferences']
+            return response.json()["notification_preferences"]
         return False

--- a/canvasapi/content_migration.py
+++ b/canvasapi/content_migration.py
@@ -20,17 +20,18 @@ class ContentMigration(CanvasObject):
 
         :rtype: int
         """
-        if hasattr(self, 'course_id'):
+        if hasattr(self, "course_id"):
             return self.course_id
-        elif hasattr(self, 'group_id'):
+        elif hasattr(self, "group_id"):
             return self.group_id
-        elif hasattr(self, 'account_id'):
+        elif hasattr(self, "account_id"):
             return self.account_id
-        elif hasattr(self, 'user_id'):
+        elif hasattr(self, "user_id"):
             return self.user_id
         else:
             raise ValueError(
-                "Content Migration does not have an account_id, course_id, group_id or user_id")
+                "Content Migration does not have an account_id, course_id, group_id or user_id"
+            )
 
     @property
     def _parent_type(self):
@@ -39,17 +40,18 @@ class ContentMigration(CanvasObject):
 
         :rtype: str
         """
-        if hasattr(self, 'course_id'):
-            return 'course'
-        elif hasattr(self, 'group_id'):
-            return 'group'
-        elif hasattr(self, 'account_id'):
-            return 'account'
-        elif hasattr(self, 'user_id'):
-            return 'user'
+        if hasattr(self, "course_id"):
+            return "course"
+        elif hasattr(self, "group_id"):
+            return "group"
+        elif hasattr(self, "account_id"):
+            return "account"
+        elif hasattr(self, "user_id"):
+            return "user"
         else:
             raise ValueError(
-                "Content Migration does not have an account_id, course_id, group_id or user_id")
+                "Content Migration does not have an account_id, course_id, group_id or user_id"
+            )
 
     def get_migration_issue(self, migration_issue, **kwargs):
         """
@@ -78,23 +80,26 @@ class ContentMigration(CanvasObject):
         """
         from canvasapi.content_migration import MigrationIssue
 
-        migration_issue_id = obj_or_id(migration_issue, "migration_issue", (MigrationIssue,))
+        migration_issue_id = obj_or_id(
+            migration_issue, "migration_issue", (MigrationIssue,)
+        )
 
         response = self._requester.request(
-            'GET',
-            '{}s/{}/content_migrations/{}/migration_issues/{}'.format(
-                self._parent_type,
-                self._parent_id,
-                self.id,
-                migration_issue_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "{}s/{}/content_migrations/{}/migration_issues/{}".format(
+                self._parent_type, self._parent_id, self.id, migration_issue_id
+            ),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         response_json = response.json()
-        response_json.update({
-            'context_type': self._parent_type,
-            'context_id': self._parent_id,
-            'content_migration_id': self.id})
+        response_json.update(
+            {
+                "context_type": self._parent_type,
+                "context_id": self._parent_id,
+                "content_migration_id": self.id,
+            }
+        )
 
         return MigrationIssue(self._requester, response_json)
 
@@ -126,14 +131,16 @@ class ContentMigration(CanvasObject):
         return PaginatedList(
             MigrationIssue,
             self._requester,
-            'GET',
-            '{}s/{}/content_migrations/{}/migration_issues/'.format(
-                self._parent_type,
-                self._parent_id, self.id),
-            {'context_type': self._parent_type,
-             'context_id': self._parent_id,
-             'content_migration_id': self.id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "{}s/{}/content_migrations/{}/migration_issues/".format(
+                self._parent_type, self._parent_id, self.id
+            ),
+            {
+                "context_type": self._parent_type,
+                "context_id": self._parent_id,
+                "content_migration_id": self.id,
+            },
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_parent(self, **kwargs):
@@ -151,18 +158,18 @@ class ContentMigration(CanvasObject):
         from canvasapi.user import User
 
         response = self._requester.request(
-            'GET',
-            '{}s/{}'.format(self._parent_type, self._parent_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "{}s/{}".format(self._parent_type, self._parent_id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
-        if self._parent_type == 'group':
+        if self._parent_type == "group":
             return Group(self._requester, response.json())
-        elif self._parent_type == 'course':
+        elif self._parent_type == "course":
             return Course(self._requester, response.json())
-        elif self._parent_type == 'account':
+        elif self._parent_type == "account":
             return Account(self._requester, response.json())
-        elif self._parent_type == 'user':
+        elif self._parent_type == "user":
             return User(self._requester, response.json())
 
     def get_progress(self, **kwargs):
@@ -180,9 +187,7 @@ class ContentMigration(CanvasObject):
         progress_id = self.progress_url.split("/")[-1]
 
         response = self._requester.request(
-            'GET',
-            'progress/{}'.format(progress_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET", "progress/{}".format(progress_id), _kwargs=combine_kwargs(**kwargs)
         )
         return Progress(self._requester, response.json())
 
@@ -206,12 +211,14 @@ class ContentMigration(CanvasObject):
         :rtype: bool
         """
         response = self._requester.request(
-            'PUT',
-            '{}s/{}/content_migrations/{}'.format(self._parent_type, self._parent_id, self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "{}s/{}/content_migrations/{}".format(
+                self._parent_type, self._parent_id, self.id
+            ),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
-        if 'migration_type' in response.json():
+        if "migration_type" in response.json():
             super(ContentMigration, self).set_attributes(response.json())
             return True
         else:
@@ -244,16 +251,14 @@ class MigrationIssue(CanvasObject):
         :rtype: bool
         """
         response = self._requester.request(
-            'PUT',
-            '{}s/{}/content_migrations/{}/migration_issues/{}'.format(
-                self.context_type,
-                self.context_id,
-                self.content_migration_id,
-                self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "{}s/{}/content_migrations/{}/migration_issues/{}".format(
+                self.context_type, self.context_id, self.content_migration_id, self.id
+            ),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
-        if 'workflow_state' in response.json():
+        if "workflow_state" in response.json():
             super(MigrationIssue, self).set_attributes(response.json())
             return True
         else:

--- a/canvasapi/conversation.py
+++ b/canvasapi/conversation.py
@@ -8,7 +8,6 @@ from canvasapi.util import combine_kwargs
 
 @python_2_unicode_compatible
 class Conversation(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.subject, self.id)
 
@@ -22,12 +21,10 @@ class Conversation(CanvasObject):
         :rtype: `bool`
         """
         response = self._requester.request(
-            'PUT',
-            'conversations/{}'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT", "conversations/{}".format(self.id), _kwargs=combine_kwargs(**kwargs)
         )
 
-        if response.json().get('id'):
+        if response.json().get("id"):
             super(Conversation, self).set_attributes(response.json())
             return True
         else:
@@ -42,12 +39,9 @@ class Conversation(CanvasObject):
 
         :rtype: `bool`
         """
-        response = self._requester.request(
-            'DELETE',
-            'conversations/{}'.format(self.id)
-        )
+        response = self._requester.request("DELETE", "conversations/{}".format(self.id))
 
-        if response.json().get('id'):
+        if response.json().get("id"):
             super(Conversation, self).set_attributes(response.json())
             return True
         else:
@@ -68,9 +62,9 @@ class Conversation(CanvasObject):
         :rtype: :class:`canvasapi.account.Conversation`
         """
         response = self._requester.request(
-            'POST',
-            'conversations/{}/add_recipients'.format(self.id),
-            recipients=recipients
+            "POST",
+            "conversations/{}/add_recipients".format(self.id),
+            recipients=recipients,
         )
         return Conversation(self._requester, response.json())
 
@@ -87,10 +81,10 @@ class Conversation(CanvasObject):
         :rtype: :class:`canvasapi.account.Conversation`
         """
         response = self._requester.request(
-            'POST',
-            'conversations/{}/add_message'.format(self.id),
+            "POST",
+            "conversations/{}/add_message".format(self.id),
             body=body,
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         return Conversation(self._requester, response.json())
 
@@ -109,8 +103,6 @@ class Conversation(CanvasObject):
         :rtype: `dict`
         """
         response = self._requester.request(
-            'POST',
-            'conversations/{}/remove_messages'.format(self.id),
-            remove=remove
+            "POST", "conversations/{}/remove_messages".format(self.id), remove=remove
         )
         return response.json()

--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -19,14 +19,13 @@ from canvasapi.upload import Uploader
 from canvasapi.util import combine_kwargs, is_multivalued, obj_or_id
 from canvasapi.rubric import Rubric
 
-warnings.simplefilter('always', DeprecationWarning)
+warnings.simplefilter("always", DeprecationWarning)
 
 
 @python_2_unicode_compatible
 class Course(CanvasObject):
-
     def __str__(self):
-        return '{} {} ({})'.format(self.course_code, self.name, self.id)
+        return "{} {} ({})".format(self.course_code, self.name, self.id)
 
     def conclude(self):
         """
@@ -39,12 +38,10 @@ class Course(CanvasObject):
         :rtype: bool
         """
         response = self._requester.request(
-            'DELETE',
-            'courses/{}'.format(self.id),
-            event="conclude"
+            "DELETE", "courses/{}".format(self.id), event="conclude"
         )
 
-        return response.json().get('conclude')
+        return response.json().get("conclude")
 
     def create_assignment_overrides(self, assignment_overrides, **kwargs):
         """
@@ -61,15 +58,15 @@ class Course(CanvasObject):
         """
         from canvasapi.assignment import AssignmentOverride
 
-        kwargs['assignment_overrides'] = assignment_overrides
+        kwargs["assignment_overrides"] = assignment_overrides
 
         return PaginatedList(
             AssignmentOverride,
             self._requester,
-            'POST',
-            'courses/{}/assignments/overrides'.format(self.id),
-            {'course_id': self.id},
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "courses/{}/assignments/overrides".format(self.id),
+            {"course_id": self.id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def delete(self):
@@ -83,11 +80,9 @@ class Course(CanvasObject):
         :rtype: bool
         """
         response = self._requester.request(
-            'DELETE',
-            'courses/{}'.format(self.id),
-            event="delete"
+            "DELETE", "courses/{}".format(self.id), event="delete"
         )
-        return response.json().get('delete')
+        return response.json().get("delete")
 
     def update(self, **kwargs):
         """
@@ -100,15 +95,13 @@ class Course(CanvasObject):
         :rtype: bool
         """
         response = self._requester.request(
-            'PUT',
-            'courses/{}'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT", "courses/{}".format(self.id), _kwargs=combine_kwargs(**kwargs)
         )
 
-        if response.json().get('name'):
+        if response.json().get("name"):
             super(Course, self).set_attributes(response.json())
 
-        return response.json().get('name')
+        return response.json().get("name")
 
     def update_assignment_overrides(self, assignment_overrides, **kwargs):
         """
@@ -127,15 +120,15 @@ class Course(CanvasObject):
         """
         from canvasapi.assignment import AssignmentOverride
 
-        kwargs['assignment_overrides'] = assignment_overrides
+        kwargs["assignment_overrides"] = assignment_overrides
 
         return PaginatedList(
             AssignmentOverride,
             self._requester,
-            'PUT',
-            'courses/{}/assignments/overrides'.format(self.id),
-            {'course_id': self.id},
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "courses/{}/assignments/overrides".format(self.id),
+            {"course_id": self.id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_user(self, user, user_id_type=None):
@@ -156,15 +149,12 @@ class Course(CanvasObject):
         from canvasapi.user import User
 
         if user_id_type:
-            uri = 'courses/{}/users/{}:{}'.format(self.id, user_id_type, user)
+            uri = "courses/{}/users/{}:{}".format(self.id, user_id_type, user)
         else:
             user_id = obj_or_id(user, "user", (User,))
-            uri = 'courses/{}/users/{}'.format(self.id, user_id)
+            uri = "courses/{}/users/{}".format(self.id, user_id)
 
-        response = self._requester.request(
-            'GET',
-            uri
-        )
+        response = self._requester.request("GET", uri)
         return User(self._requester, response.json())
 
     def get_users(self, **kwargs):
@@ -182,9 +172,9 @@ class Course(CanvasObject):
         return PaginatedList(
             User,
             self._requester,
-            'GET',
-            'courses/{}/search_users'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/search_users".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def enroll_user(self, user, enrollment_type, **kwargs):
@@ -203,13 +193,13 @@ class Course(CanvasObject):
         from canvasapi.enrollment import Enrollment
         from canvasapi.user import User
 
-        kwargs['enrollment[user_id]'] = obj_or_id(user, "user", (User,))
-        kwargs['enrollment[type]'] = enrollment_type
+        kwargs["enrollment[user_id]"] = obj_or_id(user, "user", (User,))
+        kwargs["enrollment[type]"] = enrollment_type
 
         response = self._requester.request(
-            'POST',
-            'courses/{}/enrollments'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "courses/{}/enrollments".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         return Enrollment(self._requester, response.json())
@@ -228,10 +218,7 @@ class Course(CanvasObject):
         from canvasapi.user import User
 
         return PaginatedList(
-            User,
-            self._requester,
-            'GET',
-            'courses/{}/recent_students'.format(self.id)
+            User, self._requester, "GET", "courses/{}/recent_students".format(self.id)
         )
 
     def preview_html(self, html):
@@ -246,11 +233,9 @@ class Course(CanvasObject):
         :rtype: str
         """
         response = self._requester.request(
-            'POST',
-            'courses/{}/preview_html'.format(self.id),
-            html=html
+            "POST", "courses/{}/preview_html".format(self.id), html=html
         )
-        return response.json().get('html', '')
+        return response.json().get("html", "")
 
     def get_settings(self):
         """
@@ -261,10 +246,7 @@ class Course(CanvasObject):
 
         :rtype: dict
         """
-        response = self._requester.request(
-            'GET',
-            'courses/{}/settings'.format(self.id)
-        )
+        response = self._requester.request("GET", "courses/{}/settings".format(self.id))
         return response.json()
 
     def update_settings(self, **kwargs):
@@ -277,9 +259,7 @@ class Course(CanvasObject):
         :rtype: dict
         """
         response = self._requester.request(
-            'PUT',
-            'courses/{}/settings'.format(self.id),
-            **kwargs
+            "PUT", "courses/{}/settings".format(self.id), **kwargs
         )
         return response.json()
 
@@ -297,10 +277,7 @@ class Course(CanvasObject):
         :rtype: tuple
         """
         return Uploader(
-            self._requester,
-            'courses/{}/files'.format(self.id),
-            file,
-            **kwargs
+            self._requester, "courses/{}/files".format(self.id), file, **kwargs
         ).start()
 
     def reset(self):
@@ -314,8 +291,7 @@ class Course(CanvasObject):
         :rtype: :class:`canvasapi.course.Course`
         """
         response = self._requester.request(
-            'POST',
-            'courses/{}/reset_content'.format(self.id),
+            "POST", "courses/{}/reset_content".format(self.id)
         )
         return Course(self._requester, response.json())
 
@@ -330,12 +306,13 @@ class Course(CanvasObject):
             :class:`canvasapi.enrollment.Enrollment`
         """
         from canvasapi.enrollment import Enrollment
+
         return PaginatedList(
             Enrollment,
             self._requester,
-            'GET',
-            'courses/{}/enrollments'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/enrollments".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_assignment(self, assignment, **kwargs):
@@ -355,9 +332,9 @@ class Course(CanvasObject):
         assignment_id = obj_or_id(assignment, "assignment", (Assignment,))
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/assignments/{}'.format(self.id, assignment_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/assignments/{}".format(self.id, assignment_id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return Assignment(self._requester, response.json())
 
@@ -374,15 +351,15 @@ class Course(CanvasObject):
         """
         from canvasapi.assignment import AssignmentOverride
 
-        kwargs['assignment_overrides'] = assignment_overrides
+        kwargs["assignment_overrides"] = assignment_overrides
 
         return PaginatedList(
             AssignmentOverride,
             self._requester,
-            'GET',
-            'courses/{}/assignments/overrides'.format(self.id),
-            {'course_id': self.id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/assignments/overrides".format(self.id),
+            {"course_id": self.id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_assignments(self, **kwargs):
@@ -400,9 +377,9 @@ class Course(CanvasObject):
         return PaginatedList(
             Assignment,
             self._requester,
-            'GET',
-            'courses/{}/assignments'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/assignments".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def create_assignment(self, assignment, **kwargs):
@@ -420,15 +397,15 @@ class Course(CanvasObject):
         """
         from canvasapi.assignment import Assignment
 
-        if isinstance(assignment, dict) and 'name' in assignment:
-            kwargs['assignment'] = assignment
+        if isinstance(assignment, dict) and "name" in assignment:
+            kwargs["assignment"] = assignment
         else:
             raise RequiredFieldMissing("Dictionary with key 'name' is required.")
 
         response = self._requester.request(
-            'POST',
-            'courses/{}/assignments'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "courses/{}/assignments".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         return Assignment(self._requester, response.json())
@@ -444,13 +421,14 @@ class Course(CanvasObject):
             :class:`canvasapi.quiz.Quiz`
         """
         from canvasapi.quiz import Quiz
+
         return PaginatedList(
             Quiz,
             self._requester,
-            'GET',
-            'courses/{}/quizzes'.format(self.id),
-            {'course_id': self.id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/quizzes".format(self.id),
+            {"course_id": self.id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_quiz(self, quiz):
@@ -470,11 +448,10 @@ class Course(CanvasObject):
         quiz_id = obj_or_id(quiz, "quiz", (Quiz,))
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/quizzes/{}'.format(self.id, quiz_id)
+            "GET", "courses/{}/quizzes/{}".format(self.id, quiz_id)
         )
         quiz_json = response.json()
-        quiz_json.update({'course_id': self.id})
+        quiz_json.update({"course_id": self.id})
 
         return Quiz(self._requester, quiz_json)
 
@@ -491,18 +468,18 @@ class Course(CanvasObject):
         """
         from canvasapi.quiz import Quiz
 
-        if isinstance(quiz, dict) and 'title' in quiz:
-            kwargs['quiz'] = quiz
+        if isinstance(quiz, dict) and "title" in quiz:
+            kwargs["quiz"] = quiz
         else:
             raise RequiredFieldMissing("Dictionary with key 'title' is required.")
 
         response = self._requester.request(
-            'POST',
-            'courses/{}/quizzes'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "courses/{}/quizzes".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         quiz_json = response.json()
-        quiz_json.update({'course_id': self.id})
+        quiz_json.update({"course_id": self.id})
 
         return Quiz(self._requester, quiz_json)
 
@@ -521,10 +498,10 @@ class Course(CanvasObject):
         return PaginatedList(
             Module,
             self._requester,
-            'GET',
-            'courses/{}/modules'.format(self.id),
-            {'course_id': self.id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/modules".format(self.id),
+            {"course_id": self.id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_module(self, module, **kwargs):
@@ -544,11 +521,10 @@ class Course(CanvasObject):
         module_id = obj_or_id(module, "module", (Module,))
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/modules/{}'.format(self.id, module_id),
+            "GET", "courses/{}/modules/{}".format(self.id, module_id)
         )
         module_json = response.json()
-        module_json.update({'course_id': self.id})
+        module_json.update({"course_id": self.id})
 
         return Module(self._requester, module_json)
 
@@ -566,18 +542,18 @@ class Course(CanvasObject):
         """
         from canvasapi.module import Module
 
-        if isinstance(module, dict) and 'name' in module:
-            kwargs['module'] = module
+        if isinstance(module, dict) and "name" in module:
+            kwargs["module"] = module
         else:
             raise RequiredFieldMissing("Dictionary with key 'name' is required.")
 
         response = self._requester.request(
-            'POST',
-            'courses/{}/modules'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "courses/{}/modules".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         module_json = response.json()
-        module_json.update({'course_id': self.id})
+        module_json.update({"course_id": self.id})
 
         return Module(self._requester, module_json)
 
@@ -596,11 +572,10 @@ class Course(CanvasObject):
         tool_id = obj_or_id(tool, "tool", (ExternalTool,))
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/external_tools/{}'.format(self.id, tool_id),
+            "GET", "courses/{}/external_tools/{}".format(self.id, tool_id)
         )
         tool_json = response.json()
-        tool_json.update({'course_id': self.id})
+        tool_json.update({"course_id": self.id})
 
         return ExternalTool(self._requester, tool_json)
 
@@ -617,10 +592,10 @@ class Course(CanvasObject):
         return PaginatedList(
             ExternalTool,
             self._requester,
-            'GET',
-            'courses/{}/external_tools'.format(self.id),
-            {'course_id': self.id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/external_tools".format(self.id),
+            {"course_id": self.id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_sections(self, **kwargs):
@@ -638,9 +613,9 @@ class Course(CanvasObject):
         return PaginatedList(
             Section,
             self._requester,
-            'GET',
-            'courses/{}/sections'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/sections".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_section(self, section, **kwargs):
@@ -660,9 +635,9 @@ class Course(CanvasObject):
         section_id = obj_or_id(section, "section", (Section,))
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/sections/{}'.format(self.id, section_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/sections/{}".format(self.id, section_id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return Section(self._requester, response.json())
 
@@ -676,11 +651,10 @@ class Course(CanvasObject):
         :rtype: :class:`canvasapi.course.Course`
         """
         response = self._requester.request(
-            'GET',
-            'courses/{}/front_page'.format(self.id)
+            "GET", "courses/{}/front_page".format(self.id)
         )
         page_json = response.json()
-        page_json.update({'course_id': self.id})
+        page_json.update({"course_id": self.id})
 
         return Page(self._requester, page_json)
 
@@ -694,12 +668,12 @@ class Course(CanvasObject):
         :rtype: :class:`canvasapi.course.Course`
         """
         response = self._requester.request(
-            'PUT',
-            'courses/{}/front_page'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "courses/{}/front_page".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         page_json = response.json()
-        page_json.update({'course_id': self.id})
+        page_json.update({"course_id": self.id})
 
         return Page(self._requester, page_json)
 
@@ -716,10 +690,10 @@ class Course(CanvasObject):
         return PaginatedList(
             Page,
             self._requester,
-            'GET',
-            'courses/{}/pages'.format(self.id),
-            {'course_id': self.id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/pages".format(self.id),
+            {"course_id": self.id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def create_page(self, wiki_page, **kwargs):
@@ -735,19 +709,17 @@ class Course(CanvasObject):
         :rtype: :class:`canvasapi.course.Course`
         """
 
-        if isinstance(wiki_page, dict) and 'title' in wiki_page:
-            kwargs['wiki_page'] = wiki_page
+        if isinstance(wiki_page, dict) and "title" in wiki_page:
+            kwargs["wiki_page"] = wiki_page
         else:
             raise RequiredFieldMissing("Dictionary with key 'title' is required.")
 
         response = self._requester.request(
-            'POST',
-            'courses/{}/pages'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST", "courses/{}/pages".format(self.id), _kwargs=combine_kwargs(**kwargs)
         )
 
         page_json = response.json()
-        page_json.update({'course_id': self.id})
+        page_json.update({"course_id": self.id})
 
         return Page(self._requester, page_json)
 
@@ -765,11 +737,10 @@ class Course(CanvasObject):
         """
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/pages/{}'.format(self.id, url)
+            "GET", "courses/{}/pages/{}".format(self.id, url)
         )
         page_json = response.json()
-        page_json.update({'course_id': self.id})
+        page_json.update({"course_id": self.id})
 
         return Page(self._requester, page_json)
 
@@ -790,7 +761,7 @@ class Course(CanvasObject):
         warnings.warn(
             "`list_sections` is being deprecated and will be removed in a future version."
             " Use `get_sections` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
         return self.get_sections(**kwargs)
 
@@ -805,10 +776,11 @@ class Course(CanvasObject):
         """
 
         from canvasapi.section import Section
+
         response = self._requester.request(
-            'POST',
-            'courses/{}/sections'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "courses/{}/sections".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         return Section(self._requester, response.json())
@@ -830,7 +802,7 @@ class Course(CanvasObject):
         warnings.warn(
             "`list_groups` is being deprecated and will be removed in a future version."
             " Use `get_groups` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_groups(**kwargs)
@@ -846,12 +818,13 @@ class Course(CanvasObject):
             :class:`canvasapi.course.Course`
         """
         from canvasapi.group import Group
+
         return PaginatedList(
             Group,
             self._requester,
-            'GET',
-            'courses/{}/groups'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/groups".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def create_group_category(self, name, **kwargs):
@@ -868,10 +841,10 @@ class Course(CanvasObject):
         from canvasapi.group import GroupCategory
 
         response = self._requester.request(
-            'POST',
-            'courses/{}/group_categories'.format(self.id),
+            "POST",
+            "courses/{}/group_categories".format(self.id),
             name=name,
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         return GroupCategory(self._requester, response.json())
 
@@ -892,7 +865,7 @@ class Course(CanvasObject):
         warnings.warn(
             "`list_group_categories` is being deprecated and will be removed in a future version."
             " Use `get_group_categories` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_group_categories(**kwargs)
@@ -912,9 +885,9 @@ class Course(CanvasObject):
         return PaginatedList(
             GroupCategory,
             self._requester,
-            'GET',
-            'courses/{}/group_categories'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/group_categories".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_file(self, file, **kwargs):
@@ -934,9 +907,9 @@ class Course(CanvasObject):
         file_id = obj_or_id(file, "file", (File,))
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/files/{}'.format(self.id, file_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/files/{}".format(self.id, file_id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return File(self._requester, response.json())
 
@@ -955,12 +928,11 @@ class Course(CanvasObject):
         topic_id = obj_or_id(topic, "topic", (DiscussionTopic,))
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/discussion_topics/{}'.format(self.id, topic_id)
+            "GET", "courses/{}/discussion_topics/{}".format(self.id, topic_id)
         )
 
         response_json = response.json()
-        response_json.update({'course_id': self.id})
+        response_json.update({"course_id": self.id})
 
         return DiscussionTopic(self._requester, response_json)
 
@@ -979,8 +951,7 @@ class Course(CanvasObject):
         topic_id = obj_or_id(topic, "topic", (DiscussionTopic,))
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/discussion_topics/{}/view'.format(self.id, topic_id),
+            "GET", "courses/{}/discussion_topics/{}/view".format(self.id, topic_id)
         )
         return response.json()
 
@@ -997,10 +968,10 @@ class Course(CanvasObject):
         return PaginatedList(
             DiscussionTopic,
             self._requester,
-            'GET',
-            'courses/{}/discussion_topics'.format(self.id),
-            {'course_id': self.id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/discussion_topics".format(self.id),
+            {"course_id": self.id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_assignment_group(self, assignment_group, **kwargs):
@@ -1017,15 +988,17 @@ class Course(CanvasObject):
         """
         from canvasapi.assignment import AssignmentGroup
 
-        assignment_group_id = obj_or_id(assignment_group, "assignment_group", (AssignmentGroup,))
+        assignment_group_id = obj_or_id(
+            assignment_group, "assignment_group", (AssignmentGroup,)
+        )
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/assignment_groups/{}'.format(self.id, assignment_group_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/assignment_groups/{}".format(self.id, assignment_group_id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         response_json = response.json()
-        response_json.update({'course_id': self.id})
+        response_json.update({"course_id": self.id})
 
         return AssignmentGroup(self._requester, response_json)
 
@@ -1046,7 +1019,7 @@ class Course(CanvasObject):
         warnings.warn(
             "`list_assignment_groups` is being deprecated and will be removed "
             "in a future version. Use `get_assignment_groups` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_assignment_groups(**kwargs)
@@ -1066,10 +1039,10 @@ class Course(CanvasObject):
         return PaginatedList(
             AssignmentGroup,
             self._requester,
-            'GET',
-            'courses/{}/assignment_groups'.format(self.id),
-            {'course_id': self.id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/assignment_groups".format(self.id),
+            {"course_id": self.id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def create_discussion_topic(self, **kwargs):
@@ -1082,13 +1055,13 @@ class Course(CanvasObject):
         :rtype: :class:`canvasapi.discussion_topic.DiscussionTopic`
         """
         response = self._requester.request(
-            'POST',
-            'courses/{}/discussion_topics'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "courses/{}/discussion_topics".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         response_json = response.json()
-        response_json.update({'course_id': self.id})
+        response_json.update({"course_id": self.id})
 
         return DiscussionTopic(self._requester, response_json)
 
@@ -1116,12 +1089,10 @@ class Course(CanvasObject):
             raise ValueError("Param `order` must be a list, tuple, or string.")
 
         response = self._requester.request(
-            'POST',
-            'courses/{}/discussion_topics/reorder'.format(self.id),
-            order=order
+            "POST", "courses/{}/discussion_topics/reorder".format(self.id), order=order
         )
 
-        return response.json().get('reorder')
+        return response.json().get("reorder")
 
     def create_assignment_group(self, **kwargs):
         """
@@ -1135,16 +1106,18 @@ class Course(CanvasObject):
         from canvasapi.assignment import AssignmentGroup
 
         response = self._requester.request(
-            'POST',
-            'courses/{}/assignment_groups'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "courses/{}/assignment_groups".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         response_json = response.json()
-        response_json.update({'course_id': self.id})
+        response_json.update({"course_id": self.id})
 
         return AssignmentGroup(self._requester, response_json)
 
-    def create_external_tool(self, name, privacy_level, consumer_key, shared_secret, **kwargs):
+    def create_external_tool(
+        self, name, privacy_level, consumer_key, shared_secret, **kwargs
+    ):
         """
         Create an external tool in the current course.
 
@@ -1165,16 +1138,16 @@ class Course(CanvasObject):
         from canvasapi.external_tool import ExternalTool
 
         response = self._requester.request(
-            'POST',
-            'courses/{}/external_tools'.format(self.id),
+            "POST",
+            "courses/{}/external_tools".format(self.id),
             name=name,
             privacy_level=privacy_level,
             consumer_key=consumer_key,
             shared_secret=shared_secret,
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         response_json = response.json()
-        response_json.update({'course_id': self.id})
+        response_json.update({"course_id": self.id})
 
         return ExternalTool(self._requester, response_json)
 
@@ -1189,8 +1162,7 @@ class Course(CanvasObject):
         """
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/analytics/activity'.format(self.id)
+            "GET", "courses/{}/analytics/activity".format(self.id)
         )
 
         return response.json()
@@ -1206,9 +1178,9 @@ class Course(CanvasObject):
         """
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/analytics/assignments'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/analytics/assignments".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         return response.json()
@@ -1224,9 +1196,9 @@ class Course(CanvasObject):
         """
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/analytics/student_summaries'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/analytics/student_summaries".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         return response.json()
@@ -1248,8 +1220,7 @@ class Course(CanvasObject):
         user_id = obj_or_id(user, "user", (User,))
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/analytics/users/{}/activity'.format(self.id, user_id)
+            "GET", "courses/{}/analytics/users/{}/activity".format(self.id, user_id)
         )
 
         return response.json()
@@ -1271,8 +1242,7 @@ class Course(CanvasObject):
         user_id = obj_or_id(user, "user", (User,))
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/analytics/users/{}/assignments'.format(self.id, user_id)
+            "GET", "courses/{}/analytics/users/{}/assignments".format(self.id, user_id)
         )
 
         return response.json()
@@ -1294,8 +1264,8 @@ class Course(CanvasObject):
         user_id = obj_or_id(user, "user", (User,))
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/analytics/users/{}/communication'.format(self.id, user_id)
+            "GET",
+            "courses/{}/analytics/users/{}/communication".format(self.id, user_id),
         )
 
         return response.json()
@@ -1322,16 +1292,15 @@ class Course(CanvasObject):
         from canvasapi.assignment import Assignment
 
         warnings.warn(
-            'Course.submit_assignment() is deprecated and will be removed in '
-            'the future. Use Assignment.submit() instead.',
-            DeprecationWarning
+            "Course.submit_assignment() is deprecated and will be removed in "
+            "the future. Use Assignment.submit() instead.",
+            DeprecationWarning,
         )
 
         assignment_id = obj_or_id(assignment, "assignment", (Assignment,))
 
         assignment = Assignment(
-            self._requester,
-            {'course_id': self.id, 'id': assignment_id}
+            self._requester, {"course_id": self.id, "id": assignment_id}
         )
 
         return assignment.submit(submission, **kwargs)
@@ -1356,16 +1325,15 @@ class Course(CanvasObject):
         from canvasapi.assignment import Assignment
 
         warnings.warn(
-            'Course.list_submissions() is deprecated and will be removed in '
-            'the future. Use Assignment.get_submissions() instead.',
-            DeprecationWarning
+            "Course.list_submissions() is deprecated and will be removed in "
+            "the future. Use Assignment.get_submissions() instead.",
+            DeprecationWarning,
         )
 
         assignment_id = obj_or_id(assignment, "assignment", (Assignment,))
 
         assignment = Assignment(
-            self._requester,
-            {'course_id': self.id, 'id': assignment_id}
+            self._requester, {"course_id": self.id, "id": assignment_id}
         )
 
         return assignment.get_submissions(**kwargs)
@@ -1389,7 +1357,7 @@ class Course(CanvasObject):
             "`list_multiple_submissions`"
             " is being deprecated and will be removed in a future version."
             " Use `get_multiple_submissions` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_multiple_submissions(**kwargs)
@@ -1405,17 +1373,19 @@ class Course(CanvasObject):
         :rtype: :class:`canvasapi.paginated_list.PaginatedList` of
             :class:`canvasapi.submission.Submission`
         """
-        if 'grouped' in kwargs:
-            warnings.warn('The `grouped` parameter must be empty. Removing kwarg `grouped`.')
-            del kwargs['grouped']
+        if "grouped" in kwargs:
+            warnings.warn(
+                "The `grouped` parameter must be empty. Removing kwarg `grouped`."
+            )
+            del kwargs["grouped"]
 
         return PaginatedList(
             Submission,
             self._requester,
-            'GET',
-            'courses/{}/students/submissions'.format(self.id),
-            {'course_id': self.id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/students/submissions".format(self.id),
+            {"course_id": self.id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_submission(self, assignment, user, **kwargs):
@@ -1439,16 +1409,15 @@ class Course(CanvasObject):
         from canvasapi.assignment import Assignment
 
         warnings.warn(
-            '`Course.get_submission()` is deprecated and will be removed in a '
-            'future version. Use `Assignment.get_submission()` instead',
-            DeprecationWarning
+            "`Course.get_submission()` is deprecated and will be removed in a "
+            "future version. Use `Assignment.get_submission()` instead",
+            DeprecationWarning,
         )
 
-        assignment_id = obj_or_id(assignment, 'assignment', (Assignment,))
+        assignment_id = obj_or_id(assignment, "assignment", (Assignment,))
 
         assignment = Assignment(
-            self._requester,
-            {'course_id': self.id, 'id': assignment_id}
+            self._requester, {"course_id": self.id, "id": assignment_id}
         )
 
         return assignment.get_submission(user, **kwargs)
@@ -1475,19 +1444,18 @@ class Course(CanvasObject):
         from canvasapi.user import User
 
         warnings.warn(
-            '`Course.update_submission()` is deprecated and will be removed in a '
-            'future version. Use `Submission.edit()` instead',
-            DeprecationWarning
+            "`Course.update_submission()` is deprecated and will be removed in a "
+            "future version. Use `Submission.edit()` instead",
+            DeprecationWarning,
         )
 
         assignment_id = obj_or_id(assignment, "assignment", (Assignment,))
         user_id = obj_or_id(user, "user", (User,))
 
-        submission = Submission(self._requester, {
-            'course_id': self.id,
-            'assignment_id': assignment_id,
-            'user_id': user_id,
-        })
+        submission = Submission(
+            self._requester,
+            {"course_id": self.id, "assignment_id": assignment_id, "user_id": user_id},
+        )
 
         return submission.edit(**kwargs)
 
@@ -1511,16 +1479,15 @@ class Course(CanvasObject):
         from canvasapi.assignment import Assignment
 
         warnings.warn(
-            '`Course.list_gradeable_students()` is deprecated and will be '
-            'removed in a future version. Use '
-            '`Assignment.get_gradeable_students()` instead.',
-            DeprecationWarning
+            "`Course.list_gradeable_students()` is deprecated and will be "
+            "removed in a future version. Use "
+            "`Assignment.get_gradeable_students()` instead.",
+            DeprecationWarning,
         )
 
         assignment_id = obj_or_id(assignment, "assignment", (Assignment,))
         assignment = Assignment(
-            self._requester,
-            {'id': assignment_id, 'course_id': self.id}
+            self._requester, {"id": assignment_id, "course_id": self.id}
         )
 
         return assignment.get_gradeable_students(**kwargs)
@@ -1548,19 +1515,18 @@ class Course(CanvasObject):
         from canvasapi.user import User
 
         warnings.warn(
-            '`Course.mark_submission_as_read()` is deprecated and will be '
-            'removed in a future version. Use `Submission.mark_read()` instead.',
-            DeprecationWarning
+            "`Course.mark_submission_as_read()` is deprecated and will be "
+            "removed in a future version. Use `Submission.mark_read()` instead.",
+            DeprecationWarning,
         )
 
         assignment_id = obj_or_id(assignment, "assignment", (Assignment,))
         user_id = obj_or_id(user, "user", (User,))
 
-        submission = Submission(self._requester, {
-            'course_id': self.id,
-            'assignment_id': assignment_id,
-            'user_id': user_id
-        })
+        submission = Submission(
+            self._requester,
+            {"course_id": self.id, "assignment_id": assignment_id, "user_id": user_id},
+        )
         return submission.mark_read(**kwargs)
 
     def mark_submission_as_unread(self, assignment, user, **kwargs):
@@ -1586,19 +1552,18 @@ class Course(CanvasObject):
         from canvasapi.user import User
 
         warnings.warn(
-            '`Course.mark_submission_as_unread()` is deprecated and will be '
-            'removed in a future version. Use `Submission.mark_unread()` instead.',
-            DeprecationWarning
+            "`Course.mark_submission_as_unread()` is deprecated and will be "
+            "removed in a future version. Use `Submission.mark_unread()` instead.",
+            DeprecationWarning,
         )
 
         assignment_id = obj_or_id(assignment, "assignment", (Assignment,))
         user_id = obj_or_id(user, "user", (User,))
 
-        submission = Submission(self._requester, {
-            'course_id': self.id,
-            'assignment_id': assignment_id,
-            'user_id': user_id
-        })
+        submission = Submission(
+            self._requester,
+            {"course_id": self.id, "assignment_id": assignment_id, "user_id": user_id},
+        )
         return submission.mark_unread(**kwargs)
 
     def list_external_feeds(self, **kwargs):
@@ -1618,7 +1583,7 @@ class Course(CanvasObject):
         warnings.warn(
             "`list_external_feeds` is being deprecated and will be removed in "
             "a future version. Use `get_external_feeds` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_external_feeds(**kwargs)
@@ -1634,12 +1599,13 @@ class Course(CanvasObject):
             :class:`canvasapi.external_feed.ExternalFeed`
         """
         from canvasapi.external_feed import ExternalFeed
+
         return PaginatedList(
             ExternalFeed,
             self._requester,
-            'GET',
-            'courses/{}/external_feeds'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/external_feeds".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def create_external_feed(self, url, **kwargs):
@@ -1654,11 +1620,12 @@ class Course(CanvasObject):
         :rtype: :class:`canvasapi.external_feed.ExternalFeed`
         """
         from canvasapi.external_feed import ExternalFeed
+
         response = self._requester.request(
-            'POST',
-            'courses/{}/external_feeds'.format(self.id),
+            "POST",
+            "courses/{}/external_feeds".format(self.id),
             url=url,
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         return ExternalFeed(self._requester, response.json())
 
@@ -1679,8 +1646,7 @@ class Course(CanvasObject):
         feed_id = obj_or_id(feed, "feed", (ExternalFeed,))
 
         response = self._requester.request(
-            'DELETE',
-            'courses/{}/external_feeds/{}'.format(self.id, feed_id)
+            "DELETE", "courses/{}/external_feeds/{}".format(self.id, feed_id)
         )
         return ExternalFeed(self._requester, response.json())
 
@@ -1701,7 +1667,7 @@ class Course(CanvasObject):
         warnings.warn(
             "`list_files` is being deprecated and will be removed in a future "
             "version. Use `get_files` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_files(**kwargs)
@@ -1721,9 +1687,9 @@ class Course(CanvasObject):
         return PaginatedList(
             File,
             self._requester,
-            'GET',
-            'courses/{}/files'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/files".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_folder(self, folder):
@@ -1741,8 +1707,7 @@ class Course(CanvasObject):
         folder_id = obj_or_id(folder, "folder", (Folder,))
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/folders/{}'.format(self.id, folder_id)
+            "GET", "courses/{}/folders/{}".format(self.id, folder_id)
         )
         return Folder(self._requester, response.json())
 
@@ -1764,7 +1729,7 @@ class Course(CanvasObject):
         warnings.warn(
             "`list_folders` is being deprecated and will be removed in a "
             "future version. Use `get_folders` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_folders(**kwargs)
@@ -1783,9 +1748,9 @@ class Course(CanvasObject):
         return PaginatedList(
             Folder,
             self._requester,
-            'GET',
-            'courses/{}/folders'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/folders".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def create_folder(self, name, **kwargs):
@@ -1800,10 +1765,10 @@ class Course(CanvasObject):
         :rtype: :class:`canvasapi.folder.Folder`
         """
         response = self._requester.request(
-            'POST',
-            'courses/{}/folders'.format(self.id),
+            "POST",
+            "courses/{}/folders".format(self.id),
             name=name,
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         return Folder(self._requester, response.json())
 
@@ -1825,7 +1790,7 @@ class Course(CanvasObject):
         warnings.warn(
             "`list_tabs` is being deprecated and will be removed in a future "
             "version. Use `get_tabs` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_tabs(**kwargs)
@@ -1844,10 +1809,10 @@ class Course(CanvasObject):
         return PaginatedList(
             Tab,
             self._requester,
-            'GET',
-            'courses/{}/tabs'.format(self.id),
-            {'course_id': self.id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/tabs".format(self.id),
+            {"course_id": self.id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def update_tab(self, tab_id, **kwargs):
@@ -1869,13 +1834,10 @@ class Course(CanvasObject):
         warnings.warn(
             "`Course.update_tab()` is being deprecated and will be removed in "
             "a future version. Use `Tab.update()` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
-        tab = Tab(self._requester, {
-            'course_id': self.id,
-            'id': tab_id
-        })
+        tab = Tab(self._requester, {"course_id": self.id, "id": tab_id})
         return tab.update(**kwargs)
 
     def get_rubric(self, rubric_id, **kwargs):
@@ -1890,9 +1852,9 @@ class Course(CanvasObject):
         :rtype: :class:`canvasapi.rubric.Rubric`
         """
         response = self._requester.request(
-            'GET',
-            'courses/%s/rubrics/%s' % (self.id, rubric_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/%s/rubrics/%s" % (self.id, rubric_id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         return Rubric(self._requester, response.json())
@@ -1914,7 +1876,7 @@ class Course(CanvasObject):
         warnings.warn(
             "`list_rubrics` is being deprecated and will be removed in a "
             "future version. Use `get_rubrics` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_rubrics(**kwargs)
@@ -1932,9 +1894,9 @@ class Course(CanvasObject):
         return PaginatedList(
             Rubric,
             self._requester,
-            'GET',
-            'courses/%s/rubrics' % (self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/%s/rubrics" % (self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_root_outcome_group(self):
@@ -1950,8 +1912,7 @@ class Course(CanvasObject):
         from canvasapi.outcome import OutcomeGroup
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/root_outcome_group'.format(self.id)
+            "GET", "courses/{}/root_outcome_group".format(self.id)
         )
         return OutcomeGroup(self._requester, response.json())
 
@@ -1973,8 +1934,7 @@ class Course(CanvasObject):
         outcome_group_id = obj_or_id(group, "group", (OutcomeGroup,))
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/outcome_groups/{}'.format(self.id, outcome_group_id)
+            "GET", "courses/{}/outcome_groups/{}".format(self.id, outcome_group_id)
         )
 
         return OutcomeGroup(self._requester, response.json())
@@ -1995,8 +1955,8 @@ class Course(CanvasObject):
         return PaginatedList(
             OutcomeGroup,
             self._requester,
-            'GET',
-            'courses/{}/outcome_groups'.format(self.id)
+            "GET",
+            "courses/{}/outcome_groups".format(self.id),
         )
 
     def get_all_outcome_links_in_context(self):
@@ -2015,8 +1975,8 @@ class Course(CanvasObject):
         return PaginatedList(
             OutcomeLink,
             self._requester,
-            'GET',
-            'courses/{}/outcome_group_links'.format(self.id)
+            "GET",
+            "courses/{}/outcome_group_links".format(self.id),
         )
 
     def get_outcome_results(self, **kwargs):
@@ -2030,9 +1990,9 @@ class Course(CanvasObject):
         :rtype: dict
         """
         response = self._requester.request(
-            'GET',
-            'courses/{}/outcome_results'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/outcome_results".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         return response.json()
@@ -2048,9 +2008,9 @@ class Course(CanvasObject):
         :rtype: dict
         """
         response = self._requester.request(
-            'GET',
-            'courses/{}/outcome_rollups'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/outcome_rollups".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         return response.json()
@@ -2075,14 +2035,16 @@ class Course(CanvasObject):
             if not isinstance(entry, dict):
                 raise ValueError("grading_scheme_entry must consist of dictionaries.")
             if "name" not in entry or "value" not in entry:
-                raise ValueError("Dictionaries with keys 'name' and 'value' are required.")
+                raise ValueError(
+                    "Dictionaries with keys 'name' and 'value' are required."
+                )
         kwargs["grading_scheme_entry"] = grading_scheme_entry
 
         response = self._requester.request(
-            'POST',
-            'courses/%s/grading_standards' % (self.id),
+            "POST",
+            "courses/%s/grading_standards" % (self.id),
             title=title,
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         return GradingStandard(self._requester, response.json())
 
@@ -2099,9 +2061,9 @@ class Course(CanvasObject):
         return PaginatedList(
             GradingStandard,
             self._requester,
-            'GET',
-            'courses/%s/grading_standards' % (self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/%s/grading_standards" % (self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_single_grading_standard(self, grading_standard_id, **kwargs):
@@ -2117,9 +2079,9 @@ class Course(CanvasObject):
         """
 
         response = self._requester.request(
-            'GET',
-            'courses/%s/grading_standards/%d' % (self.id, grading_standard_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/%s/grading_standards/%d" % (self.id, grading_standard_id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return GradingStandard(self._requester, response.json())
 
@@ -2138,20 +2100,20 @@ class Course(CanvasObject):
         from canvasapi.content_migration import ContentMigration, Migrator
 
         if isinstance(migration_type, Migrator):
-            kwargs['migration_type'] = migration_type.type
+            kwargs["migration_type"] = migration_type.type
         elif isinstance(migration_type, string_types):
-            kwargs['migration_type'] = migration_type
+            kwargs["migration_type"] = migration_type
         else:
-            raise TypeError('Parameter migration_type must be of type Migrator or str')
+            raise TypeError("Parameter migration_type must be of type Migrator or str")
 
         response = self._requester.request(
-            'POST',
-            'courses/{}/content_migrations'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "courses/{}/content_migrations".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         response_json = response.json()
-        response_json.update({'course_id': self.id})
+        response_json.update({"course_id": self.id})
 
         return ContentMigration(self._requester, response_json)
 
@@ -2169,16 +2131,18 @@ class Course(CanvasObject):
         """
         from canvasapi.content_migration import ContentMigration
 
-        migration_id = obj_or_id(content_migration, "content_migration", (ContentMigration,))
+        migration_id = obj_or_id(
+            content_migration, "content_migration", (ContentMigration,)
+        )
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/content_migrations/{}'.format(self.id, migration_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/content_migrations/{}".format(self.id, migration_id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         response_json = response.json()
-        response_json.update({'course_id': self.id})
+        response_json.update({"course_id": self.id})
 
         return ContentMigration(self._requester, response_json)
 
@@ -2197,10 +2161,10 @@ class Course(CanvasObject):
         return PaginatedList(
             ContentMigration,
             self._requester,
-            'GET',
-            'courses/{}/content_migrations'.format(self.id),
-            {'course_id': self.id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/content_migrations".format(self.id),
+            {"course_id": self.id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_migration_systems(self, **kwargs):
@@ -2218,9 +2182,9 @@ class Course(CanvasObject):
         return PaginatedList(
             Migrator,
             self._requester,
-            'GET',
-            'courses/{}/content_migrations/migrators'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/content_migrations/migrators".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def set_quiz_extensions(self, quiz_extensions, **kwargs):
@@ -2255,25 +2219,27 @@ class Course(CanvasObject):
         """
 
         if not isinstance(quiz_extensions, list) or not quiz_extensions:
-            raise ValueError('Param `quiz_extensions` must be a non-empty list.')
+            raise ValueError("Param `quiz_extensions` must be a non-empty list.")
 
         if any(not isinstance(extension, dict) for extension in quiz_extensions):
-            raise ValueError('Param `quiz_extensions` must only contain dictionaries')
+            raise ValueError("Param `quiz_extensions` must only contain dictionaries")
 
-        if any('user_id' not in extension for extension in quiz_extensions):
+        if any("user_id" not in extension for extension in quiz_extensions):
             raise RequiredFieldMissing(
-                'Dictionaries in `quiz_extensions` must contain key `user_id`'
+                "Dictionaries in `quiz_extensions` must contain key `user_id`"
             )
 
-        kwargs['quiz_extensions'] = quiz_extensions
+        kwargs["quiz_extensions"] = quiz_extensions
 
         response = self._requester.request(
-            'POST',
-            'courses/{}/quiz_extensions'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "courses/{}/quiz_extensions".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
-        extension_list = response.json()['quiz_extensions']
-        return [QuizExtension(self._requester, extension) for extension in extension_list]
+        extension_list = response.json()["quiz_extensions"]
+        return [
+            QuizExtension(self._requester, extension) for extension in extension_list
+        ]
 
     def submissions_bulk_update(self, **kwargs):
         """
@@ -2286,18 +2252,15 @@ class Course(CanvasObject):
         :rtype: :class:`canvasapi.progress.Progress`
         """
         response = self._requester.request(
-            'POST',
-            'courses/{}/submissions/update_grades'.format(
-                self.id
-            ),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "courses/{}/submissions/update_grades".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return Progress(self._requester, response.json())
 
 
 @python_2_unicode_compatible
 class CourseNickname(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.nickname, self.course_id)
 
@@ -2312,7 +2275,6 @@ class CourseNickname(CanvasObject):
         :rtype: :class:`canvasapi.course.CourseNickname`
         """
         response = self._requester.request(
-            'DELETE',
-            'users/self/course_nicknames/{}'.format(self.course_id)
+            "DELETE", "users/self/course_nicknames/{}".format(self.course_id)
         )
         return CourseNickname(self._requester, response.json())

--- a/canvasapi/current_user.py
+++ b/canvasapi/current_user.py
@@ -15,10 +15,7 @@ class CurrentUser(User):
     def __init__(self, _requester):
         self._requester = _requester
 
-        response = self._requester.request(
-            'GET',
-            'users/self'
-        )
+        response = self._requester.request("GET", "users/self")
 
         super(CurrentUser, self).__init__(self._requester, response.json())
 
@@ -41,7 +38,7 @@ class CurrentUser(User):
         warnings.warn(
             "`list_groups` is being deprecated and will be removed in a "
             "future version. Use `get_groups` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_groups(**kwargs)
@@ -60,9 +57,9 @@ class CurrentUser(User):
         return PaginatedList(
             Group,
             self._requester,
-            'GET',
-            'users/self/groups',
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "users/self/groups",
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def list_bookmarks(self, **kwargs):
@@ -82,7 +79,7 @@ class CurrentUser(User):
         warnings.warn(
             "`list_bookmarks` is being deprecated and will be removed in a "
             "future version. Use `get_bookmarks` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_bookmarks(**kwargs)
@@ -97,12 +94,7 @@ class CurrentUser(User):
         :rtype: :class:`canvasapi.paginated_list.PaginatedList` of
             :class:`canvasapi.bookmark.Bookmark`
         """
-        return PaginatedList(
-            Bookmark,
-            self._requester,
-            'GET',
-            'users/self/bookmarks'
-        )
+        return PaginatedList(Bookmark, self._requester, "GET", "users/self/bookmarks")
 
     def create_bookmark(self, name, url, **kwargs):
         """
@@ -120,11 +112,11 @@ class CurrentUser(User):
         from canvasapi.bookmark import Bookmark
 
         response = self._requester.request(
-            'POST',
-            'users/self/bookmarks',
+            "POST",
+            "users/self/bookmarks",
             name=name,
             url=url,
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         return Bookmark(self._requester, response.json())
@@ -146,7 +138,6 @@ class CurrentUser(User):
         bookmark_id = obj_or_id(bookmark, "bookmark", (Bookmark,))
 
         response = self._requester.request(
-            'GET',
-            'users/self/bookmarks/{}'.format(bookmark_id)
+            "GET", "users/self/bookmarks/{}".format(bookmark_id)
         )
         return Bookmark(self._requester, response.json())

--- a/canvasapi/discussion_topic.py
+++ b/canvasapi/discussion_topic.py
@@ -21,9 +21,9 @@ class DiscussionTopic(CanvasObject):
 
         :rtype: int
         """
-        if hasattr(self, 'course_id'):
+        if hasattr(self, "course_id"):
             return self.course_id
-        elif hasattr(self, 'group_id'):
+        elif hasattr(self, "group_id"):
             return self.group_id
         else:
             raise ValueError("Discussion Topic does not have a course_id or group_id")
@@ -35,10 +35,10 @@ class DiscussionTopic(CanvasObject):
 
         :rtype: str
         """
-        if hasattr(self, 'course_id'):
-            return 'course'
-        elif hasattr(self, 'group_id'):
-            return 'group'
+        if hasattr(self, "course_id"):
+            return "course"
+        elif hasattr(self, "group_id"):
+            return "group"
         else:
             raise ValueError("Discussion Topic does not have a course_id or group_id")
 
@@ -52,13 +52,12 @@ class DiscussionTopic(CanvasObject):
         from canvasapi.course import Course
 
         response = self._requester.request(
-            'GET',
-            '{}s/{}'.format(self._parent_type, self._parent_id)
+            "GET", "{}s/{}".format(self._parent_type, self._parent_id)
         )
 
-        if self._parent_type == 'group':
+        if self._parent_type == "group":
             return Group(self._requester, response.json())
-        elif self._parent_type == 'course':
+        elif self._parent_type == "course":
             return Course(self._requester, response.json())
 
     def delete(self):
@@ -75,14 +74,12 @@ class DiscussionTopic(CanvasObject):
         :rtype: bool
         """
         response = self._requester.request(
-            'DELETE',
-            '{}s/{}/discussion_topics/{}'.format(
-                self._parent_type,
-                self._parent_id,
-                self.id
-            )
+            "DELETE",
+            "{}s/{}/discussion_topics/{}".format(
+                self._parent_type, self._parent_id, self.id
+            ),
         )
-        return 'deleted_at' in response.json()
+        return "deleted_at" in response.json()
 
     def update(self, **kwargs):
         """
@@ -97,13 +94,11 @@ class DiscussionTopic(CanvasObject):
         :rtype: :class:`canvasapi.discussion_topic.DiscussionTopic`
         """
         response = self._requester.request(
-            'PUT',
-            '{}s/{}/discussion_topics/{}'.format(
-                self._parent_type,
-                self._parent_id,
-                self.id
+            "PUT",
+            "{}s/{}/discussion_topics/{}".format(
+                self._parent_type, self._parent_id, self.id
             ),
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         return DiscussionTopic(self._requester, response.json())
 
@@ -120,19 +115,19 @@ class DiscussionTopic(CanvasObject):
         :rtype: :class:`canvasapi.discussion_topic.DiscussionEntry`
         """
         response = self._requester.request(
-            'POST',
-            '{}s/{}/discussion_topics/{}/entries'.format(
-                self._parent_type,
-                self._parent_id,
-                self.id
+            "POST",
+            "{}s/{}/discussion_topics/{}/entries".format(
+                self._parent_type, self._parent_id, self.id
             ),
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         response_json = response.json()
-        response_json.update({
-            'discussion_id': self.id,
-            '{}_id'.format(self._parent_type): self._parent_id
-        })
+        response_json.update(
+            {
+                "discussion_id": self.id,
+                "{}_id".format(self._parent_type): self._parent_id,
+            }
+        )
         return DiscussionEntry(self._requester, response_json)
 
     def list_topic_entries(self, **kwargs):
@@ -155,7 +150,7 @@ class DiscussionTopic(CanvasObject):
         warnings.warn(
             "`list_topic_entries` is being deprecated and will be removed in "
             "a future version. Use `get_topic_entries` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_topic_entries(**kwargs)
@@ -176,17 +171,15 @@ class DiscussionTopic(CanvasObject):
         return PaginatedList(
             DiscussionEntry,
             self._requester,
-            'GET',
-            '{}s/{}/discussion_topics/{}/entries'.format(
-                self._parent_type,
-                self._parent_id,
-                self.id
+            "GET",
+            "{}s/{}/discussion_topics/{}/entries".format(
+                self._parent_type, self._parent_id, self.id
             ),
             {
-                'discussion_id': self.id,
-                '{}_id'.format(self._parent_type): self._parent_id
+                "discussion_id": self.id,
+                "{}_id".format(self._parent_type): self._parent_id,
             },
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def list_entries(self, ids, **kwargs):
@@ -213,7 +206,7 @@ class DiscussionTopic(CanvasObject):
         warnings.warn(
             "`list_entries` is being deprecated and will be removed in a "
             "future version. Use `get_entries` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_entries(ids, **kwargs)
@@ -236,21 +229,19 @@ class DiscussionTopic(CanvasObject):
             :class:`canvasapi.discussion_topic.DiscussionEntry`
         """
 
-        entry_ids = [obj_or_id(item, "ids", (DiscussionEntry, )) for item in ids]
+        entry_ids = [obj_or_id(item, "ids", (DiscussionEntry,)) for item in ids]
 
         kwargs.update(ids=entry_ids)
         return PaginatedList(
             DiscussionEntry,
             self._requester,
-            'GET',
-            '{}s/{}/discussion_topics/{}/entry_list'.format(
-                self._parent_type,
-                self._parent_id,
-                self.id
+            "GET",
+            "{}s/{}/discussion_topics/{}/entry_list".format(
+                self._parent_type, self._parent_id, self.id
             ),
             {
-                'discussion_id': self.id,
-                '{}_id'.format(self._parent_type): self._parent_id
+                "discussion_id": self.id,
+                "{}_id".format(self._parent_type): self._parent_id,
             },
             _kwargs=combine_kwargs(**kwargs),
         )
@@ -268,12 +259,10 @@ class DiscussionTopic(CanvasObject):
         :rtype: bool
         """
         response = self._requester.request(
-            'PUT',
-            '{}s/{}/discussion_topics/{}/read'.format(
-                self._parent_type,
-                self._parent_id,
-                self.id
-            )
+            "PUT",
+            "{}s/{}/discussion_topics/{}/read".format(
+                self._parent_type, self._parent_id, self.id
+            ),
         )
         return response.status_code == 204
 
@@ -290,12 +279,10 @@ class DiscussionTopic(CanvasObject):
         :rtype: bool
         """
         response = self._requester.request(
-            'DELETE',
-            '{}s/{}/discussion_topics/{}/read'.format(
-                self._parent_type,
-                self._parent_id,
-                self.id
-            )
+            "DELETE",
+            "{}s/{}/discussion_topics/{}/read".format(
+                self._parent_type, self._parent_id, self.id
+            ),
         )
         return response.status_code == 204
 
@@ -312,13 +299,11 @@ class DiscussionTopic(CanvasObject):
         :rtype: bool
         """
         response = self._requester.request(
-            'PUT',
-            '{}s/{}/discussion_topics/{}/read_all'.format(
-                self._parent_type,
-                self._parent_id,
-                self.id
+            "PUT",
+            "{}s/{}/discussion_topics/{}/read_all".format(
+                self._parent_type, self._parent_id, self.id
             ),
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         return response.status_code == 204
 
@@ -335,13 +320,11 @@ class DiscussionTopic(CanvasObject):
         :rtype: bool
         """
         response = self._requester.request(
-            'DELETE',
-            '{}s/{}/discussion_topics/{}/read_all'.format(
-                self._parent_type,
-                self._parent_id,
-                self.id
+            "DELETE",
+            "{}s/{}/discussion_topics/{}/read_all".format(
+                self._parent_type, self._parent_id, self.id
             ),
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         return response.status_code == 204
 
@@ -358,12 +341,10 @@ class DiscussionTopic(CanvasObject):
         :rtype: bool
         """
         response = self._requester.request(
-            'PUT',
-            '{}s/{}/discussion_topics/{}/subscribed'.format(
-                self._parent_type,
-                self._parent_id,
-                self.id
-            )
+            "PUT",
+            "{}s/{}/discussion_topics/{}/subscribed".format(
+                self._parent_type, self._parent_id, self.id
+            ),
         )
         return response.status_code == 204
 
@@ -380,12 +361,10 @@ class DiscussionTopic(CanvasObject):
         :rtype: bool
         """
         response = self._requester.request(
-            'DELETE',
-            '{}s/{}/discussion_topics/{}/subscribed'.format(
-                self._parent_type,
-                self._parent_id,
-                self.id
-            )
+            "DELETE",
+            "{}s/{}/discussion_topics/{}/subscribed".format(
+                self._parent_type, self._parent_id, self.id
+            ),
         )
         return response.status_code == 204
 
@@ -402,9 +381,9 @@ class DiscussionEntry(CanvasObject):
 
         :rtype: int
         """
-        if hasattr(self, 'course_id'):
+        if hasattr(self, "course_id"):
             return self.course_id
-        elif hasattr(self, 'group_id'):
+        elif hasattr(self, "group_id"):
             return self.group_id
         else:
             raise ValueError("Discussion Topic does not have a course_id or group_id")
@@ -416,10 +395,10 @@ class DiscussionEntry(CanvasObject):
 
         :rtype: str
         """
-        if hasattr(self, 'course_id'):
-            return 'course'
-        elif hasattr(self, 'group_id'):
-            return 'group'
+        if hasattr(self, "course_id"):
+            return "course"
+        elif hasattr(self, "group_id"):
+            return "group"
         else:
             raise ValueError("Discussion Topic does not have a course_id or group_id")
 
@@ -431,17 +410,17 @@ class DiscussionEntry(CanvasObject):
         """
 
         response = self._requester.request(
-            'GET',
-            '{}s/{}/discussion_topics/{}'.format(
+            "GET",
+            "{}s/{}/discussion_topics/{}".format(
                 self._discussion_parent_type,
                 self._discussion_parent_id,
-                self.discussion_id
-            )
+                self.discussion_id,
+            ),
         )
 
         response_json = response.json()
         response_json.update(
-            {'{}_id'.format(self._discussion_parent_type): self._discussion_parent_id}
+            {"{}_id".format(self._discussion_parent_type): self._discussion_parent_id}
         )
 
         return DiscussionTopic(self._requester, response.json())
@@ -459,20 +438,20 @@ class DiscussionEntry(CanvasObject):
         :rtype: bool
         """
         response = self._requester.request(
-            'PUT',
-            '{}s/{}/discussion_topics/{}/entries/{}'.format(
+            "PUT",
+            "{}s/{}/discussion_topics/{}/entries/{}".format(
                 self._discussion_parent_type,
                 self._discussion_parent_id,
                 self.discussion_id,
-                self.id
+                self.id,
             ),
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
 
-        if response.json().get('updated_at'):
+        if response.json().get("updated_at"):
             super(DiscussionEntry, self).set_attributes(response.json())
 
-        return 'updated_at' in response.json()
+        return "updated_at" in response.json()
 
     def delete(self, **kwargs):
         """
@@ -487,16 +466,16 @@ class DiscussionEntry(CanvasObject):
         :rtype: bool
         """
         response = self._requester.request(
-            'DELETE',
-            '{}s/{}/discussion_topics/{}/entries/{}'.format(
+            "DELETE",
+            "{}s/{}/discussion_topics/{}/entries/{}".format(
                 self._discussion_parent_type,
                 self._discussion_parent_id,
                 self.discussion_id,
-                self.id
+                self.id,
             ),
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
-        return 'deleted_at' in response.json()
+        return "deleted_at" in response.json()
 
     def post_reply(self, **kwargs):
         """
@@ -512,14 +491,14 @@ class DiscussionEntry(CanvasObject):
         :rtype: :class:`canvasapi.discussion_topic.DiscussionEntry`
         """
         response = self._requester.request(
-            'POST',
-            '{}s/{}/discussion_topics/{}/entries/{}/replies'.format(
+            "POST",
+            "{}s/{}/discussion_topics/{}/entries/{}/replies".format(
                 self._discussion_parent_type,
                 self._discussion_parent_id,
                 self.discussion_id,
-                self.id
+                self.id,
             ),
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         response_json = response.json()
         response_json.update(discussion_id=self.discussion_id)
@@ -547,7 +526,7 @@ class DiscussionEntry(CanvasObject):
         warnings.warn(
             "`list_replies` is being deprecated and will be removed in a "
             "future version. Use `get_replies` instead.",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_replies(**kwargs)
@@ -570,18 +549,20 @@ class DiscussionEntry(CanvasObject):
         return PaginatedList(
             DiscussionEntry,
             self._requester,
-            'GET',
-            '{}s/{}/discussion_topics/{}/entries/{}/replies'.format(
+            "GET",
+            "{}s/{}/discussion_topics/{}/entries/{}/replies".format(
                 self._discussion_parent_type,
                 self._discussion_parent_id,
                 self.discussion_id,
-                self.id
+                self.id,
             ),
             {
-                'discussion_id': self.discussion_id,
-                '{}_id'.format(self._discussion_parent_type): self._discussion_parent_id
+                "discussion_id": self.discussion_id,
+                "{}_id".format(
+                    self._discussion_parent_type
+                ): self._discussion_parent_id,
             },
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     # TODO: update to use correct class
@@ -598,13 +579,13 @@ class DiscussionEntry(CanvasObject):
         :rtype: bool
         """
         response = self._requester.request(
-            'PUT',
-            '{}s/{}/discussion_topics/{}/entries/{}/read'.format(
+            "PUT",
+            "{}s/{}/discussion_topics/{}/entries/{}/read".format(
                 self._discussion_parent_type,
                 self._discussion_parent_id,
                 self.discussion_id,
-                self.id
-            )
+                self.id,
+            ),
         )
         return response.status_code == 204
 
@@ -624,13 +605,13 @@ class DiscussionEntry(CanvasObject):
         :rtype: bool
         """
         response = self._requester.request(
-            'DELETE',
-            '{}s/{}/discussion_topics/{}/entries/{}/read'.format(
+            "DELETE",
+            "{}s/{}/discussion_topics/{}/entries/{}/read".format(
                 self._discussion_parent_type,
                 self._discussion_parent_id,
                 self.discussion_id,
-                self.id
-            )
+                self.id,
+            ),
         )
         return response.status_code == 204
 
@@ -654,14 +635,14 @@ class DiscussionEntry(CanvasObject):
             raise ValueError("`rating` must be 0 or 1.")
 
         response = self._requester.request(
-            'POST',
-            '{}s/{}/discussion_topics/{}/entries/{}/rating'.format(
+            "POST",
+            "{}s/{}/discussion_topics/{}/entries/{}/rating".format(
                 self._discussion_parent_type,
                 self._discussion_parent_id,
                 self.discussion_id,
-                self.id
+                self.id,
             ),
             rating=rating,
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         return response.status_code == 204

--- a/canvasapi/enrollment.py
+++ b/canvasapi/enrollment.py
@@ -7,7 +7,6 @@ from canvasapi.canvas_object import CanvasObject
 
 @python_2_unicode_compatible
 class Enrollment(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.type, self.id)
 
@@ -25,18 +24,19 @@ class Enrollment(CanvasObject):
         :type task: str
         :rtype: :class:`canvasapi.enrollment.Enrollment`
         """
-        ALLOWED_TASKS = ['conclude', 'delete', 'inactivate', 'deactivate']
+        ALLOWED_TASKS = ["conclude", "delete", "inactivate", "deactivate"]
 
         if task not in ALLOWED_TASKS:
-            raise ValueError('{} is not a valid task. Please use one of the following: {}'.format(
-                task,
-                ','.join(ALLOWED_TASKS)
-            ))
+            raise ValueError(
+                "{} is not a valid task. Please use one of the following: {}".format(
+                    task, ",".join(ALLOWED_TASKS)
+                )
+            )
 
         response = self._requester.request(
-            'DELETE',
-            'courses/{}/enrollments/{}'.format(self.course_id, self.id),
-            task=task
+            "DELETE",
+            "courses/{}/enrollments/{}".format(self.course_id, self.id),
+            task=task,
         )
         return Enrollment(self._requester, response.json())
 
@@ -50,7 +50,7 @@ class Enrollment(CanvasObject):
         :rtype: :class:`canvasapi.enrollment.Enrollment`
         """
         response = self._requester.request(
-            'PUT',
-            'courses/{}/enrollments/{}/reactivate'.format(self.course_id, self.id)
+            "PUT",
+            "courses/{}/enrollments/{}/reactivate".format(self.course_id, self.id),
         )
         return Enrollment(self._requester, response.json())

--- a/canvasapi/enrollment_term.py
+++ b/canvasapi/enrollment_term.py
@@ -8,7 +8,6 @@ from canvasapi.util import combine_kwargs
 
 @python_2_unicode_compatible
 class EnrollmentTerm(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.name, self.id)
 
@@ -22,8 +21,7 @@ class EnrollmentTerm(CanvasObject):
         :rtype: :class:`canvasapi.enrollment_term.EnrollmentTerm`
         """
         response = self._requester.request(
-            'DELETE',
-            'accounts/{}/terms/{}'.format(self.account_id, self.id)
+            "DELETE", "accounts/{}/terms/{}".format(self.account_id, self.id)
         )
         return EnrollmentTerm(self._requester, response.json())
 
@@ -37,9 +35,9 @@ class EnrollmentTerm(CanvasObject):
         :rtype: :class:`canvasapi.enrollment_term.EnrollmentTerm`
         """
         response = self._requester.request(
-            'PUT',
-            'accounts/{}/terms/{}'.format(self.account_id, self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "accounts/{}/terms/{}".format(self.account_id, self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         return EnrollmentTerm(self._requester, response.json())

--- a/canvasapi/exceptions.py
+++ b/canvasapi/exceptions.py
@@ -8,15 +8,16 @@ class CanvasException(Exception):  # pragma: no cover
     """
     Base class for all errors returned by the Canvas API.
     """
+
     def __init__(self, message):
         if isinstance(message, dict):
-            self.error_report_id = message.get('error_report_id', None)
+            self.error_report_id = message.get("error_report_id", None)
 
-            errors = message.get('errors', False)
+            errors = message.get("errors", False)
             if errors:
                 self.message = errors
             else:
-                self.message = ('Something went wrong. ', message)
+                self.message = ("Something went wrong. ", message)
         else:
             self.message = message
 
@@ -26,34 +27,41 @@ class CanvasException(Exception):  # pragma: no cover
 
 class BadRequest(CanvasException):
     """Canvas was unable to understand the request. More information may be needed."""
+
     pass
 
 
 class InvalidAccessToken(CanvasException):
     """CanvasAPI was unable to make an API connection."""
+
     pass
 
 
 class Unauthorized(CanvasException):
     """CanvasAPI's key is valid, but is unauthorized to access the requested resource."""
+
     pass
 
 
 class ResourceDoesNotExist(CanvasException):
     """Canvas could not locate the requested resource."""
+
     pass
 
 
 class RequiredFieldMissing(CanvasException):
     """A required field is missing."""
+
     pass
 
 
 class Forbidden(CanvasException):
     """Canvas has denied access to the resource for this user."""
+
     pass
 
 
 class Conflict(CanvasException):
     """Canvas had a conflict with an existing resource."""
+
     pass

--- a/canvasapi/external_feed.py
+++ b/canvasapi/external_feed.py
@@ -7,6 +7,5 @@ from canvasapi.canvas_object import CanvasObject
 
 @python_2_unicode_compatible
 class ExternalFeed(CanvasObject):
-
     def __str__(self):
         return "{}".format(self.display_name)

--- a/canvasapi/external_tool.py
+++ b/canvasapi/external_tool.py
@@ -9,7 +9,6 @@ from canvasapi.util import combine_kwargs
 
 @python_2_unicode_compatible
 class ExternalTool(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.name, self.id)
 
@@ -20,9 +19,9 @@ class ExternalTool(CanvasObject):
 
         :rtype: int
         """
-        if hasattr(self, 'course_id'):
+        if hasattr(self, "course_id"):
             return self.course_id
-        elif hasattr(self, 'account_id'):
+        elif hasattr(self, "account_id"):
             return self.account_id
         else:
             raise ValueError("ExternalTool does not have a course_id or account_id")
@@ -34,10 +33,10 @@ class ExternalTool(CanvasObject):
 
         :rtype: str
         """
-        if hasattr(self, 'course_id'):
-            return 'course'
-        elif hasattr(self, 'account_id'):
-            return 'account'
+        if hasattr(self, "course_id"):
+            return "course"
+        elif hasattr(self, "account_id"):
+            return "account"
         else:
             raise ValueError("ExternalTool does not have a course_id or account_id")
 
@@ -51,13 +50,12 @@ class ExternalTool(CanvasObject):
         from canvasapi.course import Course
 
         response = self._requester.request(
-            'GET',
-            '{}s/{}'.format(self.parent_type, self.parent_id)
+            "GET", "{}s/{}".format(self.parent_type, self.parent_id)
         )
 
-        if self.parent_type == 'account':
+        if self.parent_type == "account":
             return Account(self._requester, response.json())
-        elif self.parent_type == 'course':
+        elif self.parent_type == "course":
             return Course(self._requester, response.json())
 
     def delete(self):
@@ -72,8 +70,10 @@ class ExternalTool(CanvasObject):
         :rtype: :class:`canvasapi.external_tool.ExternalTool`
         """
         response = self._requester.request(
-            'DELETE',
-            '{}s/{}/external_tools/{}'.format(self.parent_type, self.parent_id, self.id)
+            "DELETE",
+            "{}s/{}/external_tools/{}".format(
+                self.parent_type, self.parent_id, self.id
+            ),
         )
 
         return ExternalTool(self._requester, response.json())
@@ -90,13 +90,15 @@ class ExternalTool(CanvasObject):
         :rtype: :class:`canvasapi.external_tool.ExternalTool`
         """
         response = self._requester.request(
-            'PUT',
-            '{}s/{}/external_tools/{}'.format(self.parent_type, self.parent_id, self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "{}s/{}/external_tools/{}".format(
+                self.parent_type, self.parent_id, self.id
+            ),
+            _kwargs=combine_kwargs(**kwargs),
         )
         response_json = response.json()
 
-        if 'name' in response_json:
+        if "name" in response_json:
             super(ExternalTool, self).set_attributes(response_json)
 
         return ExternalTool(self._requester, response_json)
@@ -112,13 +114,15 @@ class ExternalTool(CanvasObject):
 
         :rtype: str
         """
-        kwargs['id'] = self.id
+        kwargs["id"] = self.id
         response = self._requester.request(
-            'GET',
-            '{}s/{}/external_tools/sessionless_launch'.format(self.parent_type, self.parent_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "{}s/{}/external_tools/sessionless_launch".format(
+                self.parent_type, self.parent_id
+            ),
+            _kwargs=combine_kwargs(**kwargs),
         )
         try:
-            return response.json()['url']
+            return response.json()["url"]
         except KeyError:
-            raise CanvasException('Canvas did not respond with a valid URL')
+            raise CanvasException("Canvas did not respond with a valid URL")

--- a/canvasapi/file.py
+++ b/canvasapi/file.py
@@ -7,7 +7,6 @@ from canvasapi.canvas_object import CanvasObject
 
 @python_2_unicode_compatible
 class File(CanvasObject):
-
     def __str__(self):
         return "{}".format(self.display_name)
 
@@ -20,10 +19,7 @@ class File(CanvasObject):
 
         :rtype: :class:`canvasapi.file.File`
         """
-        response = self._requester.request(
-            'DELETE',
-            'files/{}'.format(self.id)
-        )
+        response = self._requester.request("DELETE", "files/{}".format(self.id))
         return File(self._requester, response.json())
 
     def get_contents(self):
@@ -32,10 +28,7 @@ class File(CanvasObject):
 
         :rtype: str
         """
-        response = self._requester.request(
-            'GET',
-            _url=self.url
-        )
+        response = self._requester.request("GET", _url=self.url)
         return response.text
 
     def download(self, location):
@@ -45,10 +38,7 @@ class File(CanvasObject):
         :param location: The path to download to.
         :type location: str
         """
-        response = self._requester.request(
-            'GET',
-            _url=self.url
-        )
+        response = self._requester.request("GET", _url=self.url)
 
-        with open(location, 'wb') as file_out:
+        with open(location, "wb") as file_out:
             file_out.write(response.content)

--- a/canvasapi/folder.py
+++ b/canvasapi/folder.py
@@ -12,7 +12,6 @@ from canvasapi.upload import Uploader
 
 @python_2_unicode_compatible
 class Folder(CanvasObject):
-
     def __str__(self):
         return "{}".format(self.full_name)
 
@@ -33,7 +32,7 @@ class Folder(CanvasObject):
         warnings.warn(
             "`list_files` is being deprecated and will be removed in a future "
             "version. Use `get_files` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_files(**kwargs)
@@ -53,9 +52,9 @@ class Folder(CanvasObject):
         return PaginatedList(
             File,
             self._requester,
-            'GET',
-            'folders/{}/files'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "folders/{}/files".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def delete(self, **kwargs):
@@ -69,9 +68,7 @@ class Folder(CanvasObject):
         :rtype: :class:`canvasapi.folder.Folder`
         """
         response = self._requester.request(
-            'DELETE',
-            'folders/{}'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "DELETE", "folders/{}".format(self.id), _kwargs=combine_kwargs(**kwargs)
         )
         return Folder(self._requester, response.json())
 
@@ -92,7 +89,7 @@ class Folder(CanvasObject):
         warnings.warn(
             "`list_folders` is being deprecated and will be removed in a "
             "future version. Use `get_folders` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_folders(**kwargs)
@@ -108,10 +105,7 @@ class Folder(CanvasObject):
             :class:`canvasapi.folder.Folder`
         """
         return PaginatedList(
-            Folder,
-            self._requester,
-            'GET',
-            'folders/{}/folders'.format(self.id)
+            Folder, self._requester, "GET", "folders/{}/folders".format(self.id)
         )
 
     def create_folder(self, name, **kwargs):
@@ -126,10 +120,10 @@ class Folder(CanvasObject):
         :rtype: :class:`canvasapi.folder.Folder`
         """
         response = self._requester.request(
-            'POST',
-            'folders/{}/folders'.format(self.id),
+            "POST",
+            "folders/{}/folders".format(self.id),
             name=name,
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         return Folder(self._requester, response.json())
 
@@ -146,13 +140,8 @@ class Folder(CanvasObject):
                     and the JSON response from the API.
         :rtype: tuple
         """
-        my_path = 'folders/{}/files'.format(self.id)
-        return Uploader(
-            self._requester,
-            my_path,
-            file,
-            **kwargs
-        ).start()
+        my_path = "folders/{}/files".format(self.id)
+        return Uploader(self._requester, my_path, file, **kwargs).start()
 
     def update(self, **kwargs):
         """
@@ -164,12 +153,10 @@ class Folder(CanvasObject):
         :rtype: :class:`canvasapi.folder.Folder`
         """
         response = self._requester.request(
-            'PUT',
-            'folders/{}'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT", "folders/{}".format(self.id), _kwargs=combine_kwargs(**kwargs)
         )
 
-        if 'name' in response.json():
+        if "name" in response.json():
             super(Folder, self).set_attributes(response.json())
 
         return Folder(self._requester, response.json())
@@ -189,12 +176,12 @@ class Folder(CanvasObject):
         from canvasapi.file import File
 
         file_id = obj_or_id(source_file, "source_file", (File,))
-        kwargs['source_file_id'] = file_id
+        kwargs["source_file_id"] = file_id
 
         response = self._requester.request(
-            'POST',
-            'folders/{}/copy_file'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "folders/{}/copy_file".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         return File(self._requester, response.json())

--- a/canvasapi/grading_standard.py
+++ b/canvasapi/grading_standard.py
@@ -7,6 +7,5 @@ from canvasapi.canvas_object import CanvasObject
 
 @python_2_unicode_compatible
 class GradingStandard(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.title, self.id)

--- a/canvasapi/group.py
+++ b/canvasapi/group.py
@@ -15,7 +15,6 @@ from canvasapi.util import combine_kwargs, is_multivalued, obj_or_id
 
 @python_2_unicode_compatible
 class Group(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.name, self.id)
 
@@ -33,19 +32,17 @@ class Group(CanvasObject):
         """
         from canvasapi.course import Page
 
-        if isinstance(wiki_page, dict) and 'title' in wiki_page:
-            kwargs['wiki_page'] = wiki_page
+        if isinstance(wiki_page, dict) and "title" in wiki_page:
+            kwargs["wiki_page"] = wiki_page
         else:
             raise RequiredFieldMissing("Dictionary with key 'title' is required.")
 
         response = self._requester.request(
-            'POST',
-            'groups/{}/pages'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST", "groups/{}/pages".format(self.id), _kwargs=combine_kwargs(**kwargs)
         )
 
         page_json = response.json()
-        page_json.update({'group_id': self.id})
+        page_json.update({"group_id": self.id})
 
         return Page(self._requester, page_json)
 
@@ -61,12 +58,12 @@ class Group(CanvasObject):
         from canvasapi.course import Page
 
         response = self._requester.request(
-            'PUT',
-            'groups/{}/front_page'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "groups/{}/front_page".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         page_json = response.json()
-        page_json.update({'group_id': self.id})
+        page_json.update({"group_id": self.id})
 
         return Page(self._requester, page_json)
 
@@ -82,11 +79,10 @@ class Group(CanvasObject):
         from canvasapi.course import Page
 
         response = self._requester.request(
-            'GET',
-            'groups/{}/front_page'.format(self.id)
+            "GET", "groups/{}/front_page".format(self.id)
         )
         page_json = response.json()
-        page_json.update({'group_id': self.id})
+        page_json.update({"group_id": self.id})
 
         return Page(self._requester, page_json)
 
@@ -105,11 +101,10 @@ class Group(CanvasObject):
         from canvasapi.course import Page
 
         response = self._requester.request(
-            'GET',
-            'groups/{}/pages/{}'.format(self.id, url)
+            "GET", "groups/{}/pages/{}".format(self.id, url)
         )
         page_json = response.json()
-        page_json.update({'group_id': self.id})
+        page_json.update({"group_id": self.id})
 
         return Page(self._requester, page_json)
 
@@ -124,13 +119,14 @@ class Group(CanvasObject):
             :class:`canvasapi.page.Page`
         """
         from canvasapi.course import Page
+
         return PaginatedList(
             Page,
             self._requester,
-            'GET',
-            'groups/{}/pages'.format(self.id),
-            {'group_id': self.id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "groups/{}/pages".format(self.id),
+            {"group_id": self.id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def edit(self, **kwargs):
@@ -143,9 +139,7 @@ class Group(CanvasObject):
         :rtype: :class:`canvasapi.group.Group`
         """
         response = self._requester.request(
-            'PUT',
-            'groups/{}'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT", "groups/{}".format(self.id), _kwargs=combine_kwargs(**kwargs)
         )
         return Group(self._requester, response.json())
 
@@ -158,10 +152,7 @@ class Group(CanvasObject):
 
         :rtype: :class:`canvasapi.group.Group`
         """
-        response = self._requester.request(
-            'DELETE',
-            'groups/{}'.format(self.id)
-        )
+        response = self._requester.request("DELETE", "groups/{}".format(self.id))
         return Group(self._requester, response.json())
 
     def invite(self, invitees):
@@ -180,9 +171,9 @@ class Group(CanvasObject):
         return PaginatedList(
             GroupMembership,
             self._requester,
-            'POST',
-            'groups/{}/invite'.format(self.id),
-            invitees=invitees
+            "POST",
+            "groups/{}/invite".format(self.id),
+            invitees=invitees,
         )
 
     def list_users(self, **kwargs):
@@ -202,7 +193,7 @@ class Group(CanvasObject):
         warnings.warn(
             "`list_users` is being deprecated and will be removed in a future "
             "version. Use `get_users` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_users(**kwargs)
@@ -218,12 +209,13 @@ class Group(CanvasObject):
             :class:`canvasapi.user.User`
         """
         from canvasapi.user import User
+
         return PaginatedList(
             User,
             self._requester,
-            'GET',
-            'groups/{}/users'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "groups/{}/users".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def remove_user(self, user):
@@ -243,8 +235,7 @@ class Group(CanvasObject):
         user_id = obj_or_id(user, "user", (User,))
 
         response = self._requester.request(
-            'DELETE',
-            'groups/{}/users/{}'.format(self.id, user_id),
+            "DELETE", "groups/{}/users/{}".format(self.id, user_id)
         )
         return User(self._requester, response.json())
 
@@ -268,10 +259,7 @@ class Group(CanvasObject):
         from canvasapi.upload import Uploader
 
         return Uploader(
-            self._requester,
-            'groups/{}/files'.format(self.id),
-            file,
-            **kwargs
+            self._requester, "groups/{}/files".format(self.id), file, **kwargs
         ).start()
 
     def preview_html(self, html):
@@ -286,11 +274,9 @@ class Group(CanvasObject):
         :rtype: str
         """
         response = self._requester.request(
-            'POST',
-            'groups/{}/preview_html'.format(self.id),
-            html=html
+            "POST", "groups/{}/preview_html".format(self.id), html=html
         )
-        return response.json().get('html', '')
+        return response.json().get("html", "")
 
     def get_activity_stream_summary(self):
         """
@@ -302,8 +288,7 @@ class Group(CanvasObject):
         :rtype: dict
         """
         response = self._requester.request(
-            'GET',
-            'groups/{}/activity_stream/summary'.format(self.id)
+            "GET", "groups/{}/activity_stream/summary".format(self.id)
         )
         return response.json()
 
@@ -324,7 +309,7 @@ class Group(CanvasObject):
         warnings.warn(
             "`list_memberships` is being deprecated and will be removed in a "
             "future version. Use `get_memberships` instead.",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_memberships(**kwargs)
@@ -342,9 +327,9 @@ class Group(CanvasObject):
         return PaginatedList(
             GroupMembership,
             self._requester,
-            'GET',
-            'groups/{}/memberships'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "groups/{}/memberships".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_membership(self, user, membership_type):
@@ -367,8 +352,7 @@ class Group(CanvasObject):
         user_id = obj_or_id(user, "user", (User,))
 
         response = self._requester.request(
-            'GET',
-            'groups/{}/{}/{}'.format(self.id, membership_type, user_id)
+            "GET", "groups/{}/{}/{}".format(self.id, membership_type, user_id)
         )
         return GroupMembership(self._requester, response.json())
 
@@ -390,10 +374,10 @@ class Group(CanvasObject):
         user_id = obj_or_id(user, "user", (User,))
 
         response = self._requester.request(
-            'POST',
-            'groups/{}/memberships'.format(self.id),
+            "POST",
+            "groups/{}/memberships".format(self.id),
             user_id=user_id,
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         return GroupMembership(self._requester, response.json())
 
@@ -414,9 +398,9 @@ class Group(CanvasObject):
         user_id = obj_or_id(user, "user", (User,))
 
         response = self._requester.request(
-            'PUT',
-            'groups/{}/users/{}'.format(self.id, user_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "groups/{}/users/{}".format(self.id, user_id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return GroupMembership(self._requester, response.json())
 
@@ -435,12 +419,11 @@ class Group(CanvasObject):
         topic_id = obj_or_id(topic, "topic", (DiscussionTopic,))
 
         response = self._requester.request(
-            'GET',
-            'groups/{}/discussion_topics/{}'.format(self.id, topic_id)
+            "GET", "groups/{}/discussion_topics/{}".format(self.id, topic_id)
         )
 
         response_json = response.json()
-        response_json.update({'group_id': self.id})
+        response_json.update({"group_id": self.id})
 
         return DiscussionTopic(self._requester, response_json)
 
@@ -457,12 +440,13 @@ class Group(CanvasObject):
         :rtype: :class:`canvasapi.file.File`
         """
         from canvasapi.file import File
+
         file_id = obj_or_id(file, "file", (File,))
 
         response = self._requester.request(
-            'GET',
-            'groups/{}/files/{}'.format(self.id, file_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "groups/{}/files/{}".format(self.id, file_id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return File(self._requester, response.json())
 
@@ -481,8 +465,7 @@ class Group(CanvasObject):
         topic_id = obj_or_id(topic, "topic", (DiscussionTopic,))
 
         response = self._requester.request(
-            'GET',
-            'groups/{}/discussion_topics/{}/view'.format(self.id, topic_id),
+            "GET", "groups/{}/discussion_topics/{}/view".format(self.id, topic_id)
         )
         return response.json()
 
@@ -500,10 +483,10 @@ class Group(CanvasObject):
         return PaginatedList(
             DiscussionTopic,
             self._requester,
-            'GET',
-            'groups/{}/discussion_topics'.format(self.id),
-            {'group_id': self.id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "groups/{}/discussion_topics".format(self.id),
+            {"group_id": self.id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def create_discussion_topic(self, **kwargs):
@@ -516,13 +499,13 @@ class Group(CanvasObject):
         :rtype: :class:`canvasapi.discussion_topic.DiscussionTopic`
         """
         response = self._requester.request(
-            'POST',
-            'groups/{}/discussion_topics'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "groups/{}/discussion_topics".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         response_json = response.json()
-        response_json.update({'group_id': self.id})
+        response_json.update({"group_id": self.id})
 
         return DiscussionTopic(self._requester, response_json)
 
@@ -550,12 +533,10 @@ class Group(CanvasObject):
             raise ValueError("Param `order` must be a list, tuple, or string.")
 
         response = self._requester.request(
-            'POST',
-            'groups/{}/discussion_topics/reorder'.format(self.id),
-            order=order
+            "POST", "groups/{}/discussion_topics/reorder".format(self.id), order=order
         )
 
-        return response.json().get('reorder')
+        return response.json().get("reorder")
 
     def list_external_feeds(self, **kwargs):
         """
@@ -574,7 +555,7 @@ class Group(CanvasObject):
         warnings.warn(
             "`list_external_feeds` is being deprecated and will be removed in "
             "a future version. Use `get_external_feeds` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_external_feeds(**kwargs)
@@ -590,11 +571,12 @@ class Group(CanvasObject):
             :class:`canvasapi.external_feed.ExternalFeed`
         """
         from canvasapi.external_feed import ExternalFeed
+
         return PaginatedList(
             ExternalFeed,
             self._requester,
-            'GET',
-            'groups/{}/external_feeds'.format(self.id)
+            "GET",
+            "groups/{}/external_feeds".format(self.id),
         )
 
     def create_external_feed(self, url, **kwargs):
@@ -609,11 +591,12 @@ class Group(CanvasObject):
         :rtype: :class:`canvasapi.external_feed.ExternalFeed`
         """
         from canvasapi.external_feed import ExternalFeed
+
         response = self._requester.request(
-            'POST',
-            'groups/{}/external_feeds'.format(self.id),
+            "POST",
+            "groups/{}/external_feeds".format(self.id),
             url=url,
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         return ExternalFeed(self._requester, response.json())
 
@@ -634,8 +617,7 @@ class Group(CanvasObject):
         feed_id = obj_or_id(feed, "feed", (ExternalFeed,))
 
         response = self._requester.request(
-            'DELETE',
-            'groups/{}/external_feeds/{}'.format(self.id, feed_id)
+            "DELETE", "groups/{}/external_feeds/{}".format(self.id, feed_id)
         )
         return ExternalFeed(self._requester, response.json())
 
@@ -656,7 +638,7 @@ class Group(CanvasObject):
         warnings.warn(
             "`list_files` is being deprecated and will be removed in a future "
             "version. Use `get_files` instead.",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_files(**kwargs)
@@ -676,9 +658,9 @@ class Group(CanvasObject):
         return PaginatedList(
             File,
             self._requester,
-            'GET',
-            'groups/{}/files'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "groups/{}/files".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_folder(self, folder):
@@ -696,8 +678,7 @@ class Group(CanvasObject):
         folder_id = obj_or_id(folder, "folder", (Folder,))
 
         response = self._requester.request(
-            'GET',
-            'groups/{}/folders/{}'.format(self.id, folder_id)
+            "GET", "groups/{}/folders/{}".format(self.id, folder_id)
         )
         return Folder(self._requester, response.json())
 
@@ -719,7 +700,7 @@ class Group(CanvasObject):
         warnings.warn(
             "`list_folders` is being deprecated and will be removed in a "
             "future version. Use `get_folders` instead.",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_folders(**kwargs)
@@ -736,10 +717,7 @@ class Group(CanvasObject):
             :class:`canvasapi.folder.Folder`
         """
         return PaginatedList(
-            Folder,
-            self._requester,
-            'GET',
-            'groups/{}/folders'.format(self.id)
+            Folder, self._requester, "GET", "groups/{}/folders".format(self.id)
         )
 
     def create_folder(self, name, **kwargs):
@@ -754,10 +732,10 @@ class Group(CanvasObject):
         :rtype: :class:`canvasapi.folder.Folder`
         """
         response = self._requester.request(
-            'POST',
-            'groups/{}/folders'.format(self.id),
+            "POST",
+            "groups/{}/folders".format(self.id),
             name=name,
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         return Folder(self._requester, response.json())
 
@@ -779,7 +757,7 @@ class Group(CanvasObject):
         warnings.warn(
             "`list_tabs` is being deprecated and will be removed in a future "
             "version. Use `get_tabs` instead.",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_tabs(**kwargs)
@@ -798,10 +776,10 @@ class Group(CanvasObject):
         return PaginatedList(
             Tab,
             self._requester,
-            'GET',
-            'groups/{}/tabs'.format(self.id),
-            {'group_id': self.id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "groups/{}/tabs".format(self.id),
+            {"group_id": self.id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def create_content_migration(self, migration_type, **kwargs):
@@ -819,20 +797,20 @@ class Group(CanvasObject):
         from canvasapi.content_migration import ContentMigration, Migrator
 
         if isinstance(migration_type, Migrator):
-            kwargs['migration_type'] = migration_type.type
+            kwargs["migration_type"] = migration_type.type
         elif isinstance(migration_type, string_types):
-            kwargs['migration_type'] = migration_type
+            kwargs["migration_type"] = migration_type
         else:
-            raise TypeError('Parameter migration_type must be of type Migrator or str')
+            raise TypeError("Parameter migration_type must be of type Migrator or str")
 
         response = self._requester.request(
-            'POST',
-            'groups/{}/content_migrations'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "groups/{}/content_migrations".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         response_json = response.json()
-        response_json.update({'group_id': self.id})
+        response_json.update({"group_id": self.id})
 
         return ContentMigration(self._requester, response_json)
 
@@ -850,16 +828,18 @@ class Group(CanvasObject):
         """
         from canvasapi.content_migration import ContentMigration
 
-        migration_id = obj_or_id(content_migration, "content_migration", (ContentMigration,))
+        migration_id = obj_or_id(
+            content_migration, "content_migration", (ContentMigration,)
+        )
 
         response = self._requester.request(
-            'GET',
-            'groups/{}/content_migrations/{}'.format(self.id, migration_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "groups/{}/content_migrations/{}".format(self.id, migration_id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         response_json = response.json()
-        response_json.update({'group_id': self.id})
+        response_json.update({"group_id": self.id})
 
         return ContentMigration(self._requester, response_json)
 
@@ -878,10 +858,10 @@ class Group(CanvasObject):
         return PaginatedList(
             ContentMigration,
             self._requester,
-            'GET',
-            'groups/{}/content_migrations'.format(self.id),
-            {'group_id': self.id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "groups/{}/content_migrations".format(self.id),
+            {"group_id": self.id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_migration_systems(self, **kwargs):
@@ -899,9 +879,9 @@ class Group(CanvasObject):
         return PaginatedList(
             Migrator,
             self._requester,
-            'GET',
-            'groups/{}/content_migrations/migrators'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "groups/{}/content_migrations/migrators".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_assignment_override(self, assignment, **kwargs):
@@ -921,18 +901,16 @@ class Group(CanvasObject):
         assignment_id = obj_or_id(assignment, "assignment", (Assignment,))
 
         response = self._requester.request(
-            'GET',
-            'groups/{}/assignments/{}/override'.format(self.id, assignment_id)
+            "GET", "groups/{}/assignments/{}/override".format(self.id, assignment_id)
         )
         response_json = response.json()
-        response_json.update({'course_id': self.course_id})
+        response_json.update({"course_id": self.course_id})
 
         return AssignmentOverride(self._requester, response_json)
 
 
 @python_2_unicode_compatible
 class GroupMembership(CanvasObject):
-
     def __str__(self):
         return "{} - {} ({})".format(self.user_id, self.group_id, self.id)
 
@@ -947,9 +925,9 @@ class GroupMembership(CanvasObject):
         """
 
         response = self._requester.request(
-            'PUT',
-            'groups/{}/memberships/{}'.format(self.group_id, self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "groups/{}/memberships/{}".format(self.group_id, self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return GroupMembership(self._requester, response.json())
 
@@ -971,8 +949,7 @@ class GroupMembership(CanvasObject):
         user_id = obj_or_id(user, "user", (User,))
 
         response = self._requester.request(
-            'DELETE',
-            'groups/{}/users/{}'.format(self.id, user_id),
+            "DELETE", "groups/{}/users/{}".format(self.id, user_id)
         )
         return response.json()
 
@@ -987,15 +964,13 @@ class GroupMembership(CanvasObject):
         :rtype: dict
         """
         response = self._requester.request(
-            'DELETE',
-            'groups/{}/memberships/self'.format(self.id),
+            "DELETE", "groups/{}/memberships/self".format(self.id)
         )
         return response.json()
 
 
 @python_2_unicode_compatible
 class GroupCategory(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.name, self.id)
 
@@ -1009,9 +984,9 @@ class GroupCategory(CanvasObject):
         :rtype: :class:`canvasapi.group.Group`
         """
         response = self._requester.request(
-            'POST',
-            'group_categories/{}/groups'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "group_categories/{}/groups".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return Group(self._requester, response.json())
 
@@ -1025,9 +1000,9 @@ class GroupCategory(CanvasObject):
         :rtype: :class:`canvasapi.group.GroupCategory`
         """
         response = self._requester.request(
-            'PUT',
-            'group_categories/{}'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "group_categories/{}".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return GroupCategory(self._requester, response.json())
 
@@ -1041,8 +1016,7 @@ class GroupCategory(CanvasObject):
         :rtype: empty dict
         """
         response = self._requester.request(
-            'DELETE',
-            'group_categories/{}'.format(self.id)
+            "DELETE", "group_categories/{}".format(self.id)
         )
         return response.json()
 
@@ -1063,7 +1037,7 @@ class GroupCategory(CanvasObject):
         warnings.warn(
             "`list_groups` is being deprecated and will be removed in a "
             "future version. Use `get_groups` instead.",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_groups(**kwargs)
@@ -1079,10 +1053,7 @@ class GroupCategory(CanvasObject):
             :class:`canvasapi.group.Group`
         """
         return PaginatedList(
-            Group,
-            self._requester,
-            'GET',
-            'group_categories/{}/groups'.format(self.id)
+            Group, self._requester, "GET", "group_categories/{}/groups".format(self.id)
         )
 
     def list_users(self, **kwargs):
@@ -1102,7 +1073,7 @@ class GroupCategory(CanvasObject):
         warnings.warn(
             "`list_users` is being deprecated and will be removed in a future version."
             " Use `get_users` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_users(**kwargs)
@@ -1118,12 +1089,13 @@ class GroupCategory(CanvasObject):
             :class:`canvasapi.user.User`
         """
         from canvasapi.user import User
+
         return PaginatedList(
             User,
             self._requester,
-            'GET',
-            'group_categories/{}/users'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "group_categories/{}/users".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def assign_members(self, sync=False):
@@ -1138,16 +1110,16 @@ class GroupCategory(CanvasObject):
         """
         from canvasapi.user import User
         from canvasapi.progress import Progress
+
         if sync:
             return PaginatedList(
                 User,
                 self._requester,
-                'POST',
-                'group_categories/{}/assign_unassigned_members'.format(self.id)
+                "POST",
+                "group_categories/{}/assign_unassigned_members".format(self.id),
             )
         else:
             response = self._requester.request(
-                'POST',
-                'group_categories/{}/assign_unassigned_members'.format(self.id)
+                "POST", "group_categories/{}/assign_unassigned_members".format(self.id)
             )
             return Progress(self._requester, response.json())

--- a/canvasapi/login.py
+++ b/canvasapi/login.py
@@ -8,7 +8,6 @@ from canvasapi.util import combine_kwargs
 
 @python_2_unicode_compatible
 class Login(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.id, self.unique_id)
 
@@ -22,8 +21,7 @@ class Login(CanvasObject):
         :rtype: :class:`canvasapi.login.Login`
         """
         response = self._requester.request(
-            'DELETE',
-            'users/{}/logins/{}'.format(self.user_id, self.id)
+            "DELETE", "users/{}/logins/{}".format(self.user_id, self.id)
         )
         return Login(self._requester, response.json())
 
@@ -37,8 +35,8 @@ class Login(CanvasObject):
         :rtype: :class:`canvasapi.login.Login`
         """
         response = self._requester.request(
-            'PUT',
-            'accounts/{}/logins/{}'.format(self.account_id, self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "accounts/{}/logins/{}".format(self.account_id, self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return Login(self._requester, response.json())

--- a/canvasapi/module.py
+++ b/canvasapi/module.py
@@ -11,7 +11,6 @@ from canvasapi.util import combine_kwargs, obj_or_id
 
 @python_2_unicode_compatible
 class Module(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.name, self.id)
 
@@ -25,12 +24,12 @@ class Module(CanvasObject):
         :rtype: :class:`canvasapi.module.Module`
         """
         response = self._requester.request(
-            'PUT',
-            'courses/{}/modules/{}'.format(self.course_id, self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "courses/{}/modules/{}".format(self.course_id, self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         module_json = response.json()
-        module_json.update({'course_id': self.course_id})
+        module_json.update({"course_id": self.course_id})
 
         return Module(self._requester, module_json)
 
@@ -44,11 +43,10 @@ class Module(CanvasObject):
         :rtype: :class:`canvasapi.module.Module`
         """
         response = self._requester.request(
-            'DELETE',
-            'courses/{}/modules/{}'.format(self.course_id, self.id),
+            "DELETE", "courses/{}/modules/{}".format(self.course_id, self.id)
         )
         module_json = response.json()
-        module_json.update({'course_id': self.course_id})
+        module_json.update({"course_id": self.course_id})
 
         return Module(self._requester, module_json)
 
@@ -66,11 +64,10 @@ class Module(CanvasObject):
         :rtype: :class:`canvasapi.module.Module`
         """
         response = self._requester.request(
-            'PUT',
-            'courses/{}/modules/{}/relock'.format(self.course_id, self.id),
+            "PUT", "courses/{}/modules/{}/relock".format(self.course_id, self.id)
         )
         module_json = response.json()
-        module_json.update({'course_id': self.course_id})
+        module_json.update({"course_id": self.course_id})
 
         return Module(self._requester, module_json)
 
@@ -91,7 +88,7 @@ class Module(CanvasObject):
         warnings.warn(
             "`list_module_items` is being deprecated and will be removed in a "
             "future version. Use `get_module_items` instead.",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_module_items(**kwargs)
@@ -109,10 +106,10 @@ class Module(CanvasObject):
         return PaginatedList(
             ModuleItem,
             self._requester,
-            'GET',
-            'courses/{}/modules/{}/items'.format(self.course_id, self.id),
-            {'course_id': self.course_id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/modules/{}/items".format(self.course_id, self.id),
+            {"course_id": self.course_id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_module_item(self, module_item, **kwargs):
@@ -130,12 +127,14 @@ class Module(CanvasObject):
         module_item_id = obj_or_id(module_item, "module_item", (ModuleItem,))
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/modules/{}/items/{}'.format(self.course_id, self.id, module_item_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/modules/{}/items/{}".format(
+                self.course_id, self.id, module_item_id
+            ),
+            _kwargs=combine_kwargs(**kwargs),
         )
         module_item_json = response.json()
-        module_item_json.update({'course_id': self.course_id})
+        module_item_json.update({"course_id": self.course_id})
 
         return ModuleItem(self._requester, module_item_json)
 
@@ -151,28 +150,29 @@ class Module(CanvasObject):
         :returns: The created module item.
         :rtype: :class:`canvasapi.module.ModuleItem`
         """
-        if isinstance(module_item, dict) and 'type' in module_item:
-            if 'content_id' in module_item:
-                kwargs['module_item'] = module_item
+        if isinstance(module_item, dict) and "type" in module_item:
+            if "content_id" in module_item:
+                kwargs["module_item"] = module_item
             else:
-                raise RequiredFieldMissing("Dictionary with key 'content_id' is required.")
+                raise RequiredFieldMissing(
+                    "Dictionary with key 'content_id' is required."
+                )
         else:
             raise RequiredFieldMissing("Dictionary with key 'type' is required.")
 
         response = self._requester.request(
-            'POST',
-            'courses/{}/modules/{}/items'.format(self.course_id, self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "courses/{}/modules/{}/items".format(self.course_id, self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         module_item_json = response.json()
-        module_item_json.update({'course_id': self.course_id})
+        module_item_json.update({"course_id": self.course_id})
 
         return ModuleItem(self._requester, module_item_json)
 
 
 @python_2_unicode_compatible
 class ModuleItem(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.title, self.id)
 
@@ -187,12 +187,14 @@ class ModuleItem(CanvasObject):
         :rtype: :class:`canvasapi.module.ModuleItem`
         """
         response = self._requester.request(
-            'PUT',
-            'courses/{}/modules/{}/items/{}'.format(self.course_id, self.module_id, self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "courses/{}/modules/{}/items/{}".format(
+                self.course_id, self.module_id, self.id
+            ),
+            _kwargs=combine_kwargs(**kwargs),
         )
         module_item_json = response.json()
-        module_item_json.update({'course_id': self.course_id})
+        module_item_json.update({"course_id": self.course_id})
 
         return ModuleItem(self._requester, module_item_json)
 
@@ -206,11 +208,13 @@ class ModuleItem(CanvasObject):
         :rtype: :class:`canvasapi.module.ModuleItem`
         """
         response = self._requester.request(
-            'DELETE',
-            'courses/{}/modules/{}/items/{}'.format(self.course_id, self.module_id, self.id),
+            "DELETE",
+            "courses/{}/modules/{}/items/{}".format(
+                self.course_id, self.module_id, self.id
+            ),
         )
         module_item_json = response.json()
-        module_item_json.update({'course_id': self.course_id})
+        module_item_json.update({"course_id": self.course_id})
 
         return ModuleItem(self._requester, module_item_json)
 
@@ -224,11 +228,13 @@ class ModuleItem(CanvasObject):
         :rtype: :class:`canvasapi.module.ModuleItem`
         """
         response = self._requester.request(
-            'PUT',
-            'courses/{}/modules/{}/items/{}/done'.format(self.course_id, self.module_id, self.id),
+            "PUT",
+            "courses/{}/modules/{}/items/{}/done".format(
+                self.course_id, self.module_id, self.id
+            ),
         )
         module_item_json = response.json()
-        module_item_json.update({'course_id': self.course_id})
+        module_item_json.update({"course_id": self.course_id})
 
         return ModuleItem(self._requester, module_item_json)
 
@@ -242,10 +248,12 @@ class ModuleItem(CanvasObject):
         :rtype: :class:`canvasapi.module.ModuleItem`
         """
         response = self._requester.request(
-            'DELETE',
-            'courses/{}/modules/{}/items/{}/done'.format(self.course_id, self.module_id, self.id),
+            "DELETE",
+            "courses/{}/modules/{}/items/{}/done".format(
+                self.course_id, self.module_id, self.id
+            ),
         )
         module_item_json = response.json()
-        module_item_json.update({'course_id': self.course_id})
+        module_item_json.update({"course_id": self.course_id})
 
         return ModuleItem(self._requester, module_item_json)

--- a/canvasapi/notification_preference.py
+++ b/canvasapi/notification_preference.py
@@ -7,6 +7,5 @@ from canvasapi.canvas_object import CanvasObject
 
 @python_2_unicode_compatible
 class NotificationPreference(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.notification, self.frequency)

--- a/canvasapi/outcome.py
+++ b/canvasapi/outcome.py
@@ -10,7 +10,6 @@ from canvasapi.util import combine_kwargs, obj_or_id
 
 @python_2_unicode_compatible
 class Outcome(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.title, self.url)
 
@@ -25,32 +24,27 @@ class Outcome(CanvasObject):
         :rtype: bool
         """
         response = self._requester.request(
-            'PUT',
-            'outcomes/{}'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT", "outcomes/{}".format(self.id), _kwargs=combine_kwargs(**kwargs)
         )
 
-        if 'id' in response.json():
+        if "id" in response.json():
             super(Outcome, self).set_attributes(response.json())
 
-        return 'id' in response.json()
+        return "id" in response.json()
 
 
 @python_2_unicode_compatible
 class OutcomeLink(CanvasObject):
-
     def __str__(self):
         return "Group {} with Outcome {} ({})".format(
-            self.outcome_group,
-            self.outcome,
-            self.url
+            self.outcome_group, self.outcome, self.url
         )
 
     def context_ref(self):
-        if self.context_type == 'Course':
-            return 'courses/{}'.format(self.context_id)
-        elif self.context_type == 'Account':
-            return 'accounts/{}'.format(self.context_id)
+        if self.context_type == "Course":
+            return "courses/{}".format(self.context_id)
+        elif self.context_type == "Account":
+            return "accounts/{}".format(self.context_id)
 
     def get_outcome(self):
         """
@@ -62,11 +56,8 @@ class OutcomeLink(CanvasObject):
         :returns: Outcome object that was in the OutcomeLink
         :rtype: :class:`canvasapi.outcome.Outcome`
         """
-        oid = self.outcome['id']
-        response = self._requester.request(
-            'GET',
-            'outcomes/{}'.format(oid)
-        )
+        oid = self.outcome["id"]
+        response = self._requester.request("GET", "outcomes/{}".format(oid))
 
         return Outcome(self._requester, response.json())
 
@@ -84,10 +75,9 @@ class OutcomeLink(CanvasObject):
         :returns: Linked outcome group object.
         :rtype: :class:`canvasapi.outcome.OutcomeGroup`
         """
-        ogid = self.outcome_group['id']
+        ogid = self.outcome_group["id"]
         response = self._requester.request(
-            'GET',
-            '{}/outcome_groups/{}'.format(self.context_ref(), ogid)
+            "GET", "{}/outcome_groups/{}".format(self.context_ref(), ogid)
         )
 
         return OutcomeGroup(self._requester, response.json())
@@ -95,17 +85,16 @@ class OutcomeLink(CanvasObject):
 
 @python_2_unicode_compatible
 class OutcomeGroup(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.title, self.url)
 
     def context_ref(self):
-        if self.context_type == 'Course':
-            return 'courses/{}'.format(self.context_id)
-        elif self.context_type == 'Account':
-            return 'accounts/{}'.format(self.context_id)
+        if self.context_type == "Course":
+            return "courses/{}".format(self.context_id)
+        elif self.context_type == "Account":
+            return "accounts/{}".format(self.context_id)
         elif self.context_type is None:
-            return 'global'
+            return "global"
 
     def update(self, **kwargs):
         """
@@ -122,15 +111,15 @@ class OutcomeGroup(CanvasObject):
         :rtype: bool
         """
         response = self._requester.request(
-            'PUT',
-            '{}/outcome_groups/{}'.format(self.context_ref(), self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "{}/outcome_groups/{}".format(self.context_ref(), self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
-        if 'id' in response.json():
+        if "id" in response.json():
             super(OutcomeGroup, self).set_attributes(response.json())
 
-        return 'id' in response.json()
+        return "id" in response.json()
 
     def delete(self):
         """
@@ -147,14 +136,13 @@ class OutcomeGroup(CanvasObject):
         :rtype: bool
         """
         response = self._requester.request(
-            'DELETE',
-            '{}/outcome_groups/{}'.format(self.context_ref(), self.id)
+            "DELETE", "{}/outcome_groups/{}".format(self.context_ref(), self.id)
         )
 
-        if 'id' in response.json():
+        if "id" in response.json():
             super(OutcomeGroup, self).set_attributes(response.json())
 
-        return 'id' in response.json()
+        return "id" in response.json()
 
     def list_linked_outcomes(self, **kwargs):
         """
@@ -178,7 +166,7 @@ class OutcomeGroup(CanvasObject):
         warnings.warn(
             "`list_linked_outcomes` is being deprecated and will be removed "
             "in a future version. Use `get_linked_outcomes` instead.",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_linked_outcomes(**kwargs)
@@ -201,9 +189,9 @@ class OutcomeGroup(CanvasObject):
         return PaginatedList(
             OutcomeLink,
             self._requester,
-            'GET',
-            '{}/outcome_groups/{}/outcomes'.format(self.context_ref(), self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "{}/outcome_groups/{}/outcomes".format(self.context_ref(), self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def link_existing(self, outcome):
@@ -226,12 +214,10 @@ class OutcomeGroup(CanvasObject):
         outcome_id = obj_or_id(outcome, "outcome", (Outcome,))
 
         response = self._requester.request(
-            'PUT',
-            '{}/outcome_groups/{}/outcomes/{}'.format(
-                self.context_ref(),
-                self.id,
-                outcome_id
-            )
+            "PUT",
+            "{}/outcome_groups/{}/outcomes/{}".format(
+                self.context_ref(), self.id, outcome_id
+            ),
         )
 
         return OutcomeLink(self._requester, response.json())
@@ -254,10 +240,10 @@ class OutcomeGroup(CanvasObject):
         :rtype: :class:`canvasapi.outcome.OutcomeLink`
         """
         response = self._requester.request(
-            'POST',
-            '{}/outcome_groups/{}/outcomes'.format(self.context_ref(), self.id),
+            "POST",
+            "{}/outcome_groups/{}/outcomes".format(self.context_ref(), self.id),
             title=title,
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         return OutcomeLink(self._requester, response.json())
@@ -282,18 +268,16 @@ class OutcomeGroup(CanvasObject):
         outcome_id = obj_or_id(outcome, "outcome", (Outcome,))
 
         response = self._requester.request(
-            'DELETE',
-            '{}/outcome_groups/{}/outcomes/{}'.format(
-                self.context_ref(),
-                self.id,
-                outcome_id
-            )
+            "DELETE",
+            "{}/outcome_groups/{}/outcomes/{}".format(
+                self.context_ref(), self.id, outcome_id
+            ),
         )
 
-        if 'context_id' in response.json():
+        if "context_id" in response.json():
             super(OutcomeGroup, self).set_attributes(response.json())
 
-        return 'context_id' in response.json()
+        return "context_id" in response.json()
 
     def list_subgroups(self, **kwargs):
         """
@@ -317,7 +301,7 @@ class OutcomeGroup(CanvasObject):
         warnings.warn(
             "`list_subgroups` is being deprecated and will be removed in a "
             "future version. Use `get_subgroups` instead.",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_subgroups(**kwargs)
@@ -340,10 +324,10 @@ class OutcomeGroup(CanvasObject):
         return PaginatedList(
             OutcomeGroup,
             self._requester,
-            'GET',
-            '{}/outcome_groups/{}/subgroups'.format(self.context_ref(), self.id),
-            {'context_type': self.context_type, 'context_id': self.context_id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "{}/outcome_groups/{}/subgroups".format(self.context_ref(), self.id),
+            {"context_type": self.context_type, "context_id": self.context_id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def create_subgroup(self, title, **kwargs):
@@ -364,10 +348,10 @@ class OutcomeGroup(CanvasObject):
         :rtype: :class:`canvasapi.outcome.OutcomeGroup`
         """
         response = self._requester.request(
-            'POST',
-            '{}/outcome_groups/{}/subgroups'.format(self.context_ref(), self.id),
+            "POST",
+            "{}/outcome_groups/{}/subgroups".format(self.context_ref(), self.id),
             title=title,
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         return OutcomeGroup(self._requester, response.json())
@@ -389,12 +373,14 @@ class OutcomeGroup(CanvasObject):
         :returns: Itself as an OutcomeGroup object.
         :rtype: :class:`canvasapi.outcome.OutcomeGroup`
         """
-        source_outcome_group_id = obj_or_id(outcome_group, "outcome_group", (OutcomeGroup,))
+        source_outcome_group_id = obj_or_id(
+            outcome_group, "outcome_group", (OutcomeGroup,)
+        )
 
         response = self._requester.request(
-            'POST',
-            '{}/outcome_groups/{}/import'.format(self.context_ref(), self.id),
-            source_outcome_group_id=source_outcome_group_id
+            "POST",
+            "{}/outcome_groups/{}/import".format(self.context_ref(), self.id),
+            source_outcome_group_id=source_outcome_group_id,
         )
 
         return OutcomeGroup(self._requester, response.json())

--- a/canvasapi/page.py
+++ b/canvasapi/page.py
@@ -10,7 +10,6 @@ from canvasapi.util import combine_kwargs, obj_or_id
 
 @python_2_unicode_compatible
 class Page(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.title, self.url)
 
@@ -25,13 +24,13 @@ class Page(CanvasObject):
         :rtype: :class:`canvasapi.page.Page`
         """
         response = self._requester.request(
-            'PUT',
-            '{}s/{}/pages/{}'.format(self.parent_type, self.parent_id, self.url),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "{}s/{}/pages/{}".format(self.parent_type, self.parent_id, self.url),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         page_json = response.json()
-        page_json.update({'course_id': self.course_id})
+        page_json.update({"course_id": self.course_id})
         super(Page, self).set_attributes(page_json)
 
         return self
@@ -46,8 +45,7 @@ class Page(CanvasObject):
         :rtype: :class:`canvasapi.page.Page`
         """
         response = self._requester.request(
-            'DELETE',
-            'courses/{}/pages/{}'.format(self.course_id, self.url)
+            "DELETE", "courses/{}/pages/{}".format(self.course_id, self.url)
         )
         return Page(self._requester, response.json())
 
@@ -58,9 +56,9 @@ class Page(CanvasObject):
 
         :rtype: int
         """
-        if hasattr(self, 'course_id'):
+        if hasattr(self, "course_id"):
             return self.course_id
-        elif hasattr(self, 'group_id'):
+        elif hasattr(self, "group_id"):
             return self.group_id
         else:
             raise ValueError("Page does not have a course_id or group_id")
@@ -72,10 +70,10 @@ class Page(CanvasObject):
 
         :rtype: str
         """
-        if hasattr(self, 'course_id'):
-            return 'course'
-        elif hasattr(self, 'group_id'):
-            return 'group'
+        if hasattr(self, "course_id"):
+            return "course"
+        elif hasattr(self, "group_id"):
+            return "group"
         else:
             raise ValueError("ExternalTool does not have a course_id or group_id")
 
@@ -94,13 +92,12 @@ class Page(CanvasObject):
         from canvasapi.course import Course
 
         response = self._requester.request(
-            'GET',
-            '{}s/{}'.format(self.parent_type, self.parent_id)
+            "GET", "{}s/{}".format(self.parent_type, self.parent_id)
         )
 
-        if self.parent_type == 'group':
+        if self.parent_type == "group":
             return Group(self._requester, response.json())
-        elif self.parent_type == 'course':
+        elif self.parent_type == "course":
             return Course(self._requester, response.json())
 
     def show_latest_revision(self, **kwargs):
@@ -113,9 +110,11 @@ class Page(CanvasObject):
         :rtype: :class:`canvasapi.pagerevision.PageRevision`
         """
         response = self._requester.request(
-            'GET',
-            '{}s/{}/pages/{}/revisions/latest'.format(self.parent_type, self.parent_id, self.url),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "{}s/{}/pages/{}/revisions/latest".format(
+                self.parent_type, self.parent_id, self.url
+            ),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return PageRevision(self._requester, response.json())
 
@@ -135,20 +134,17 @@ class Page(CanvasObject):
         revision_id = obj_or_id(revision, "revision", (PageRevision,))
 
         response = self._requester.request(
-            'GET',
-            '{}s/{}/pages/{}/revisions/{}'.format(
-                self.parent_type,
-                self.parent_id,
-                self.url,
-                revision_id
+            "GET",
+            "{}s/{}/pages/{}/revisions/{}".format(
+                self.parent_type, self.parent_id, self.url, revision_id
             ),
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         pagerev_json = response.json()
         if self.parent_type == "group":
-            pagerev_json.update({'group_id': self.id})
+            pagerev_json.update({"group_id": self.id})
         elif self.parent_type == "course":
-            pagerev_json.update({'course_id': self.id})
+            pagerev_json.update({"course_id": self.id})
 
         return PageRevision(self._requester, pagerev_json)
 
@@ -169,7 +165,7 @@ class Page(CanvasObject):
         warnings.warn(
             "`list_revisions` is being deprecated and will be removed in a "
             "future version. Use `get_revisions` instead.",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_revisions(**kwargs)
@@ -187,9 +183,11 @@ class Page(CanvasObject):
         return PaginatedList(
             PageRevision,
             self._requester,
-            'GET',
-            '{}s/{}/pages/{}/revisions'.format(self.parent_type, self.parent_id, self.url),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "{}s/{}/pages/{}/revisions".format(
+                self.parent_type, self.parent_id, self.url
+            ),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def revert_to_revision(self, revision):
@@ -207,26 +205,22 @@ class Page(CanvasObject):
         """
         revision_id = obj_or_id(revision, "revision", (PageRevision,))
         response = self._requester.request(
-            'POST',
-            '{}s/{}/pages/{}/revisions/{}'.format(
-                self.parent_type,
-                self.parent_id,
-                self.url,
-                revision_id
+            "POST",
+            "{}s/{}/pages/{}/revisions/{}".format(
+                self.parent_type, self.parent_id, self.url, revision_id
             ),
         )
         pagerev_json = response.json()
         if self.parent_type == "group":
-            pagerev_json.update({'group_id': self.id})
+            pagerev_json.update({"group_id": self.id})
         elif self.parent_type == "course":
-            pagerev_json.update({'group_id': self.id})
+            pagerev_json.update({"group_id": self.id})
 
         return PageRevision(self._requester, pagerev_json)
 
 
 @python_2_unicode_compatible
 class PageRevision(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.updated_at, self.revision_id)
 
@@ -237,9 +231,9 @@ class PageRevision(CanvasObject):
 
         :rtype: int
         """
-        if hasattr(self, 'course_id'):
+        if hasattr(self, "course_id"):
             return self.course_id
-        elif hasattr(self, 'group_id'):
+        elif hasattr(self, "group_id"):
             return self.group_id
         else:
             raise ValueError("Page does not have a course_id or group_id")
@@ -251,10 +245,10 @@ class PageRevision(CanvasObject):
 
         :rtype: str
         """
-        if hasattr(self, 'course_id'):
-            return 'course'
-        elif hasattr(self, 'group_id'):
-            return 'group'
+        if hasattr(self, "course_id"):
+            return "course"
+        elif hasattr(self, "group_id"):
+            return "group"
         else:
             raise ValueError("ExternalTool does not have a course_id or group_id")
 
@@ -273,11 +267,10 @@ class PageRevision(CanvasObject):
         from canvasapi.course import Course
 
         response = self._requester.request(
-            'GET',
-            '{}s/{}'.format(self.parent_type, self.parent_id)
+            "GET", "{}s/{}".format(self.parent_type, self.parent_id)
         )
 
-        if self.parent_type == 'group':
+        if self.parent_type == "group":
             return Group(self._requester, response.json())
-        elif self.parent_type == 'course':
+        elif self.parent_type == "course":
             return Course(self._requester, response.json())

--- a/canvasapi/page_view.py
+++ b/canvasapi/page_view.py
@@ -7,6 +7,5 @@ from canvasapi.canvas_object import CanvasObject
 
 @python_2_unicode_compatible
 class PageView(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.context_type, self.id)

--- a/canvasapi/paginated_list.py
+++ b/canvasapi/paginated_list.py
@@ -9,8 +9,15 @@ class PaginatedList(object):
     """
 
     def __init__(
-        self, content_class, requester, request_method, first_url, extra_attribs=None,
-            _root=None, **kwargs):
+        self,
+        content_class,
+        requester,
+        request_method,
+        first_url,
+        extra_attribs=None,
+        _root=None,
+        **kwargs
+    ):
 
         self._elements = list()
 
@@ -18,7 +25,7 @@ class PaginatedList(object):
         self._content_class = content_class
         self._first_url = first_url
         self._first_params = kwargs or {}
-        self._first_params['per_page'] = kwargs.get('per_page', 100)
+        self._first_params["per_page"] = kwargs.get("per_page", 100)
         self._next_url = first_url
         self._next_params = self._first_params
         self._extra_attribs = extra_attribs or {}
@@ -61,17 +68,17 @@ class PaginatedList(object):
 
     def _get_next_page(self):
         response = self._requester.request(
-            self._request_method,
-            self._next_url,
-            **self._next_params
+            self._request_method, self._next_url, **self._next_params
         )
         data = response.json()
         self._next_url = None
 
-        next_link = response.links.get('next')
-        regex = r'{}(.*)'.format(re.escape(self._requester.base_url))
+        next_link = response.links.get("next")
+        regex = r"{}(.*)".format(re.escape(self._requester.base_url))
 
-        self._next_url = re.search(regex, next_link['url']).group(1) if next_link else None
+        self._next_url = (
+            re.search(regex, next_link["url"]).group(1) if next_link else None
+        )
 
         self._next_params = {}
 

--- a/canvasapi/progress.py
+++ b/canvasapi/progress.py
@@ -7,7 +7,6 @@ from canvasapi.canvas_object import CanvasObject
 
 @python_2_unicode_compatible
 class Progress(CanvasObject):
-
     def __str__(self):
         return "{} - {} ({})".format(self.tag, self.workflow_state, self.id)
 
@@ -20,10 +19,7 @@ class Progress(CanvasObject):
 
         :rtype: :class:`canvasapi.progress.Progress`
         """
-        response = self._requester.request(
-            'GET',
-            'progress/{}'.format(self.id)
-        )
+        response = self._requester.request("GET", "progress/{}".format(self.id))
         response_json = response.json()
 
         super(Progress, self).set_attributes(response_json)

--- a/canvasapi/quiz.py
+++ b/canvasapi/quiz.py
@@ -11,7 +11,6 @@ from canvasapi.util import combine_kwargs, obj_or_id
 
 @python_2_unicode_compatible
 class Quiz(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.title, self.id)
 
@@ -26,17 +25,23 @@ class Quiz(CanvasObject):
         :param conversations: Body and recipients to send the message to.
         :type :class: `canvasapi.quiz.QuizUserConversation`
 
-        """
+        :returns: True if the message was succesfully sent, False otherwise.
+        :rtype: :bool
 
+        """
         kwargs["conversations"] = conversations
 
-        return self._requester.request(
-            'POST',
-            'courses/{}/quizzes/{}/submission_users/message'.format(self.course_id, self.id),
-            _kwargs=combine_kwargs(**kwargs)
+        response = self._requester.request(
+            "POST",
+            "courses/{}/quizzes/{}/submission_users/message".format(
+                self.course_id, self.id
+            ),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
-        return
+        response = response.json()
+
+        return response["status"] == "created"
 
     def edit(self, **kwargs):
         """
@@ -49,12 +54,12 @@ class Quiz(CanvasObject):
         :rtype: :class:`canvasapi.quiz.Quiz`
         """
         response = self._requester.request(
-            'PUT',
-            'courses/{}/quizzes/{}'.format(self.course_id, self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "courses/{}/quizzes/{}".format(self.course_id, self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         quiz_json = response.json()
-        quiz_json.update({'course_id': self.course_id})
+        quiz_json.update({"course_id": self.course_id})
 
         return Quiz(self._requester, quiz_json)
 
@@ -68,12 +73,12 @@ class Quiz(CanvasObject):
         :rtype: :class:`canvasapi.quiz.Quiz`
         """
         response = self._requester.request(
-            'DELETE',
-            'courses/{}/quizzes/{}'.format(self.course_id, self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "DELETE",
+            "courses/{}/quizzes/{}".format(self.course_id, self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         quiz_json = response.json()
-        quiz_json.update({'course_id': self.course_id})
+        quiz_json.update({"course_id": self.course_id})
 
         return Quiz(self._requester, quiz_json)
 
@@ -92,13 +97,13 @@ class Quiz(CanvasObject):
         :rtype: :class:`canvasapi.quiz_group.QuizGroup`
         """
         response = self._requester.request(
-            'GET',
-            'courses/{}/quizzes/{}/groups/{}'.format(self.course_id, self.id, id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/quizzes/{}/groups/{}".format(self.course_id, self.id, id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         response_json = response.json()
-        response_json.update({'course_id': self.id})
+        response_json.update({"course_id": self.id})
 
         return QuizGroup(self._requester, response_json)
 
@@ -126,22 +131,27 @@ class Quiz(CanvasObject):
         if not isinstance(quiz_groups[0], dict):
             raise ValueError("Param `quiz_groups must contain a dictionary")
 
-        param_list = ['name', 'pick_count', 'question_points', 'assessment_question_bank_id']
+        param_list = [
+            "name",
+            "pick_count",
+            "question_points",
+            "assessment_question_bank_id",
+        ]
         if not any(param in quiz_groups[0] for param in param_list):
             raise RequiredFieldMissing("quiz_groups must contain at least 1 parameter.")
 
         kwargs["quiz_groups"] = quiz_groups
 
         response = self._requester.request(
-            'POST',
-            'courses/{}/quizzes/{}/groups'.format(self.course_id, self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "courses/{}/quizzes/{}/groups".format(self.course_id, self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         response_json = response.json()
-        response_json['quiz_groups'][0].update({'course_id': self.id})
+        response_json["quiz_groups"][0].update({"course_id": self.id})
 
-        return QuizGroup(self._requester, response_json.get('quiz_groups')[0])
+        return QuizGroup(self._requester, response_json.get("quiz_groups")[0])
 
     def create_question(self, **kwargs):
         """
@@ -154,12 +164,12 @@ class Quiz(CanvasObject):
         """
 
         response = self._requester.request(
-            'POST',
-            'courses/{}/quizzes/{}/questions'.format(self.course_id, self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "courses/{}/quizzes/{}/questions".format(self.course_id, self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         response_json = response.json()
-        response_json.update({'course_id': self.course_id})
+        response_json.update({"course_id": self.course_id})
 
         return QuizQuestion(self._requester, response_json)
 
@@ -178,16 +188,14 @@ class Quiz(CanvasObject):
         question_id = obj_or_id(question, "question", (QuizQuestion,))
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/quizzes/{}/questions/{}'.format(
-                self.course_id,
-                self.id,
-                question_id
+            "GET",
+            "courses/{}/quizzes/{}/questions/{}".format(
+                self.course_id, self.id, question_id
             ),
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         response_json = response.json()
-        response_json.update({'course_id': self.course_id})
+        response_json.update({"course_id": self.course_id})
 
         return QuizQuestion(self._requester, response_json)
 
@@ -204,10 +212,10 @@ class Quiz(CanvasObject):
         return PaginatedList(
             QuizQuestion,
             self._requester,
-            'GET',
-            'courses/{}/quizzes/{}/questions'.format(self.course_id, self.id),
-            {'course_id': self.course_id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/quizzes/{}/questions".format(self.course_id, self.id),
+            {"course_id": self.course_id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def set_extensions(self, quiz_extensions, **kwargs):
@@ -242,25 +250,27 @@ class Quiz(CanvasObject):
         """
 
         if not isinstance(quiz_extensions, list) or not quiz_extensions:
-            raise ValueError('Param `quiz_extensions` must be a non-empty list.')
+            raise ValueError("Param `quiz_extensions` must be a non-empty list.")
 
         if any(not isinstance(extension, dict) for extension in quiz_extensions):
-            raise ValueError('Param `quiz_extensions` must only contain dictionaries')
+            raise ValueError("Param `quiz_extensions` must only contain dictionaries")
 
-        if any('user_id' not in extension for extension in quiz_extensions):
+        if any("user_id" not in extension for extension in quiz_extensions):
             raise RequiredFieldMissing(
-                'Dictionaries in `quiz_extensions` must contain key `user_id`'
+                "Dictionaries in `quiz_extensions` must contain key `user_id`"
             )
 
-        kwargs['quiz_extensions'] = quiz_extensions
+        kwargs["quiz_extensions"] = quiz_extensions
 
         response = self._requester.request(
-            'POST',
-            'courses/{}/quizzes/{}/extensions'.format(self.course_id, self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "courses/{}/quizzes/{}/extensions".format(self.course_id, self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
-        extension_list = response.json()['quiz_extensions']
-        return [QuizExtension(self._requester, extension) for extension in extension_list]
+        extension_list = response.json()["quiz_extensions"]
+        return [
+            QuizExtension(self._requester, extension) for extension in extension_list
+        ]
 
     def get_all_quiz_submissions(self, **kwargs):
         """
@@ -272,16 +282,16 @@ class Quiz(CanvasObject):
         :rtype: list of :class:`canvasapi.quiz.QuizSubmission`
         """
         response = self._requester.request(
-            'GET',
-            'courses/{}/quizzes/{}/submissions'.format(
-                self.course_id,
-                self.id
-            ),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "courses/{}/quizzes/{}/submissions".format(self.course_id, self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
-        submission_list = response.json()['quiz_submissions']
+        submission_list = response.json()["quiz_submissions"]
 
-        return [QuizSubmission(self._requester, submission) for submission in submission_list]
+        return [
+            QuizSubmission(self._requester, submission)
+            for submission in submission_list
+        ]
 
     def get_quiz_submission(self, quiz_submission, **kwargs):
         """
@@ -295,20 +305,20 @@ class Quiz(CanvasObject):
 
         :rtype: :class:`canvasapi.quiz.QuizSubmission`
         """
-        quiz_submission_id = obj_or_id(quiz_submission, "quiz_submission", (QuizSubmission,))
+        quiz_submission_id = obj_or_id(
+            quiz_submission, "quiz_submission", (QuizSubmission,)
+        )
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/quizzes/{}/submissions/{}'.format(
-                self.course_id,
-                self.id,
-                quiz_submission_id
+            "GET",
+            "courses/{}/quizzes/{}/submissions/{}".format(
+                self.course_id, self.id, quiz_submission_id
             ),
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         response_json = response.json()["quiz_submissions"][0]
-        response_json.update({'course_id': self.course_id})
+        response_json.update({"course_id": self.course_id})
 
         return QuizSubmission(self._requester, response_json)
 
@@ -323,23 +333,19 @@ class Quiz(CanvasObject):
         :rtype: :class:`canvasapi.quiz.QuizSubmission`
         """
         response = self._requester.request(
-            'POST',
-            'courses/{}/quizzes/{}/submissions'.format(
-                self.course_id,
-                self.id
-            ),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "courses/{}/quizzes/{}/submissions".format(self.course_id, self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         response_json = response.json()["quiz_submissions"][0]
-        response_json.update({'course_id': self.course_id})
+        response_json.update({"course_id": self.course_id})
 
         return QuizSubmission(self._requester, response_json)
 
 
 @python_2_unicode_compatible
 class QuizSubmission(CanvasObject):
-
     def __str__(self):
         return "{}-{}".format(self.quiz_id, self.user_id)
 
@@ -353,23 +359,23 @@ class QuizSubmission(CanvasObject):
 
         :rtype: :class:`canvasapi.quiz.QuizSubmission`
         """
-        if 'attempt' in kwargs:
+        if "attempt" in kwargs:
             raise ValueError("Key `attempt` provided by Canvas, should not be set.")
 
-        if 'validation_token' in kwargs:
-            raise ValueError("Key `validation_token` provided by Canvas, should not be set.")
+        if "validation_token" in kwargs:
+            raise ValueError(
+                "Key `validation_token` provided by Canvas, should not be set."
+            )
 
-        kwargs['attempt'] = self.attempt
-        kwargs['validation_token'] = self.validation_token
+        kwargs["attempt"] = self.attempt
+        kwargs["validation_token"] = self.validation_token
 
         response = self._requester.request(
-            'POST',
-            'courses/{}/quizzes/{}/submissions/{}/complete'.format(
-                self.course_id,
-                self.quiz_id,
-                self.id
+            "POST",
+            "courses/{}/quizzes/{}/submissions/{}/complete".format(
+                self.course_id, self.quiz_id, self.id
             ),
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         response_json = response.json()["quiz_submissions"][0]
@@ -385,17 +391,15 @@ class QuizSubmission(CanvasObject):
 
         :rtype: dict
         """
-        if 'attempt' in kwargs:
+        if "attempt" in kwargs:
             raise ValueError("Key `attempt` provided by Canvas, should not be set.")
 
         response = self._requester.request(
-            'GET',
-            'courses/{}/quizzes/{}/submissions/{}/time'.format(
-                self.course_id,
-                self.quiz_id,
-                self.id
+            "GET",
+            "courses/{}/quizzes/{}/submissions/{}/time".format(
+                self.course_id, self.quiz_id, self.id
             ),
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         return response.json()
@@ -413,13 +417,11 @@ class QuizSubmission(CanvasObject):
         :rtype: :class:`canvasapi.quiz.QuizSubmission`
         """
         response = self._requester.request(
-            'PUT',
-            'courses/{}/quizzes/{}/submissions/{}'.format(
-                self.course_id,
-                self.quiz_id,
-                self.id
+            "PUT",
+            "courses/{}/quizzes/{}/submissions/{}".format(
+                self.course_id, self.quiz_id, self.id
             ),
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         response_json = response.json()["quiz_submissions"][0]
 
@@ -428,14 +430,12 @@ class QuizSubmission(CanvasObject):
 
 @python_2_unicode_compatible
 class QuizExtension(CanvasObject):
-
     def __str__(self):
         return "{}-{}".format(self.quiz_id, self.user_id)
 
 
 @python_2_unicode_compatible
 class QuizQuestion(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.question_name, self.id)
 
@@ -450,13 +450,11 @@ class QuizQuestion(CanvasObject):
         :rtype: bool
         """
         response = self._requester.request(
-            'DELETE',
-            'courses/{}/quizzes/{}/questions/{}'.format(
-                self.course_id,
-                self.quiz_id,
-                self.id
+            "DELETE",
+            "courses/{}/quizzes/{}/questions/{}".format(
+                self.course_id, self.quiz_id, self.id
             ),
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         return response.status_code == 204
@@ -471,16 +469,14 @@ class QuizQuestion(CanvasObject):
         :rtype: :class:`canvasapi.quiz.QuizQuestion`
         """
         response = self._requester.request(
-            'PUT',
-            'courses/{}/quizzes/{}/questions/{}'.format(
-                self.course_id,
-                self.quiz_id,
-                self.id
+            "PUT",
+            "courses/{}/quizzes/{}/questions/{}".format(
+                self.course_id, self.quiz_id, self.id
             ),
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         response_json = response.json()
-        response_json.update({'course_id': self.course_id})
+        response_json.update({"course_id": self.course_id})
 
         super(QuizQuestion, self).set_attributes(response_json)
         return self

--- a/canvasapi/quiz.py
+++ b/canvasapi/quiz.py
@@ -15,6 +15,29 @@ class Quiz(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.title, self.id)
 
+    def broadcast_message(self, conversations, **kwargs):
+        """
+        Send a message to unsubmitted or submitted users for the quiz.
+
+        :calls: `POST /api/v1/courses/:course_id/quizzes/:id/submission_users/message\
+        <https://canvas.instructure.com/doc/api/quiz_submission_user_list.html#method.\
+        quizzes/quiz_submission_users.message>`_
+
+        :param conversations: Body and recipients to send the message to.
+        :type :class: `canvasapi.quiz.QuizUserConversation`
+
+        """
+
+        kwargs["conversations"] = conversations
+
+        return self._requester.request(
+            'POST',
+            'courses/{}/quizzes/{}/submission_users/message'.format(self.course_id, self.id),
+            _kwargs=combine_kwargs(**kwargs)
+        )
+
+        return
+
     def edit(self, **kwargs):
         """
         Modify this quiz.

--- a/canvasapi/quiz_group.py
+++ b/canvasapi/quiz_group.py
@@ -9,7 +9,6 @@ from canvasapi.util import combine_kwargs
 
 @python_2_unicode_compatible
 class QuizGroup(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.name, self.id)
 
@@ -37,21 +36,21 @@ class QuizGroup(CanvasObject):
         if not isinstance(quiz_groups[0], dict):
             raise ValueError("Param `quiz_groups` must contain a dictionary")
 
-        param_list = ['name', 'pick_count', 'question_points']
+        param_list = ["name", "pick_count", "question_points"]
         if not any(param in quiz_groups[0] for param in param_list):
             raise RequiredFieldMissing("quiz_groups must contain at least 1 parameter.")
 
         kwargs["quiz_groups"] = quiz_groups
 
         response = self._requester.request(
-            'PUT',
-            'courses/{}/quizzes/{}/groups/{}'.format(self.course_id, self.quiz_id, id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "courses/{}/quizzes/{}/groups/{}".format(self.course_id, self.quiz_id, id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
-        successful = 'name' in response.json().get('quiz_groups')[0]
+        successful = "name" in response.json().get("quiz_groups")[0]
         if successful:
-            super(QuizGroup, self).set_attributes(response.json().get('quiz_groups')[0])
+            super(QuizGroup, self).set_attributes(response.json().get("quiz_groups")[0])
 
         return successful
 
@@ -69,10 +68,10 @@ class QuizGroup(CanvasObject):
         :rtype: bool
         """
         response = self._requester.request(
-            'DELETE',
-            'courses/{}/quizzes/{}/groups/{}'.format(self.course_id, self.quiz_id, id)
+            "DELETE",
+            "courses/{}/quizzes/{}/groups/{}".format(self.course_id, self.quiz_id, id),
         )
-        return (response.status_code == 204)
+        return response.status_code == 204
 
     def reorder_question_group(self, id, order, **kwargs):
         """
@@ -106,9 +105,11 @@ class QuizGroup(CanvasObject):
         kwargs["order"] = order
 
         response = self._requester.request(
-            'POST',
-            'courses/{}/quizzes/{}/groups/{}/reorder'.format(self.course_id, self.quiz_id, id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "courses/{}/quizzes/{}/groups/{}/reorder".format(
+                self.course_id, self.quiz_id, id
+            ),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
-        return (response.status_code == 204)
+        return response.status_code == 204

--- a/canvasapi/requester.py
+++ b/canvasapi/requester.py
@@ -4,8 +4,13 @@ from datetime import datetime
 import requests
 
 from canvasapi.exceptions import (
-    BadRequest, CanvasException, Conflict, Forbidden, InvalidAccessToken,
-    ResourceDoesNotExist, Unauthorized
+    BadRequest,
+    CanvasException,
+    Conflict,
+    Forbidden,
+    InvalidAccessToken,
+    ResourceDoesNotExist,
+    Unauthorized,
 )
 
 
@@ -27,8 +32,15 @@ class Requester(object):
         self._cache = []
 
     def request(
-            self, method, endpoint=None, headers=None, use_auth=True,
-            _url=None, _kwargs=None, **kwargs):
+        self,
+        method,
+        endpoint=None,
+        headers=None,
+        use_auth=True,
+        _url=None,
+        _kwargs=None,
+        **kwargs
+    ):
         """
         Make a request to the Canvas API and return the response.
 
@@ -57,7 +69,7 @@ class Requester(object):
             headers = {}
 
         if use_auth:
-            auth_header = {'Authorization': 'Bearer {}'.format(self.access_token)}
+            auth_header = {"Authorization": "Bearer {}".format(self.access_token)}
             headers.update(auth_header)
 
         # Convert kwargs into list of 2-tuples and combine with _kwargs.
@@ -77,13 +89,13 @@ class Requester(object):
                 _kwargs[i] = (kw, arg.isoformat())
 
         # Determine the appropriate request method.
-        if method == 'GET':
+        if method == "GET":
             req_method = self._get_request
-        elif method == 'POST':
+        elif method == "POST":
             req_method = self._post_request
-        elif method == 'DELETE':
+        elif method == "DELETE":
             req_method = self._delete_request
-        elif method == 'PUT':
+        elif method == "PUT":
             req_method = self._put_request
 
         # Call the request method
@@ -99,14 +111,14 @@ class Requester(object):
         if response.status_code == 400:
             raise BadRequest(response.text)
         elif response.status_code == 401:
-            if 'WWW-Authenticate' in response.headers:
+            if "WWW-Authenticate" in response.headers:
                 raise InvalidAccessToken(response.json())
             else:
                 raise Unauthorized(response.json())
         elif response.status_code == 403:
             raise Forbidden(response.text)
         elif response.status_code == 404:
-            raise ResourceDoesNotExist('Not Found')
+            raise ResourceDoesNotExist("Not Found")
         elif response.status_code == 409:
             raise Conflict(response.text)
         elif response.status_code == 500:
@@ -136,12 +148,12 @@ class Requester(object):
         # Grab file from data.
         file = None
         for tup in data:
-            if tup[0] == 'file':
-                file = {'file': tup[1]}
+            if tup[0] == "file":
+                file = {"file": tup[1]}
                 break
 
         # Remove file entry from data.
-        data[:] = [tup for tup in data if tup[0] != 'file']
+        data[:] = [tup for tup in data if tup[0] != "file"]
 
         return self._session.post(url, headers=headers, data=data, files=file)
 

--- a/canvasapi/rubric.py
+++ b/canvasapi/rubric.py
@@ -7,6 +7,5 @@ from canvasapi.canvas_object import CanvasObject
 
 @python_2_unicode_compatible
 class Rubric(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.title, self.id)

--- a/canvasapi/section.py
+++ b/canvasapi/section.py
@@ -9,18 +9,13 @@ from canvasapi.progress import Progress
 from canvasapi.submission import Submission
 from canvasapi.util import combine_kwargs, obj_or_id
 
-warnings.simplefilter('always', DeprecationWarning)
+warnings.simplefilter("always", DeprecationWarning)
 
 
 @python_2_unicode_compatible
 class Section(CanvasObject):
-
     def __str__(self):
-        return '{} - {} ({})'.format(
-            self.name,
-            self.course_id,
-            self.id,
-        )
+        return "{} - {} ({})".format(self.name, self.course_id, self.id)
 
     def get_assignment_override(self, assignment, **kwargs):
         """
@@ -39,11 +34,10 @@ class Section(CanvasObject):
         assignment_id = obj_or_id(assignment, "assignment", (Assignment,))
 
         response = self._requester.request(
-            'GET',
-            'sections/{}/assignments/{}/override'.format(self.id, assignment_id)
+            "GET", "sections/{}/assignments/{}/override".format(self.id, assignment_id)
         )
         response_json = response.json()
-        response_json.update({'course_id': self.course_id})
+        response_json.update({"course_id": self.course_id})
 
         return AssignmentOverride(self._requester, response_json)
 
@@ -62,9 +56,9 @@ class Section(CanvasObject):
         return PaginatedList(
             Enrollment,
             self._requester,
-            'GET',
-            'sections/{}/enrollments'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "sections/{}/enrollments".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def cross_list_section(self, new_course):
@@ -84,8 +78,7 @@ class Section(CanvasObject):
         new_course_id = obj_or_id(new_course, "new_course", (Course,))
 
         response = self._requester.request(
-            'POST',
-            'sections/{}/crosslist/{}'.format(self.id, new_course_id)
+            "POST", "sections/{}/crosslist/{}".format(self.id, new_course_id)
         )
         return Section(self._requester, response.json())
 
@@ -99,8 +92,7 @@ class Section(CanvasObject):
         :rtype: :class:`canvasapi.section.Section`
         """
         response = self._requester.request(
-            'DELETE',
-            'sections/{}/crosslist'.format(self.id)
+            "DELETE", "sections/{}/crosslist".format(self.id)
         )
         return Section(self._requester, response.json())
 
@@ -114,12 +106,10 @@ class Section(CanvasObject):
         :rtype: :class:`canvasapi.section.Section`
         """
         response = self._requester.request(
-            'PUT',
-            'sections/{}'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT", "sections/{}".format(self.id), _kwargs=combine_kwargs(**kwargs)
         )
 
-        if 'name' in response.json():
+        if "name" in response.json():
             super(Section, self).set_attributes(response.json())
 
         return self
@@ -133,10 +123,7 @@ class Section(CanvasObject):
 
         :rtype: :class:`canvasapi.section.Section`
         """
-        response = self._requester.request(
-            'DELETE',
-            'sections/{}'.format(self.id)
-        )
+        response = self._requester.request("DELETE", "sections/{}".format(self.id))
         return Section(self._requester, response.json())
 
     def submit_assignment(self, assignment, submission, **kwargs):
@@ -160,17 +147,16 @@ class Section(CanvasObject):
         from canvasapi.assignment import Assignment
 
         warnings.warn(
-            'Section.submit_assignment() is deprecated and will be removed '
-            'in the future. Use Assignment.submit() instead.',
-            DeprecationWarning
+            "Section.submit_assignment() is deprecated and will be removed "
+            "in the future. Use Assignment.submit() instead.",
+            DeprecationWarning,
         )
 
         assignment_id = obj_or_id(assignment, "assignment", (Assignment,))
-        assignment = Assignment(self._requester, {
-            'course_id': self.course_id,
-            'section_id': self.id,
-            'id': assignment_id
-        })
+        assignment = Assignment(
+            self._requester,
+            {"course_id": self.course_id, "section_id": self.id, "id": assignment_id},
+        )
         return assignment.submit(submission, **kwargs)
 
     def list_submissions(self, assignment, **kwargs):
@@ -193,17 +179,16 @@ class Section(CanvasObject):
         from canvasapi.assignment import Assignment
 
         warnings.warn(
-            'Section.list_submissions() is deprecated and will be removed '
-            'in the future. Use Assignment.get_submissions() instead.',
-            DeprecationWarning
+            "Section.list_submissions() is deprecated and will be removed "
+            "in the future. Use Assignment.get_submissions() instead.",
+            DeprecationWarning,
         )
 
         assignment_id = obj_or_id(assignment, "assignment", (Assignment,))
-        assignment = Assignment(self._requester, {
-            'course_id': self.course_id,
-            'section_id': self.id,
-            'id': assignment_id
-        })
+        assignment = Assignment(
+            self._requester,
+            {"course_id": self.course_id, "section_id": self.id, "id": assignment_id},
+        )
 
         return assignment.get_submissions(**kwargs)
 
@@ -226,7 +211,7 @@ class Section(CanvasObject):
             "`list_multiple_submissions`"
             " is being deprecated and will be removed in a future version."
             " Use `get_multiple_submissions` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_multiple_submissions(**kwargs)
@@ -242,17 +227,19 @@ class Section(CanvasObject):
         :rtype: :class:`canvasapi.paginated_list.PaginatedList` of
             :class:`canvasapi.submission.Submission`
         """
-        if 'grouped' in kwargs:
-            warnings.warn('The `grouped` parameter must be empty. Removing kwarg `grouped`.')
-            del kwargs['grouped']
+        if "grouped" in kwargs:
+            warnings.warn(
+                "The `grouped` parameter must be empty. Removing kwarg `grouped`."
+            )
+            del kwargs["grouped"]
 
         return PaginatedList(
             Submission,
             self._requester,
-            'GET',
-            'sections/{}/students/submissions'.format(self.id),
-            {'section_id': self.id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "sections/{}/students/submissions".format(self.id),
+            {"section_id": self.id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_submission(self, assignment, user, **kwargs):
@@ -276,18 +263,17 @@ class Section(CanvasObject):
         from canvasapi.assignment import Assignment
 
         warnings.warn(
-            'Section.get_submission() is deprecated and will be removed '
-            'in the future. Use Assignment.get_submission() instead.',
-            DeprecationWarning
+            "Section.get_submission() is deprecated and will be removed "
+            "in the future. Use Assignment.get_submission() instead.",
+            DeprecationWarning,
         )
 
         assignment_id = obj_or_id(assignment, "assignment", (Assignment,))
 
-        assignment = Assignment(self._requester, {
-            'course_id': self.course_id,
-            'section_id': self.id,
-            'id': assignment_id
-        })
+        assignment = Assignment(
+            self._requester,
+            {"course_id": self.course_id, "section_id": self.id, "id": assignment_id},
+        )
 
         return assignment.get_submission(user, **kwargs)
 
@@ -313,19 +299,22 @@ class Section(CanvasObject):
         from canvasapi.user import User
 
         warnings.warn(
-            'Section.update_submission() is deprecated and will be removed '
-            'in the future. Use Submission.edit() instead.',
-            DeprecationWarning
+            "Section.update_submission() is deprecated and will be removed "
+            "in the future. Use Submission.edit() instead.",
+            DeprecationWarning,
         )
 
         assignment_id = obj_or_id(assignment, "assignment", (Assignment,))
         user_id = obj_or_id(user, "user", (User,))
 
-        submission = Submission(self._requester, {
-            'course_id': self.course_id,
-            'assignment_id': assignment_id,
-            'user_id': user_id
-        })
+        submission = Submission(
+            self._requester,
+            {
+                "course_id": self.course_id,
+                "assignment_id": assignment_id,
+                "user_id": user_id,
+            },
+        )
 
         return submission.edit(**kwargs)
 
@@ -352,19 +341,22 @@ class Section(CanvasObject):
         from canvasapi.user import User
 
         warnings.warn(
-            'Section.mark_submission_as_read() is deprecated and will be '
-            'removed in the future. Use Submission.mark_read() instead.',
-            DeprecationWarning
+            "Section.mark_submission_as_read() is deprecated and will be "
+            "removed in the future. Use Submission.mark_read() instead.",
+            DeprecationWarning,
         )
 
         assignment_id = obj_or_id(assignment, "assignment", (Assignment,))
         user_id = obj_or_id(user, "user", (User,))
 
-        submission = Submission(self._requester, {
-            'course_id': self.course_id,
-            'assignment_id': assignment_id,
-            'user_id': user_id
-        })
+        submission = Submission(
+            self._requester,
+            {
+                "course_id": self.course_id,
+                "assignment_id": assignment_id,
+                "user_id": user_id,
+            },
+        )
         return submission.mark_read(**kwargs)
 
     def mark_submission_as_unread(self, assignment, user, **kwargs):
@@ -390,19 +382,22 @@ class Section(CanvasObject):
         from canvasapi.user import User
 
         warnings.warn(
-            'Section.mark_submission_as_unread() is deprecated and will be '
-            'removed in the future. Use Submission.mark_unread() instead.',
-            DeprecationWarning
+            "Section.mark_submission_as_unread() is deprecated and will be "
+            "removed in the future. Use Submission.mark_unread() instead.",
+            DeprecationWarning,
         )
 
         assignment_id = obj_or_id(assignment, "assignment", (Assignment,))
         user_id = obj_or_id(user, "user", (User,))
 
-        submission = Submission(self._requester, {
-            'course_id': self.course_id,
-            'assignment_id': assignment_id,
-            'user_id': user_id
-        })
+        submission = Submission(
+            self._requester,
+            {
+                "course_id": self.course_id,
+                "assignment_id": assignment_id,
+                "user_id": user_id,
+            },
+        )
         return submission.mark_unread(**kwargs)
 
     def submissions_bulk_update(self, **kwargs):
@@ -416,10 +411,8 @@ class Section(CanvasObject):
         :rtype: :class:`canvasapi.progress.Progress`
         """
         response = self._requester.request(
-            'POST',
-            'sections/{}/submissions/update_grades'.format(
-                self.id
-            ),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "sections/{}/submissions/update_grades".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return Progress(self._requester, response.json())

--- a/canvasapi/submission.py
+++ b/canvasapi/submission.py
@@ -9,9 +9,8 @@ from canvasapi.util import combine_kwargs
 
 @python_2_unicode_compatible
 class Submission(CanvasObject):
-
     def __str__(self):
-        return '{}-{}'.format(self.assignment_id, self.user_id)
+        return "{}-{}".format(self.assignment_id, self.user_id)
 
     def edit(self, **kwargs):
         """
@@ -23,13 +22,11 @@ class Submission(CanvasObject):
         :rtype: :class:`canvasapi.submission.Submission`
         """
         response = self._requester.request(
-            'PUT',
-            'courses/{}/assignments/{}/submissions/{}'.format(
-                self.course_id,
-                self.assignment_id,
-                self.user_id
+            "PUT",
+            "courses/{}/assignments/{}/submissions/{}".format(
+                self.course_id, self.assignment_id, self.user_id
             ),
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         response_json = response.json()
         response_json.update(course_id=self.course_id)
@@ -49,12 +46,10 @@ class Submission(CanvasObject):
         :rtype: bool
         """
         response = self._requester.request(
-            'PUT',
-            'courses/{}/assignments/{}/submissions/{}/read'.format(
-                self.course_id,
-                self.assignment_id,
-                self.user_id
-            )
+            "PUT",
+            "courses/{}/assignments/{}/submissions/{}/read".format(
+                self.course_id, self.assignment_id, self.user_id
+            ),
         )
         return response.status_code == 204
 
@@ -70,12 +65,10 @@ class Submission(CanvasObject):
         :rtype: bool
         """
         response = self._requester.request(
-            'DELETE',
-            'courses/{}/assignments/{}/submissions/{}/read'.format(
-                self.course_id,
-                self.assignment_id,
-                self.user_id
-            )
+            "DELETE",
+            "courses/{}/assignments/{}/submissions/{}/read".format(
+                self.course_id, self.assignment_id, self.user_id
+            ),
         )
         return response.status_code == 204
 
@@ -95,20 +88,14 @@ class Submission(CanvasObject):
         """
         response = Uploader(
             self._requester,
-            'courses/{}/assignments/{}/submissions/{}/comments/files'.format(
-                self.course_id,
-                self.assignment_id,
-                self.user_id
+            "courses/{}/assignments/{}/submissions/{}/comments/files".format(
+                self.course_id, self.assignment_id, self.user_id
             ),
             file,
             **kwargs
         ).start()
 
         if response[0]:
-            self.edit(
-                comment={
-                    'file_ids': [response[1]['id']]
-                }
-            )
+            self.edit(comment={"file_ids": [response[1]["id"]]})
 
         return response

--- a/canvasapi/tab.py
+++ b/canvasapi/tab.py
@@ -8,7 +8,6 @@ from canvasapi.util import combine_kwargs
 
 @python_2_unicode_compatible
 class Tab(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.label, self.id)
 
@@ -24,16 +23,16 @@ class Tab(CanvasObject):
 
         :rtype: :class:`canvasapi.tab.Tab`
         """
-        if not hasattr(self, 'course_id'):
-            raise ValueError('Can only update tabs from a Course.')
+        if not hasattr(self, "course_id"):
+            raise ValueError("Can only update tabs from a Course.")
 
         response = self._requester.request(
-            'PUT',
-            'courses/{}/tabs/{}'.format(self.course_id, self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT",
+            "courses/{}/tabs/{}".format(self.course_id, self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         response_json = response.json()
-        response_json.update({'course_id': self.course_id})
+        response_json.update({"course_id": self.course_id})
 
         super(Tab, self).set_attributes(response.json())
 

--- a/canvasapi/upload.py
+++ b/canvasapi/upload.py
@@ -23,7 +23,7 @@ class Uploader(object):
         """
         if isinstance(file, string_types):
             if not os.path.exists(file):
-                raise IOError('File ' + file + ' does not exist.')
+                raise IOError("File " + file + " does not exist.")
             self._using_filename = True
         else:
             self._using_filename = False
@@ -44,7 +44,7 @@ class Uploader(object):
         :rtype: tuple
         """
         if self._using_filename:
-            with open(self.file, 'rb') as file:
+            with open(self.file, "rb") as file:
                 return self.request_upload_token(file)
         else:
             return self.request_upload_token(self.file)
@@ -58,13 +58,11 @@ class Uploader(object):
             and the JSON response from the API.
         :rtype: tuple
         """
-        self.kwargs['name'] = os.path.basename(file.name)
-        self.kwargs['size'] = os.fstat(file.fileno()).st_size
+        self.kwargs["name"] = os.path.basename(file.name)
+        self.kwargs["size"] = os.fstat(file.fileno()).st_size
 
         response = self._requester.request(
-            'POST',
-            self.url,
-            _kwargs=combine_kwargs(**self.kwargs)
+            "POST", self.url, _kwargs=combine_kwargs(**self.kwargs)
         )
 
         return self.upload(response, file)
@@ -81,23 +79,23 @@ class Uploader(object):
         :rtype: tuple
         """
         response = response.json()
-        if not response.get('upload_url'):
-            raise ValueError('Bad API response. No upload_url.')
+        if not response.get("upload_url"):
+            raise ValueError("Bad API response. No upload_url.")
 
-        if not response.get('upload_params'):
-            raise ValueError('Bad API response. No upload_params.')
+        if not response.get("upload_params"):
+            raise ValueError("Bad API response. No upload_params.")
 
-        kwargs = response.get('upload_params')
+        kwargs = response.get("upload_params")
 
         response = self._requester.request(
-            'POST',
+            "POST",
             use_auth=False,
-            _url=response.get('upload_url'),
+            _url=response.get("upload_url"),
             file=file,
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         # remove `while(1);` that may appear at the top of a response
-        response_json = json.loads(response.text.lstrip('while(1);'))
+        response_json = json.loads(response.text.lstrip("while(1);"))
 
-        return ('url' in response_json, response_json)
+        return ("url" in response_json, response_json)

--- a/canvasapi/user.py
+++ b/canvasapi/user.py
@@ -14,7 +14,6 @@ from canvasapi.util import combine_kwargs, obj_or_id
 
 @python_2_unicode_compatible
 class User(CanvasObject):
-
     def __str__(self):
         return "{} ({})".format(self.name, self.id)
 
@@ -27,10 +26,7 @@ class User(CanvasObject):
 
         :rtype: dict
         """
-        response = self._requester.request(
-            'GET',
-            'users/{}/profile'.format(self.id)
-        )
+        response = self._requester.request("GET", "users/{}/profile".format(self.id))
         return response.json()
 
     def get_page_views(self, **kwargs):
@@ -48,9 +44,9 @@ class User(CanvasObject):
         return PaginatedList(
             PageView,
             self._requester,
-            'GET',
-            'users/{}/page_views'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "users/{}/page_views".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_courses(self, **kwargs):
@@ -68,9 +64,9 @@ class User(CanvasObject):
         return PaginatedList(
             Course,
             self._requester,
-            'GET',
-            'users/{}/courses'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "users/{}/courses".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_missing_submissions(self):
@@ -89,8 +85,8 @@ class User(CanvasObject):
         return PaginatedList(
             Assignment,
             self._requester,
-            'GET',
-            'users/{}/missing_submissions'.format(self.id)
+            "GET",
+            "users/{}/missing_submissions".format(self.id),
         )
 
     def update_settings(self, **kwargs):
@@ -103,9 +99,7 @@ class User(CanvasObject):
         :rtype: dict
         """
         response = self._requester.request(
-            'PUT',
-            'users/{}/settings'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT", "users/{}/settings".format(self.id), _kwargs=combine_kwargs(**kwargs)
         )
         return response.json()
 
@@ -123,8 +117,7 @@ class User(CanvasObject):
         :rtype: dict
         """
         response = self._requester.request(
-            'GET',
-            'users/{}/colors/{}'.format(self.id, asset_string)
+            "GET", "users/{}/colors/{}".format(self.id, asset_string)
         )
         return response.json()
 
@@ -137,10 +130,7 @@ class User(CanvasObject):
 
         :rtype: dict
         """
-        response = self._requester.request(
-            'GET',
-            'users/{}/colors'.format(self.id)
-        )
+        response = self._requester.request("GET", "users/{}/colors".format(self.id))
         return response.json()
 
     def update_color(self, asset_string, hexcode):
@@ -162,9 +152,7 @@ class User(CanvasObject):
         :rtype: dict
         """
         response = self._requester.request(
-            'PUT',
-            'users/{}/colors/{}'.format(self.id, asset_string),
-            hexcode=hexcode
+            "PUT", "users/{}/colors/{}".format(self.id, asset_string), hexcode=hexcode
         )
         return response.json()
 
@@ -178,9 +166,7 @@ class User(CanvasObject):
         :rtype: :class:`canvasapi.user.User`
         """
         response = self._requester.request(
-            'PUT',
-            'users/{}'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "PUT", "users/{}".format(self.id), _kwargs=combine_kwargs(**kwargs)
         )
         super(User, self).set_attributes(response.json())
         return self
@@ -197,11 +183,10 @@ class User(CanvasObject):
 
         :rtype: :class:`canvasapi.user.User`
         """
-        dest_user_id = obj_or_id(destination_user, 'destination_user', (User, ))
+        dest_user_id = obj_or_id(destination_user, "destination_user", (User,))
 
         response = self._requester.request(
-            'PUT',
-            'users/{}/merge_into/{}'.format(self.id, dest_user_id),
+            "PUT", "users/{}/merge_into/{}".format(self.id, dest_user_id)
         )
         super(User, self).set_attributes(response.json())
         return self
@@ -219,10 +204,7 @@ class User(CanvasObject):
         from canvasapi.avatar import Avatar
 
         return PaginatedList(
-            Avatar,
-            self._requester,
-            'GET',
-            'users/{}/avatars'.format(self.id)
+            Avatar, self._requester, "GET", "users/{}/avatars".format(self.id)
         )
 
     def get_assignments(self, course, **kwargs):
@@ -247,9 +229,9 @@ class User(CanvasObject):
         return PaginatedList(
             Assignment,
             self._requester,
-            'GET',
-            'users/{}/courses/{}/assignments'.format(self.id, course_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "users/{}/courses/{}/assignments".format(self.id, course_id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_enrollments(self, **kwargs):
@@ -267,9 +249,9 @@ class User(CanvasObject):
         return PaginatedList(
             Enrollment,
             self._requester,
-            'GET',
-            'users/{}/enrollments'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "users/{}/enrollments".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def upload(self, file, **kwargs):
@@ -290,10 +272,7 @@ class User(CanvasObject):
         :rtype: tuple
         """
         return Uploader(
-            self._requester,
-            'users/{}/files'.format(self.id),
-            file,
-            **kwargs
+            self._requester, "users/{}/files".format(self.id), file, **kwargs
         ).start()
 
     def list_calendar_events_for_user(self, **kwargs):
@@ -314,7 +293,7 @@ class User(CanvasObject):
             "`list_calendar_events_for_user`"
             " is being deprecated and will be removed in a future version."
             " Use `get_calendar_events_for_user` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_calendar_events_for_user(**kwargs)
@@ -332,9 +311,9 @@ class User(CanvasObject):
         return PaginatedList(
             CalendarEvent,
             self._requester,
-            'GET',
-            'users/{}/calendar_events'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "users/{}/calendar_events".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def list_communication_channels(self, **kwargs):
@@ -356,7 +335,7 @@ class User(CanvasObject):
             "`list_communication_channels`"
             " is being deprecated and will be removed in a future version."
             " Use `get_communication_channels` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_communication_channels(**kwargs)
@@ -375,9 +354,9 @@ class User(CanvasObject):
         return PaginatedList(
             CommunicationChannel,
             self._requester,
-            'GET',
-            'users/{}/communication_channels'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "users/{}/communication_channels".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def list_files(self, **kwargs):
@@ -397,7 +376,7 @@ class User(CanvasObject):
         warnings.warn(
             "`list_files` is being deprecated and will be removed in a future "
             "version. Use `get_files` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_files(**kwargs)
@@ -417,9 +396,9 @@ class User(CanvasObject):
         return PaginatedList(
             File,
             self._requester,
-            'GET',
-            'users/{}/files'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "users/{}/files".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_file(self, file, **kwargs):
@@ -439,9 +418,9 @@ class User(CanvasObject):
         file_id = obj_or_id(file, "file", (File,))
 
         response = self._requester.request(
-            'GET',
-            'users/{}/files/{}'.format(self.id, file_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "users/{}/files/{}".format(self.id, file_id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return File(self._requester, response.json())
 
@@ -462,8 +441,7 @@ class User(CanvasObject):
         folder_id = obj_or_id(folder, "folder", (Folder,))
 
         response = self._requester.request(
-            'GET',
-            'users/{}/folders/{}'.format(self.id, folder_id)
+            "GET", "users/{}/folders/{}".format(self.id, folder_id)
         )
         return Folder(self._requester, response.json())
 
@@ -485,7 +463,7 @@ class User(CanvasObject):
         warnings.warn(
             "`list_folders` is being deprecated and will be removed in a "
             "future version. Use `get_folders` instead.",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_folders(**kwargs)
@@ -504,9 +482,9 @@ class User(CanvasObject):
         return PaginatedList(
             Folder,
             self._requester,
-            'GET',
-            'users/{}/folders'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "users/{}/folders".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def create_folder(self, name, **kwargs):
@@ -521,10 +499,10 @@ class User(CanvasObject):
         :rtype: :class:`canvasapi.folder.Folder`
         """
         response = self._requester.request(
-            'POST',
-            'users/{}/folders'.format(self.id),
+            "POST",
+            "users/{}/folders".format(self.id),
             name=name,
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
         return Folder(self._requester, response.json())
 
@@ -545,10 +523,10 @@ class User(CanvasObject):
         warnings.warn(
             "`list_user_logins` is being deprecated and will be removed in a future version."
             " Use `get_user_logins` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
-        return self. get_user_logins(**kwargs)
+        return self.get_user_logins(**kwargs)
 
     def get_user_logins(self, **kwargs):
         """
@@ -565,9 +543,9 @@ class User(CanvasObject):
         return PaginatedList(
             Login,
             self._requester,
-            'GET',
-            'users/{}/logins'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "users/{}/logins".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def list_observees(self, **kwargs):
@@ -587,7 +565,7 @@ class User(CanvasObject):
         warnings.warn(
             "`list_observees` is being deprecated and will be removed in a "
             "future version. Use `get_observees` instead",
-            DeprecationWarning
+            DeprecationWarning,
         )
 
         return self.get_observees(**kwargs)
@@ -606,9 +584,9 @@ class User(CanvasObject):
         return PaginatedList(
             User,
             self._requester,
-            'GET',
-            'users/{}/observees'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "users/{}/observees".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def add_observee_with_credentials(self, **kwargs):
@@ -622,9 +600,9 @@ class User(CanvasObject):
         """
 
         response = self._requester.request(
-            'POST',
-            'users/{}/observees'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "users/{}/observees".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
         return User(self._requester, response.json())
 
@@ -641,8 +619,7 @@ class User(CanvasObject):
         """
 
         response = self._requester.request(
-            'GET',
-            'users/{}/observees/{}'.format(self.id, observee_id)
+            "GET", "users/{}/observees/{}".format(self.id, observee_id)
         )
         return User(self._requester, response.json())
 
@@ -659,8 +636,7 @@ class User(CanvasObject):
         """
 
         response = self._requester.request(
-            'PUT',
-            'users/{}/observees/{}'.format(self.id, observee_id)
+            "PUT", "users/{}/observees/{}".format(self.id, observee_id)
         )
         return User(self._requester, response.json())
 
@@ -677,8 +653,7 @@ class User(CanvasObject):
         """
 
         response = self._requester.request(
-            'DELETE',
-            'users/{}/observees/{}'.format(self.id, observee_id)
+            "DELETE", "users/{}/observees/{}".format(self.id, observee_id)
         )
         return User(self._requester, response.json())
 
@@ -697,20 +672,20 @@ class User(CanvasObject):
         from canvasapi.content_migration import ContentMigration, Migrator
 
         if isinstance(migration_type, Migrator):
-            kwargs['migration_type'] = migration_type.type
+            kwargs["migration_type"] = migration_type.type
         elif isinstance(migration_type, string_types):
-            kwargs['migration_type'] = migration_type
+            kwargs["migration_type"] = migration_type
         else:
-            raise TypeError('Parameter migration_type must be of type Migrator or str')
+            raise TypeError("Parameter migration_type must be of type Migrator or str")
 
         response = self._requester.request(
-            'POST',
-            'users/{}/content_migrations'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "POST",
+            "users/{}/content_migrations".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         response_json = response.json()
-        response_json.update({'user_id': self.id})
+        response_json.update({"user_id": self.id})
 
         return ContentMigration(self._requester, response_json)
 
@@ -728,16 +703,18 @@ class User(CanvasObject):
         """
         from canvasapi.content_migration import ContentMigration
 
-        migration_id = obj_or_id(content_migration, "content_migration", (ContentMigration,))
+        migration_id = obj_or_id(
+            content_migration, "content_migration", (ContentMigration,)
+        )
 
         response = self._requester.request(
-            'GET',
-            'users/{}/content_migrations/{}'.format(self.id, migration_id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "users/{}/content_migrations/{}".format(self.id, migration_id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
         response_json = response.json()
-        response_json.update({'user_id': self.id})
+        response_json.update({"user_id": self.id})
 
         return ContentMigration(self._requester, response_json)
 
@@ -756,10 +733,10 @@ class User(CanvasObject):
         return PaginatedList(
             ContentMigration,
             self._requester,
-            'GET',
-            'users/{}/content_migrations'.format(self.id),
-            {'user_id': self.id},
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "users/{}/content_migrations".format(self.id),
+            {"user_id": self.id},
+            _kwargs=combine_kwargs(**kwargs),
         )
 
     def get_migration_systems(self, **kwargs):
@@ -777,14 +754,13 @@ class User(CanvasObject):
         return PaginatedList(
             Migrator,
             self._requester,
-            'GET',
-            'users/{}/content_migrations/migrators'.format(self.id),
-            _kwargs=combine_kwargs(**kwargs)
+            "GET",
+            "users/{}/content_migrations/migrators".format(self.id),
+            _kwargs=combine_kwargs(**kwargs),
         )
 
 
 @python_2_unicode_compatible
 class UserDisplay(CanvasObject):
-
     def __str__(self):
         return "{}".format(self.display_name)

--- a/canvasapi/util.py
+++ b/canvasapi/util.py
@@ -48,11 +48,11 @@ def combine_kwargs(**kwargs):
         if isinstance(arg, dict):
             for k, v in arg.items():
                 for tup in flatten_kwarg(k, v):
-                    combined_kwargs.append(('{}{}'.format(kw, tup[0]), tup[1]))
+                    combined_kwargs.append(("{}{}".format(kw, tup[0]), tup[1]))
         elif is_multivalued(arg):
             for i in arg:
-                for tup in flatten_kwarg('', i):
-                    combined_kwargs.append(('{}{}'.format(kw, tup[0]), tup[1]))
+                for tup in flatten_kwarg("", i):
+                    combined_kwargs.append(("{}{}".format(kw, tup[0]), tup[1]))
         else:
             combined_kwargs.append((text_type(kw), arg))
 
@@ -82,7 +82,7 @@ def flatten_kwarg(key, obj):
         new_list = []
         for k, v in obj.items():
             for tup in flatten_kwarg(k, v):
-                new_list.append(('[{}]{}'.format(key, tup[0]), tup[1]))
+                new_list.append(("[{}]{}".format(key, tup[0]), tup[1]))
         return new_list
 
     elif is_multivalued(obj):
@@ -90,11 +90,11 @@ def flatten_kwarg(key, obj):
         new_list = []
         for i in obj:
             for tup in flatten_kwarg(key, i):
-                new_list.append((tup[0] + '[]', tup[1]))
+                new_list.append((tup[0] + "[]", tup[1]))
         return new_list
     else:
         # Base case. Return list with tuple containing the value
-        return [('[{}]'.format(text_type(key)), obj)]
+        return [("[{}]".format(text_type(key)), obj)]
 
 
 def obj_or_id(parameter, param_name, object_types):
@@ -115,7 +115,7 @@ def obj_or_id(parameter, param_name, object_types):
         return int(parameter)
     except (ValueError, TypeError):
         # Special case where 'self' is a valid ID of a User object
-        if User in object_types and parameter == 'self':
+        if User in object_types and parameter == "self":
             return parameter
 
         for obj_type in object_types:
@@ -126,7 +126,9 @@ def obj_or_id(parameter, param_name, object_types):
                     break
 
         obj_type_list = ",".join([obj_type.__name__ for obj_type in object_types])
-        message = 'Parameter {} must be of type {} or int.'.format(param_name, obj_type_list)
+        message = "Parameter {} must be of type {} or int.".format(
+            param_name, obj_type_list
+        )
         raise TypeError(message)
 
 
@@ -138,8 +140,8 @@ def get_institution_url(base_url):
     :type base_url: str
     :rtype: str
     """
-    base_url = base_url.rstrip('/')
-    index = base_url.find('/api/v1')
+    base_url = base_url.rstrip("/")
+    index = base_url.find("/api/v1")
 
     if index != -1:
         return base_url[0:index]

--- a/tests/fixtures/quiz.json
+++ b/tests/fixtures/quiz.json
@@ -1,4 +1,12 @@
 {
+	"broadcast_message": {
+		"method":"POST",
+		"endpoint": "courses/1/quizzes/1/submission_users/message",
+		"data": {
+			"status": "created"
+		},
+		"status_code": 200
+	},
 	"delete": {
 		"method":"DELETE",
 		"endpoint": "courses/1/quizzes/1",

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-BASE_URL = 'https://example.com'
-BASE_URL_WITH_VERSION = 'https://example.com/api/v1/'
-BASE_URL_AS_HTTP = 'http://example.com'
-API_KEY = '123'
+BASE_URL = "https://example.com"
+BASE_URL_WITH_VERSION = "https://example.com/api/v1/"
+BASE_URL_AS_HTTP = "http://example.com"
+API_KEY = "123"
 
 INVALID_ID = 9001

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -7,7 +7,14 @@ import warnings
 import requests_mock
 
 from canvasapi import Canvas
-from canvasapi.account import Account, AccountNotification, AccountReport, Admin, Role, SSOSettings
+from canvasapi.account import (
+    Account,
+    AccountNotification,
+    AccountReport,
+    Admin,
+    Role,
+    SSOSettings,
+)
 from canvasapi.authentication_provider import AuthenticationProvider
 from canvasapi.course import Course
 from canvasapi.enrollment import Enrollment
@@ -27,12 +34,11 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestAccount(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            requires = {'account': ['get_by_id', 'get_role'], 'user': ['get_by_id']}
+            requires = {"account": ["get_by_id", "get_role"], "user": ["get_by_id"]}
             register_uris(requires, m)
 
             self.account = self.canvas.get_account(1)
@@ -46,50 +52,50 @@ class TestAccount(unittest.TestCase):
 
     # close_notification_for_user()
     def test_close_notification_for_user_id(self, m):
-        register_uris({'account': ['close_notification']}, m)
+        register_uris({"account": ["close_notification"]}, m)
 
         user_id = self.user.id
         notif_id = 1
         closed_notif = self.account.close_notification_for_user(user_id, notif_id)
 
         self.assertIsInstance(closed_notif, AccountNotification)
-        self.assertTrue(hasattr(closed_notif, 'subject'))
+        self.assertTrue(hasattr(closed_notif, "subject"))
 
     def test_close_notification_for_user_obj(self, m):
-        register_uris({'account': ['close_notification']}, m)
+        register_uris({"account": ["close_notification"]}, m)
 
         notif_id = 1
         self.account.close_notification_for_user(self.user, notif_id)
 
     # create_account()
     def test_create_account(self, m):
-        register_uris({'account': ['create_2']}, m)
+        register_uris({"account": ["create_2"]}, m)
 
         new_account = self.account.create_account()
 
         self.assertIsInstance(new_account, Account)
-        self.assertTrue(hasattr(new_account, 'id'))
+        self.assertTrue(hasattr(new_account, "id"))
 
     # create_course()
     def test_create_course(self, m):
-        register_uris({'account': ['create_course']}, m)
+        register_uris({"account": ["create_course"]}, m)
 
         course = self.account.create_course()
 
         self.assertIsInstance(course, Course)
-        self.assertTrue(hasattr(course, 'name'))
+        self.assertTrue(hasattr(course, "name"))
 
     # create_subaccount()
     def test_create_subaccount(self, m):
-        register_uris({'account': ['create_subaccount']}, m)
+        register_uris({"account": ["create_subaccount"]}, m)
 
         subaccount_name = "New Subaccount"
-        subaccount = self.account.create_subaccount({'name': subaccount_name})
+        subaccount = self.account.create_subaccount({"name": subaccount_name})
 
         self.assertIsInstance(subaccount, Account)
-        self.assertTrue(hasattr(subaccount, 'name'))
+        self.assertTrue(hasattr(subaccount, "name"))
         self.assertEqual(subaccount.name, subaccount_name)
-        self.assertTrue(hasattr(subaccount, 'root_account_id'))
+        self.assertTrue(hasattr(subaccount, "root_account_id"))
         self.assertEqual(subaccount.root_account_id, self.account.id)
 
     def test_create_course_missing_field(self, m):
@@ -98,13 +104,13 @@ class TestAccount(unittest.TestCase):
 
     # create_user()
     def test_create_user(self, m):
-        register_uris({'account': ['create_user']}, m)
+        register_uris({"account": ["create_user"]}, m)
 
         unique_id = 123456
-        user = self.account.create_user({'unique_id': unique_id})
+        user = self.account.create_user({"unique_id": unique_id})
 
         self.assertIsInstance(user, User)
-        self.assertTrue(hasattr(user, 'unique_id'))
+        self.assertTrue(hasattr(user, "unique_id"))
         self.assertEqual(user.unique_id, unique_id)
 
     def test_create_user_missing_field(self, m):
@@ -113,21 +119,21 @@ class TestAccount(unittest.TestCase):
 
     # create_notification()
     def test_create_notification(self, m):
-        register_uris({'account': ['create_notification']}, m)
+        register_uris({"account": ["create_notification"]}, m)
 
-        subject = 'Subject'
+        subject = "Subject"
         notif_dict = {
-            'subject': subject,
-            'message': 'Message',
-            'start_at': '2015-04-01T00:00:00Z',
-            'end_at': '2018-04-01T00:00:00Z'
+            "subject": subject,
+            "message": "Message",
+            "start_at": "2015-04-01T00:00:00Z",
+            "end_at": "2018-04-01T00:00:00Z",
         }
         notif = self.account.create_notification(notif_dict)
 
         self.assertIsInstance(notif, AccountNotification)
-        self.assertTrue(hasattr(notif, 'subject'))
+        self.assertTrue(hasattr(notif, "subject"))
         self.assertEqual(notif.subject, subject)
-        self.assertTrue(hasattr(notif, 'start_at_date'))
+        self.assertTrue(hasattr(notif, "start_at_date"))
         self.assertIsInstance(notif.start_at_date, datetime.datetime)
         self.assertEqual(notif.start_at_date.tzinfo, pytz.utc)
 
@@ -137,9 +143,9 @@ class TestAccount(unittest.TestCase):
 
     # delete()
     def test_delete(self, m):
-        register_uris({'account': ['create_subaccount', 'delete_subaccount']}, m)
+        register_uris({"account": ["create_subaccount", "delete_subaccount"]}, m)
 
-        subaccount = self.account.create_subaccount({'name': 'New Subaccount'})
+        subaccount = self.account.create_subaccount({"name": "New Subaccount"})
 
         self.assertTrue(subaccount.delete())
 
@@ -149,24 +155,24 @@ class TestAccount(unittest.TestCase):
 
     # delete_user()
     def test_delete_user_id(self, m):
-        register_uris({'account': ['delete_user']}, m)
+        register_uris({"account": ["delete_user"]}, m)
 
         deleted_user = self.account.delete_user(self.user.id)
 
         self.assertIsInstance(deleted_user, User)
-        self.assertTrue(hasattr(deleted_user, 'name'))
+        self.assertTrue(hasattr(deleted_user, "name"))
 
     def test_delete_user_obj(self, m):
-        register_uris({'account': ['delete_user']}, m)
+        register_uris({"account": ["delete_user"]}, m)
 
         deleted_user = self.account.delete_user(self.user)
 
         self.assertIsInstance(deleted_user, User)
-        self.assertTrue(hasattr(deleted_user, 'name'))
+        self.assertTrue(hasattr(deleted_user, "name"))
 
     # get_courses()
     def test_get_courses(self, m):
-        required = {'account': ['get_courses', 'get_courses_page_2']}
+        required = {"account": ["get_courses", "get_courses_page_2"]}
         register_uris(required, m)
 
         courses = self.account.get_courses()
@@ -174,24 +180,24 @@ class TestAccount(unittest.TestCase):
         course_list = [course for course in courses]
         self.assertEqual(len(course_list), 4)
         self.assertIsInstance(course_list[0], Course)
-        self.assertTrue(hasattr(course_list[0], 'name'))
+        self.assertTrue(hasattr(course_list[0], "name"))
 
     # get_external_tool()
     def test_get_external_tool(self, m):
-        required = {'external_tool': ['get_by_id_account']}
+        required = {"external_tool": ["get_by_id_account"]}
         register_uris(required, m)
 
         tool_by_id = self.account.get_external_tool(1)
         self.assertIsInstance(tool_by_id, ExternalTool)
-        self.assertTrue(hasattr(tool_by_id, 'name'))
+        self.assertTrue(hasattr(tool_by_id, "name"))
 
         tool_by_obj = self.account.get_external_tool(tool_by_id)
         self.assertIsInstance(tool_by_obj, ExternalTool)
-        self.assertTrue(hasattr(tool_by_obj, 'name'))
+        self.assertTrue(hasattr(tool_by_obj, "name"))
 
     # get_external_tools()
     def test_get_external_tools(self, m):
-        required = {'account': ['get_external_tools', 'get_external_tools_p2']}
+        required = {"account": ["get_external_tools", "get_external_tools_p2"]}
         register_uris(required, m)
 
         tools = self.account.get_external_tools()
@@ -202,7 +208,7 @@ class TestAccount(unittest.TestCase):
 
     # get_index_of_reports()
     def test_get_index_of_reports(self, m):
-        required = {'account': ['report_index', 'report_index_page_2']}
+        required = {"account": ["report_index", "report_index_page_2"]}
         register_uris(required, m)
 
         reports_index = self.account.get_index_of_reports("sis_export_csv")
@@ -210,11 +216,11 @@ class TestAccount(unittest.TestCase):
         reports_index_list = [index for index in reports_index]
         self.assertEqual(len(reports_index_list), 4)
         self.assertIsInstance(reports_index_list[0], AccountReport)
-        self.assertTrue(hasattr(reports_index_list[0], 'id'))
+        self.assertTrue(hasattr(reports_index_list[0], "id"))
 
     # get_reports()
     def test_get_reports(self, m):
-        required = {'account': ['reports', 'reports_page_2']}
+        required = {"account": ["reports", "reports_page_2"]}
         register_uris(required, m)
 
         reports = self.account.get_reports()
@@ -222,11 +228,11 @@ class TestAccount(unittest.TestCase):
         reports_list = [report for report in reports]
         self.assertEqual(len(reports_list), 4)
         self.assertIsInstance(reports_list[0], AccountReport)
-        self.assertTrue(hasattr(reports_list[0], 'id'))
+        self.assertTrue(hasattr(reports_list[0], "id"))
 
     # get_subaccounts()
     def test_get_subaccounts(self, m):
-        required = {'account': ['subaccounts', 'subaccounts_page_2']}
+        required = {"account": ["subaccounts", "subaccounts_page_2"]}
         register_uris(required, m)
 
         subaccounts = self.account.get_subaccounts()
@@ -234,11 +240,11 @@ class TestAccount(unittest.TestCase):
         subaccounts_list = [account for account in subaccounts]
         self.assertEqual(len(subaccounts_list), 4)
         self.assertIsInstance(subaccounts_list[0], Account)
-        self.assertTrue(hasattr(subaccounts_list[0], 'name'))
+        self.assertTrue(hasattr(subaccounts_list[0], "name"))
 
     # get_users()
     def test_get_users(self, m):
-        required = {'account': ['users', 'users_page_2']}
+        required = {"account": ["users", "users_page_2"]}
         register_uris(required, m)
 
         users = self.account.get_users()
@@ -246,11 +252,11 @@ class TestAccount(unittest.TestCase):
         user_list = [user for user in users]
         self.assertEqual(len(user_list), 4)
         self.assertIsInstance(user_list[0], User)
-        self.assertTrue(hasattr(user_list[0], 'name'))
+        self.assertTrue(hasattr(user_list[0], "name"))
 
     # get_user_notifications()
     def test_get_user_notifications_id(self, m):
-        required = {'account': ['user_notifs', 'user_notifs_page_2']}
+        required = {"account": ["user_notifs", "user_notifs_page_2"]}
         register_uris(required, m)
 
         user_notifs = self.account.get_user_notifications(self.user.id)
@@ -258,10 +264,10 @@ class TestAccount(unittest.TestCase):
         notif_list = [notif for notif in user_notifs]
         self.assertEqual(len(notif_list), 4)
         self.assertIsInstance(user_notifs[0], AccountNotification)
-        self.assertTrue(hasattr(user_notifs[0], 'subject'))
+        self.assertTrue(hasattr(user_notifs[0], "subject"))
 
     def test_get_user_notifications_obj(self, m):
-        required = {'account': ['user_notifs', 'user_notifs_page_2']}
+        required = {"account": ["user_notifs", "user_notifs_page_2"]}
         register_uris(required, m)
 
         user_notifs = self.account.get_user_notifications(self.user)
@@ -269,33 +275,33 @@ class TestAccount(unittest.TestCase):
         notif_list = [notif for notif in user_notifs]
         self.assertEqual(len(notif_list), 4)
         self.assertIsInstance(user_notifs[0], AccountNotification)
-        self.assertTrue(hasattr(user_notifs[0], 'subject'))
+        self.assertTrue(hasattr(user_notifs[0], "subject"))
 
     # update()
     def test_update(self, m):
-        register_uris({'account': ['update']}, m)
+        register_uris({"account": ["update"]}, m)
 
-        self.assertEqual(self.account.name, 'Canvas Account')
+        self.assertEqual(self.account.name, "Canvas Account")
 
-        new_name = 'Updated Name'
-        update_account_dict = {'name': new_name}
+        new_name = "Updated Name"
+        update_account_dict = {"name": new_name}
 
         self.assertTrue(self.account.update(account=update_account_dict))
         self.assertEqual(self.account.name, new_name)
 
     def test_update_fail(self, m):
-        register_uris({'account': ['update_fail']}, m)
+        register_uris({"account": ["update_fail"]}, m)
 
-        self.assertEqual(self.account.name, 'Canvas Account')
+        self.assertEqual(self.account.name, "Canvas Account")
 
-        new_name = 'Updated Name'
-        update_account_dict = {'name': new_name}
+        new_name = "Updated Name"
+        update_account_dict = {"name": new_name}
 
         self.assertFalse(self.account.update(account=update_account_dict))
 
     # list_roles()
     def test_list_roles(self, m):
-        requires = {'account': ['get_roles', 'get_roles_2']}
+        requires = {"account": ["get_roles", "get_roles_2"]}
         register_uris(requires, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
@@ -304,15 +310,15 @@ class TestAccount(unittest.TestCase):
 
             self.assertEqual(len(role_list), 4)
             self.assertIsInstance(role_list[0], Role)
-            self.assertTrue(hasattr(role_list[0], 'role'))
-            self.assertTrue(hasattr(role_list[0], 'label'))
+            self.assertTrue(hasattr(role_list[0], "role"))
+            self.assertTrue(hasattr(role_list[0], "label"))
 
             self.assertEqual(len(warning_list), 1)
             self.assertEqual(warning_list[-1].category, DeprecationWarning)
 
     # get_roles()
     def test_get_roles(self, m):
-        requires = {'account': ['get_roles', 'get_roles_2']}
+        requires = {"account": ["get_roles", "get_roles_2"]}
         register_uris(requires, m)
 
         roles = self.account.get_roles()
@@ -320,72 +326,72 @@ class TestAccount(unittest.TestCase):
 
         self.assertEqual(len(role_list), 4)
         self.assertIsInstance(role_list[0], Role)
-        self.assertTrue(hasattr(role_list[0], 'role'))
-        self.assertTrue(hasattr(role_list[0], 'label'))
+        self.assertTrue(hasattr(role_list[0], "role"))
+        self.assertTrue(hasattr(role_list[0], "label"))
 
     def test_get_role(self, m):
-        register_uris({'account': ['get_role']}, m)
+        register_uris({"account": ["get_role"]}, m)
 
         target_role_by_id = self.account.get_role(2)
         self.assertIsInstance(target_role_by_id, Role)
-        self.assertTrue(hasattr(target_role_by_id, 'role'))
-        self.assertTrue(hasattr(target_role_by_id, 'label'))
+        self.assertTrue(hasattr(target_role_by_id, "role"))
+        self.assertTrue(hasattr(target_role_by_id, "label"))
 
         target_role_by_obj = self.account.get_role(self.role)
         self.assertIsInstance(target_role_by_obj, Role)
-        self.assertTrue(hasattr(target_role_by_obj, 'role'))
-        self.assertTrue(hasattr(target_role_by_obj, 'label'))
+        self.assertTrue(hasattr(target_role_by_obj, "role"))
+        self.assertTrue(hasattr(target_role_by_obj, "label"))
 
     def test_create_role(self, m):
-        register_uris({'account': ['create_role']}, m)
+        register_uris({"account": ["create_role"]}, m)
 
         new_role = self.account.create_role(1)
         self.assertIsInstance(new_role, Role)
-        self.assertTrue(hasattr(new_role, 'role'))
-        self.assertTrue(hasattr(new_role, 'label'))
+        self.assertTrue(hasattr(new_role, "role"))
+        self.assertTrue(hasattr(new_role, "label"))
 
     def test_deactivate_role(self, m):
-        register_uris({'account': ['deactivate_role']}, m)
+        register_uris({"account": ["deactivate_role"]}, m)
 
         old_role_by_id = self.account.deactivate_role(2)
         self.assertIsInstance(old_role_by_id, Role)
-        self.assertTrue(hasattr(old_role_by_id, 'role'))
-        self.assertTrue(hasattr(old_role_by_id, 'label'))
+        self.assertTrue(hasattr(old_role_by_id, "role"))
+        self.assertTrue(hasattr(old_role_by_id, "label"))
 
         old_role_by_obj = self.account.deactivate_role(self.role)
         self.assertIsInstance(old_role_by_obj, Role)
-        self.assertTrue(hasattr(old_role_by_obj, 'role'))
-        self.assertTrue(hasattr(old_role_by_obj, 'label'))
+        self.assertTrue(hasattr(old_role_by_obj, "role"))
+        self.assertTrue(hasattr(old_role_by_obj, "label"))
 
     def test_activate_role(self, m):
-        register_uris({'account': ['activate_role']}, m)
+        register_uris({"account": ["activate_role"]}, m)
 
         activated_role_by_id = self.account.activate_role(2)
         self.assertIsInstance(activated_role_by_id, Role)
-        self.assertTrue(hasattr(activated_role_by_id, 'role'))
-        self.assertTrue(hasattr(activated_role_by_id, 'label'))
+        self.assertTrue(hasattr(activated_role_by_id, "role"))
+        self.assertTrue(hasattr(activated_role_by_id, "label"))
 
         activated_role_by_obj = self.account.activate_role(self.role)
         self.assertIsInstance(activated_role_by_obj, Role)
-        self.assertTrue(hasattr(activated_role_by_obj, 'role'))
-        self.assertTrue(hasattr(activated_role_by_obj, 'label'))
+        self.assertTrue(hasattr(activated_role_by_obj, "role"))
+        self.assertTrue(hasattr(activated_role_by_obj, "label"))
 
     def test_update_role(self, m):
-        register_uris({'account': ['update_role']}, m)
+        register_uris({"account": ["update_role"]}, m)
 
         updated_role_by_id = self.account.update_role(2)
         self.assertIsInstance(updated_role_by_id, Role)
-        self.assertTrue(hasattr(updated_role_by_id, 'role'))
-        self.assertTrue(hasattr(updated_role_by_id, 'label'))
+        self.assertTrue(hasattr(updated_role_by_id, "role"))
+        self.assertTrue(hasattr(updated_role_by_id, "label"))
 
         updated_role_by_obj = self.account.update_role(self.role)
         self.assertIsInstance(updated_role_by_obj, Role)
-        self.assertTrue(hasattr(updated_role_by_obj, 'role'))
-        self.assertTrue(hasattr(updated_role_by_obj, 'label'))
+        self.assertTrue(hasattr(updated_role_by_obj, "role"))
+        self.assertTrue(hasattr(updated_role_by_obj, "label"))
 
     # get_enrollment()
     def test_get_enrollment(self, m):
-        register_uris({'enrollment': ['get_by_id']}, m)
+        register_uris({"enrollment": ["get_by_id"]}, m)
 
         enrollment_by_id = self.account.get_enrollment(1)
         self.assertIsInstance(enrollment_by_id, Enrollment)
@@ -395,7 +401,7 @@ class TestAccount(unittest.TestCase):
 
     # list_groups()
     def test_list_groups(self, m):
-        requires = {'account': ['get_groups_context', 'get_groups_context2']}
+        requires = {"account": ["get_groups_context", "get_groups_context2"]}
         register_uris(requires, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
@@ -410,7 +416,7 @@ class TestAccount(unittest.TestCase):
 
     # get_groups()
     def test_get_groups(self, m):
-        requires = {'account': ['get_groups_context', 'get_groups_context2']}
+        requires = {"account": ["get_groups_context", "get_groups_context2"]}
         register_uris(requires, m)
 
         groups = self.account.get_groups()
@@ -421,7 +427,7 @@ class TestAccount(unittest.TestCase):
 
     # create_group_category()
     def test_create_group_category(self, m):
-        register_uris({'account': ['create_group_category']}, m)
+        register_uris({"account": ["create_group_category"]}, m)
 
         name_str = "Test String"
         response = self.account.create_group_category(name=name_str)
@@ -429,7 +435,7 @@ class TestAccount(unittest.TestCase):
 
     # list_group_categories()
     def test_list_group_categories(self, m):
-        register_uris({'account': ['get_group_categories']}, m)
+        register_uris({"account": ["get_group_categories"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             response = self.account.list_group_categories()
@@ -442,7 +448,7 @@ class TestAccount(unittest.TestCase):
 
     # get_group_categories()
     def test_get_group_categories(self, m):
-        register_uris({'account': ['get_group_categories']}, m)
+        register_uris({"account": ["get_group_categories"]}, m)
 
         response = self.account.get_group_categories()
         category_list = [category for category in response]
@@ -451,27 +457,24 @@ class TestAccount(unittest.TestCase):
 
     # create_external_tool()
     def test_create_external_tool(self, m):
-        register_uris({'external_tool': ['create_tool_account']}, m)
+        register_uris({"external_tool": ["create_tool_account"]}, m)
 
         response = self.account.create_external_tool(
             name="External Tool - Account",
             privacy_level="public",
             consumer_key="key",
-            shared_secret="secret"
+            shared_secret="secret",
         )
 
         self.assertIsInstance(response, ExternalTool)
-        self.assertTrue(hasattr(response, 'id'))
+        self.assertTrue(hasattr(response, "id"))
         self.assertEqual(response.id, 10)
 
     # create_enrollment_term()
     def test_create_enrollment_term(self, m):
-        register_uris({'enrollment_term': ['create_enrollment_term']}, m)
+        register_uris({"enrollment_term": ["create_enrollment_term"]}, m)
 
-        evnt = self.account.create_enrollment_term(
-            name="Test Enrollment Term",
-            id=45
-        )
+        evnt = self.account.create_enrollment_term(name="Test Enrollment Term", id=45)
 
         self.assertIsInstance(evnt, EnrollmentTerm)
         self.assertEqual(evnt.name, "Test Enrollment Term")
@@ -479,7 +482,7 @@ class TestAccount(unittest.TestCase):
 
     # list_enrollment_terms()
     def test_list_enrollment_terms(self, m):
-        register_uris({'account': ['get_enrollment_terms']}, m)
+        register_uris({"account": ["get_enrollment_terms"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             response = self.account.list_enrollment_terms()
@@ -492,7 +495,7 @@ class TestAccount(unittest.TestCase):
 
     # get_enrollment_terms()
     def test_get_enrollment_terms(self, m):
-        register_uris({'account': ['get_enrollment_terms']}, m)
+        register_uris({"account": ["get_enrollment_terms"]}, m)
 
         response = self.account.get_enrollment_terms()
         enrollment_terms_list = [category for category in response]
@@ -501,7 +504,7 @@ class TestAccount(unittest.TestCase):
 
     # list_user_logins()
     def test_list_user_logins(self, m):
-        requires = {'account': ['get_user_logins', 'get_user_logins_2']}
+        requires = {"account": ["get_user_logins", "get_user_logins_2"]}
         register_uris(requires, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
@@ -516,7 +519,7 @@ class TestAccount(unittest.TestCase):
 
     # get_user_logins()
     def test_get_user_logins(self, m):
-        requires = {'account': ['get_user_logins', 'get_user_logins_2']}
+        requires = {"account": ["get_user_logins", "get_user_logins_2"]}
         register_uris(requires, m)
 
         response = self.account.get_user_logins()
@@ -527,18 +530,17 @@ class TestAccount(unittest.TestCase):
 
     # create_user_login()
     def test_create_user_login(self, m):
-        register_uris({'login': ['create_user_login']}, m)
+        register_uris({"login": ["create_user_login"]}, m)
 
-        unique_id = 'belieber@example.com'
+        unique_id = "belieber@example.com"
 
         response = self.account.create_user_login(
-            user={'id': 1},
-            login={'unique_id': unique_id}
+            user={"id": 1}, login={"unique_id": unique_id}
         )
 
         self.assertIsInstance(response, Login)
-        self.assertTrue(hasattr(response, 'id'))
-        self.assertTrue(hasattr(response, 'unique_id'))
+        self.assertTrue(hasattr(response, "id"))
+        self.assertTrue(hasattr(response, "unique_id"))
         self.assertEqual(response.id, 101)
         self.assertEqual(response.unique_id, unique_id)
 
@@ -548,19 +550,25 @@ class TestAccount(unittest.TestCase):
 
     def test_create_user_login_fail_on_login_unique_id(self, m):
         with self.assertRaises(RequiredFieldMissing):
-            self.account.create_user_login(user={'id': 1}, login={})
+            self.account.create_user_login(user={"id": 1}, login={})
 
     # get_department_level_participation_data_with_given_term()
     def test_get_department_level_participation_data_with_given_term(self, m):
-        register_uris({'account': ['get_department_level_participation_data_with_given_term']}, m)
+        register_uris(
+            {"account": ["get_department_level_participation_data_with_given_term"]}, m
+        )
 
-        response = self.account.get_department_level_participation_data_with_given_term(1)
+        response = self.account.get_department_level_participation_data_with_given_term(
+            1
+        )
 
         self.assertIsInstance(response, list)
 
     # get_department_level_participation_data_current()
     def test_get_department_level_participation_data_current(self, m):
-        register_uris({'account': ['get_department_level_participation_data_current']}, m)
+        register_uris(
+            {"account": ["get_department_level_participation_data_current"]}, m
+        )
 
         response = self.account.get_department_level_participation_data_current()
 
@@ -568,7 +576,9 @@ class TestAccount(unittest.TestCase):
 
     # get_department_level_participation_data_completed()
     def test_get_department_level_participation_data_completed(self, m):
-        register_uris({'account': ['get_department_level_participation_data_completed']}, m)
+        register_uris(
+            {"account": ["get_department_level_participation_data_completed"]}, m
+        )
 
         response = self.account.get_department_level_participation_data_completed()
 
@@ -576,7 +586,9 @@ class TestAccount(unittest.TestCase):
 
     # get_department_level_grade_data_with_given_term()
     def test_get_department_level_grade_data_with_given_term(self, m):
-        register_uris({'account': ['get_department_level_grade_data_with_given_term']}, m)
+        register_uris(
+            {"account": ["get_department_level_grade_data_with_given_term"]}, m
+        )
 
         response = self.account.get_department_level_grade_data_with_given_term(1)
 
@@ -584,7 +596,7 @@ class TestAccount(unittest.TestCase):
 
     # get_department_level_grade_data_current()
     def test_get_department_level_grade_data_current(self, m):
-        register_uris({'account': ['get_department_level_grade_data_current']}, m)
+        register_uris({"account": ["get_department_level_grade_data_current"]}, m)
 
         response = self.account.get_department_level_grade_data_current()
 
@@ -592,7 +604,7 @@ class TestAccount(unittest.TestCase):
 
     # get_department_level_grade_data_completed()
     def test_get_department_level_grade_data_completed(self, m):
-        register_uris({'account': ['get_department_level_grade_data_completed']}, m)
+        register_uris({"account": ["get_department_level_grade_data_completed"]}, m)
 
         response = self.account.get_department_level_grade_data_completed()
 
@@ -600,7 +612,9 @@ class TestAccount(unittest.TestCase):
 
     # get_department_level_statistics_with_given_term()
     def test_get_department_level_statistics_with_given_term(self, m):
-        register_uris({'account': ['get_department_level_statistics_with_given_term']}, m)
+        register_uris(
+            {"account": ["get_department_level_statistics_with_given_term"]}, m
+        )
 
         response = self.account.get_department_level_statistics_with_given_term(1)
 
@@ -608,7 +622,7 @@ class TestAccount(unittest.TestCase):
 
     # get_department_level_statistics_current()
     def test_get_department_level_statistics_current(self, m):
-        register_uris({'account': ['get_department_level_statistics_current']}, m)
+        register_uris({"account": ["get_department_level_statistics_current"]}, m)
 
         response = self.account.get_department_level_statistics_current()
 
@@ -616,7 +630,7 @@ class TestAccount(unittest.TestCase):
 
     # get_department_level_statistics_completed()
     def test_get_department_level_statistics_completed(self, m):
-        register_uris({'account': ['get_department_level_statistics_completed']}, m)
+        register_uris({"account": ["get_department_level_statistics_completed"]}, m)
 
         response = self.account.get_department_level_statistics_completed()
 
@@ -624,53 +638,65 @@ class TestAccount(unittest.TestCase):
 
     # list_authentication_providers()
     def test_list_authentication_providers(self, m):
-        requires = {'account': ['list_authentication_providers',
-                                'list_authentication_providers_2']}
+        requires = {
+            "account": [
+                "list_authentication_providers",
+                "list_authentication_providers_2",
+            ]
+        }
         register_uris(requires, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             authentication_providers = self.account.list_authentication_providers()
             authentication_providers_list = [
-                authentication_provider for authentication_provider in authentication_providers
+                authentication_provider
+                for authentication_provider in authentication_providers
             ]
 
             self.assertEqual(len(authentication_providers_list), 4)
-            self.assertIsInstance(authentication_providers_list[0], AuthenticationProvider)
-            self.assertTrue(hasattr(authentication_providers_list[0], 'auth_type'))
-            self.assertTrue(hasattr(authentication_providers_list[0], 'position'))
+            self.assertIsInstance(
+                authentication_providers_list[0], AuthenticationProvider
+            )
+            self.assertTrue(hasattr(authentication_providers_list[0], "auth_type"))
+            self.assertTrue(hasattr(authentication_providers_list[0], "position"))
 
             self.assertEqual(len(warning_list), 1)
             self.assertEqual(warning_list[-1].category, DeprecationWarning)
 
     # get_authentication_providers()
     def test_get_authentication_providers(self, m):
-        requires = {'account': ['list_authentication_providers',
-                                'list_authentication_providers_2']}
+        requires = {
+            "account": [
+                "list_authentication_providers",
+                "list_authentication_providers_2",
+            ]
+        }
         register_uris(requires, m)
 
         authentication_providers = self.account.get_authentication_providers()
         authentication_providers_list = [
-            authentication_provider for authentication_provider in authentication_providers
+            authentication_provider
+            for authentication_provider in authentication_providers
         ]
 
         self.assertEqual(len(authentication_providers_list), 4)
         self.assertIsInstance(authentication_providers_list[0], AuthenticationProvider)
-        self.assertTrue(hasattr(authentication_providers_list[0], 'auth_type'))
-        self.assertTrue(hasattr(authentication_providers_list[0], 'position'))
+        self.assertTrue(hasattr(authentication_providers_list[0], "auth_type"))
+        self.assertTrue(hasattr(authentication_providers_list[0], "position"))
 
     # add_authentication_providers()
     def test_add_authentication_providers(self, m):
-        register_uris({'account': ['add_authentication_providers']}, m)
+        register_uris({"account": ["add_authentication_providers"]}, m)
 
         new_authentication_provider = self.account.add_authentication_providers()
 
         self.assertIsInstance(new_authentication_provider, AuthenticationProvider)
-        self.assertTrue(hasattr(new_authentication_provider, 'auth_type'))
-        self.assertTrue(hasattr(new_authentication_provider, 'position'))
+        self.assertTrue(hasattr(new_authentication_provider, "auth_type"))
+        self.assertTrue(hasattr(new_authentication_provider, "position"))
 
     # get_authentication_provider()
     def test_get_authentication_provider(self, m):
-        register_uris({'account': ['get_authentication_providers']}, m)
+        register_uris({"account": ["get_authentication_providers"]}, m)
 
         authentication_provider_by_id = self.account.get_authentication_provider(1)
         self.assertIsInstance(authentication_provider_by_id, AuthenticationProvider)
@@ -682,7 +708,7 @@ class TestAccount(unittest.TestCase):
 
     # show_account_auth_settings()
     def test_show_account_auth_settings(self, m):
-        register_uris({'account': ['show_account_auth_settings']}, m)
+        register_uris({"account": ["show_account_auth_settings"]}, m)
 
         response = self.account.show_account_auth_settings()
 
@@ -690,7 +716,7 @@ class TestAccount(unittest.TestCase):
 
     # update_account_auth_settings()
     def test_update_account_auth_settings(self, m):
-        register_uris({'account': ['update_account_auth_settings']}, m)
+        register_uris({"account": ["update_account_auth_settings"]}, m)
 
         response = self.account.update_account_auth_settings()
 
@@ -698,7 +724,7 @@ class TestAccount(unittest.TestCase):
 
     # get_root_outcome_group()
     def test_get_root_outcome_group(self, m):
-        register_uris({'outcome': ['account_root_outcome_group']}, m)
+        register_uris({"outcome": ["account_root_outcome_group"]}, m)
 
         outcome_group = self.account.get_root_outcome_group()
 
@@ -708,7 +734,7 @@ class TestAccount(unittest.TestCase):
 
     # get_outcome_group()
     def test_get_outcome_group(self, m):
-        register_uris({'outcome': ['account_get_outcome_group']}, m)
+        register_uris({"outcome": ["account_get_outcome_group"]}, m)
 
         outcome_group_by_id = self.account.get_outcome_group(1)
         self.assertIsInstance(outcome_group_by_id, OutcomeGroup)
@@ -722,7 +748,7 @@ class TestAccount(unittest.TestCase):
 
     # get_outcome_groups_in_context()
     def test_get_outcome_groups_in_context(self, m):
-        register_uris({'outcome': ['account_outcome_groups_in_context']}, m)
+        register_uris({"outcome": ["account_outcome_groups_in_context"]}, m)
 
         outcome_group_list = self.account.get_outcome_groups_in_context()
 
@@ -732,17 +758,17 @@ class TestAccount(unittest.TestCase):
 
     # get_all_outcome_links_in_context()
     def test_get_outcome_links_in_context(self, m):
-        register_uris({'outcome': ['account_outcome_links_in_context']}, m)
+        register_uris({"outcome": ["account_outcome_links_in_context"]}, m)
 
         outcome_link_list = self.account.get_all_outcome_links_in_context()
 
         self.assertIsInstance(outcome_link_list[0], OutcomeLink)
-        self.assertEqual(outcome_link_list[0].outcome_group['id'], 2)
-        self.assertEqual(outcome_link_list[0].outcome_group['title'], "test outcome")
+        self.assertEqual(outcome_link_list[0].outcome_group["id"], 2)
+        self.assertEqual(outcome_link_list[0].outcome_group["title"], "test outcome")
 
     # add_grading_standards()
     def test_add_grading_standards(self, m):
-        register_uris({'account': ['add_grading_standards']}, m)
+        register_uris({"account": ["add_grading_standards"]}, m)
 
         title = "Grading Standard 1"
         grading_scheme = []
@@ -753,36 +779,36 @@ class TestAccount(unittest.TestCase):
         response = self.account.add_grading_standards(title, grading_scheme)
 
         self.assertIsInstance(response, GradingStandard)
-        self.assertTrue(hasattr(response, 'title'))
+        self.assertTrue(hasattr(response, "title"))
         self.assertEqual(title, response.title)
         self.assertTrue(hasattr(response, "grading_scheme"))
-        self.assertEqual(response.grading_scheme[0].get('name'), "A")
-        self.assertEqual(response.grading_scheme[0].get('value'), 0.9)
+        self.assertEqual(response.grading_scheme[0].get("name"), "A")
+        self.assertEqual(response.grading_scheme[0].get("value"), 0.9)
 
     # add_grading_standards()
     def test_add_grading_standards_empty_list(self, m):
-        register_uris({'account': ['add_grading_standards']}, m)
+        register_uris({"account": ["add_grading_standards"]}, m)
         with self.assertRaises(ValueError):
             self.account.add_grading_standards("title", [])
 
     def test_add_grading_standards_non_dict_list(self, m):
-        register_uris({'account': ['add_grading_standards']}, m)
+        register_uris({"account": ["add_grading_standards"]}, m)
         with self.assertRaises(ValueError):
             self.account.add_grading_standards("title", [1, 2, 3])
 
     def test_add_grading_standards_missing_value_key(self, m):
-        register_uris({'account': ['add_grading_standards']}, m)
+        register_uris({"account": ["add_grading_standards"]}, m)
         with self.assertRaises(ValueError):
-            self.account.add_grading_standards("title", [{'name': "test"}])
+            self.account.add_grading_standards("title", [{"name": "test"}])
 
     def test_add_grading_standards_missing_name_key(self, m):
-        register_uris({'account': ['add_grading_standards']}, m)
+        register_uris({"account": ["add_grading_standards"]}, m)
         with self.assertRaises(ValueError):
-            self.account.add_grading_standards("title", [{'value': 2}])
+            self.account.add_grading_standards("title", [{"value": 2}])
 
     # get_grading_standards()
     def test_get_grading_standards(self, m):
-        register_uris({'account': ['get_grading_standards']}, m)
+        register_uris({"account": ["get_grading_standards"]}, m)
 
         standards = self.account.get_grading_standards()
         standard_list = [standard for standard in standards]
@@ -792,22 +818,22 @@ class TestAccount(unittest.TestCase):
 
     # get_single_grading_standards()
     def test_get_single_grading_standard(self, m):
-        register_uris({'account': ['get_single_grading_standard']}, m)
+        register_uris({"account": ["get_single_grading_standard"]}, m)
 
         response = self.account.get_single_grading_standard(1)
 
         self.assertIsInstance(response, GradingStandard)
-        self.assertTrue(hasattr(response, 'id'))
+        self.assertTrue(hasattr(response, "id"))
         self.assertEqual(1, response.id)
-        self.assertTrue(hasattr(response, 'title'))
+        self.assertTrue(hasattr(response, "title"))
         self.assertEqual("Grading Standard 1", response.title)
         self.assertTrue(hasattr(response, "grading_scheme"))
-        self.assertEqual(response.grading_scheme[0].get('name'), "A")
-        self.assertEqual(response.grading_scheme[0].get('value'), 0.9)
+        self.assertEqual(response.grading_scheme[0].get("name"), "A")
+        self.assertEqual(response.grading_scheme[0].get("value"), 0.9)
 
     # get_rubric
     def test_get_rubric(self, m):
-        register_uris({'account': ['get_rubric_single']}, m)
+        register_uris({"account": ["get_rubric_single"]}, m)
 
         rubric_id = 1
         rubric = self.account.get_rubric(rubric_id)
@@ -818,7 +844,7 @@ class TestAccount(unittest.TestCase):
 
     # list_rubrics
     def test_list_rubrics(self, m):
-        register_uris({'account': ['get_rubric_multiple']}, m)
+        register_uris({"account": ["get_rubric_multiple"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             rubrics = self.account.list_rubrics()
@@ -837,7 +863,7 @@ class TestAccount(unittest.TestCase):
 
     # get_rubrics
     def test_get_rubrics(self, m):
-        register_uris({'account': ['get_rubric_multiple']}, m)
+        register_uris({"account": ["get_rubric_multiple"]}, m)
 
         rubrics = self.account.get_rubrics()
 
@@ -852,41 +878,43 @@ class TestAccount(unittest.TestCase):
 
     # create_content_migration
     def test_create_content_migration(self, m):
-        register_uris({'account': ['create_content_migration']}, m)
+        register_uris({"account": ["create_content_migration"]}, m)
 
-        content_migration = self.account.create_content_migration('dummy_importer')
+        content_migration = self.account.create_content_migration("dummy_importer")
 
         self.assertIsInstance(content_migration, ContentMigration)
-        self.assertTrue(hasattr(content_migration, 'migration_type'))
+        self.assertTrue(hasattr(content_migration, "migration_type"))
 
     def test_create_content_migration_migrator(self, m):
-        register_uris({'account': ['create_content_migration',
-                                   'get_migration_systems_multiple']}, m)
+        register_uris(
+            {"account": ["create_content_migration", "get_migration_systems_multiple"]},
+            m,
+        )
 
         migrators = self.account.get_migration_systems()
         content_migration = self.account.create_content_migration(migrators[0])
 
         self.assertIsInstance(content_migration, ContentMigration)
-        self.assertTrue(hasattr(content_migration, 'migration_type'))
+        self.assertTrue(hasattr(content_migration, "migration_type"))
 
     def test_create_content_migration_bad_migration_type(self, m):
-        register_uris({'account': ['create_content_migration']}, m)
+        register_uris({"account": ["create_content_migration"]}, m)
 
         with self.assertRaises(TypeError):
             self.account.create_content_migration(1)
 
     # get_content_migration
     def test_get_content_migration(self, m):
-        register_uris({'account': ['get_content_migration_single']}, m)
+        register_uris({"account": ["get_content_migration_single"]}, m)
 
         content_migration = self.account.get_content_migration(1)
 
         self.assertIsInstance(content_migration, ContentMigration)
-        self.assertTrue(hasattr(content_migration, 'migration_type'))
+        self.assertTrue(hasattr(content_migration, "migration_type"))
 
     # get_content_migrations
     def test_get_content_migrations(self, m):
-        register_uris({'account': ['get_content_migration_multiple']}, m)
+        register_uris({"account": ["get_content_migration_multiple"]}, m)
 
         content_migrations = self.account.get_content_migrations()
 
@@ -901,7 +929,7 @@ class TestAccount(unittest.TestCase):
 
     # get_migration_systems
     def test_get_migration_systems(self, m):
-        register_uris({'account': ['get_migration_systems_multiple']}, m)
+        register_uris({"account": ["get_migration_systems_multiple"]}, m)
 
         migration_systems = self.account.get_migration_systems()
 
@@ -918,7 +946,7 @@ class TestAccount(unittest.TestCase):
 
     # get_admins()
     def test_get_admins(self, m):
-        register_uris({'account': ['get_admins', 'get_admins_page_2']}, m)
+        register_uris({"account": ["get_admins", "get_admins_page_2"]}, m)
 
         admins = self.account.get_admins()
         admin_list = [admin for admin in admins]
@@ -928,11 +956,11 @@ class TestAccount(unittest.TestCase):
         self.assertIsInstance(admin_list[0], Admin)
         self.assertIsInstance(admin_list[1], Admin)
 
-        self.assertTrue(hasattr(admin_list[0], 'id'))
-        self.assertTrue(hasattr(admin_list[1], 'role'))
-        self.assertTrue(hasattr(admin_list[0], 'role_id'))
-        self.assertTrue(hasattr(admin_list[1], 'workflow_state'))
+        self.assertTrue(hasattr(admin_list[0], "id"))
+        self.assertTrue(hasattr(admin_list[1], "role"))
+        self.assertTrue(hasattr(admin_list[0], "role_id"))
+        self.assertTrue(hasattr(admin_list[1], "workflow_state"))
 
-        self.assertEqual(admin_list[1].user['login_id'], 'jdoe')
-        self.assertEqual(admin_list[1].role, 'AccountAdmin')
+        self.assertEqual(admin_list[1].user["login_id"], "jdoe")
+        self.assertEqual(admin_list[1].role, "AccountAdmin")
         self.assertEqual(admin_list[0].role_id, 2)

--- a/tests/test_appointment_group.py
+++ b/tests/test_appointment_group.py
@@ -12,36 +12,35 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestAppointmentGroup(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({'appointment_group': ['get_appointment_group']}, m)
+            register_uris({"appointment_group": ["get_appointment_group"]}, m)
 
             self.appointment_group = self.canvas.get_appointment_group(567)
 
     # delete()
     def test_delete_appointment_group(self, m):
-        register_uris({'appointment_group': ['delete_appointment_group']}, m)
+        register_uris({"appointment_group": ["delete_appointment_group"]}, m)
 
         deleted_appointment_group = self.appointment_group.delete()
 
         self.assertIsInstance(deleted_appointment_group, AppointmentGroup)
-        self.assertTrue(hasattr(deleted_appointment_group, 'title'))
-        self.assertEqual(deleted_appointment_group.title, 'Test Group 3')
+        self.assertTrue(hasattr(deleted_appointment_group, "title"))
+        self.assertEqual(deleted_appointment_group.title, "Test Group 3")
 
     # edit()
     def test_edit_appointment_group(self, m):
-        register_uris({'appointment_group': ['edit_appointment_group']}, m)
+        register_uris({"appointment_group": ["edit_appointment_group"]}, m)
 
-        title = 'New Name'
+        title = "New Name"
         edited_appointment_group = self.appointment_group.edit(
-            appointment_group={'title': title, 'context_codes': {'course_765'}}
+            appointment_group={"title": title, "context_codes": {"course_765"}}
         )
 
         self.assertIsInstance(edited_appointment_group, AppointmentGroup)
-        self.assertTrue(hasattr(edited_appointment_group, 'title'))
+        self.assertTrue(hasattr(edited_appointment_group, "title"))
         self.assertEqual(edited_appointment_group.title, title)
 
     def test_edit_appointment_group_fail(self, m):

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -16,33 +16,32 @@ from tests.util import register_uris, cleanup_file
 
 @requests_mock.Mocker()
 class TestAssignment(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({'course': ['get_by_id', 'get_assignment_by_id']}, m)
+            register_uris({"course": ["get_by_id", "get_assignment_by_id"]}, m)
 
             self.course = self.canvas.get_course(1)
             self.assignment = self.course.get_assignment(1)
 
     # create_override()
     def test_create_override(self, m):
-        register_uris({'assignment': ['create_override']}, m)
+        register_uris({"assignment": ["create_override"]}, m)
 
         override = self.assignment.create_override(
             assignment_override={
-                'student_ids': [1, 2, 3],
-                'title': 'New Assignment Override'
+                "student_ids": [1, 2, 3],
+                "title": "New Assignment Override",
             }
         )
 
         self.assertIsInstance(override, AssignmentOverride)
-        self.assertEqual(override.title, 'New Assignment Override')
+        self.assertEqual(override.title, "New Assignment Override")
 
     # delete()
     def test_delete_assignments(self, m):
-        register_uris({'assignment': ['delete_assignment']}, m)
+        register_uris({"assignment": ["delete_assignment"]}, m)
 
         deleted_assignment = self.assignment.delete()
 
@@ -50,18 +49,18 @@ class TestAssignment(unittest.TestCase):
 
     # edit()
     def test_edit_assignment(self, m):
-        register_uris({'assignment': ['edit_assignment']}, m)
+        register_uris({"assignment": ["edit_assignment"]}, m)
 
-        name = 'New Name'
-        edited_assignment = self.assignment.edit(assignment={'name': name})
+        name = "New Name"
+        edited_assignment = self.assignment.edit(assignment={"name": name})
 
         self.assertIsInstance(edited_assignment, Assignment)
-        self.assertTrue(hasattr(edited_assignment, 'name'))
+        self.assertTrue(hasattr(edited_assignment, "name"))
         self.assertEqual(edited_assignment.name, name)
 
     # get_gradeable_students()
     def test_get_gradeable_students(self, m):
-        register_uris({'course': ['list_gradeable_students']}, m)
+        register_uris({"course": ["list_gradeable_students"]}, m)
 
         students = self.assignment.get_gradeable_students()
         student_list = [student for student in students]
@@ -71,7 +70,7 @@ class TestAssignment(unittest.TestCase):
 
     # get_override()
     def test_get_override(self, m):
-        register_uris({'assignment': ['get_assignment_override']}, m)
+        register_uris({"assignment": ["get_assignment_override"]}, m)
 
         override = self.assignment.get_override(1)
 
@@ -79,10 +78,15 @@ class TestAssignment(unittest.TestCase):
 
     # get_overrides()
     def test_get_overrides(self, m):
-        register_uris({'assignment': [
-            'list_assignment_overrides',
-            'list_assignment_overrides_p2'
-        ]}, m)
+        register_uris(
+            {
+                "assignment": [
+                    "list_assignment_overrides",
+                    "list_assignment_overrides_p2",
+                ]
+            },
+            m,
+        )
 
         overrides = self.assignment.get_overrides()
         override_list = [override for override in overrides]
@@ -93,24 +97,21 @@ class TestAssignment(unittest.TestCase):
 
     # get_submission()
     def test_get_submission(self, m):
-        register_uris({
-            'submission': ['get_by_id_course'],
-            'user': ['get_by_id']
-        }, m)
+        register_uris({"submission": ["get_by_id_course"], "user": ["get_by_id"]}, m)
 
         user_id = 1
         submission_by_id = self.assignment.get_submission(user_id)
         self.assertIsInstance(submission_by_id, Submission)
-        self.assertTrue(hasattr(submission_by_id, 'submission_type'))
+        self.assertTrue(hasattr(submission_by_id, "submission_type"))
 
         user = self.canvas.get_user(user_id)
         submission_by_obj = self.assignment.get_submission(user)
         self.assertIsInstance(submission_by_obj, Submission)
-        self.assertTrue(hasattr(submission_by_obj, 'submission_type'))
+        self.assertTrue(hasattr(submission_by_obj, "submission_type"))
 
     # get_submissions()
     def test_get_submissions(self, m):
-        register_uris({'submission': ['list_submissions']}, m)
+        register_uris({"submission": ["list_submissions"]}, m)
 
         submissions = self.assignment.get_submissions()
         submission_list_by_id = [submission for submission in submissions]
@@ -120,14 +121,14 @@ class TestAssignment(unittest.TestCase):
 
     # submit()
     def test_submit(self, m):
-        register_uris({'assignment': ['submit']}, m)
+        register_uris({"assignment": ["submit"]}, m)
 
         sub_type = "online_upload"
-        sub_dict = {'submission_type': sub_type}
+        sub_dict = {"submission_type": sub_type}
         submission = self.assignment.submit(sub_dict)
 
         self.assertIsInstance(submission, Submission)
-        self.assertTrue(hasattr(submission, 'submission_type'))
+        self.assertTrue(hasattr(submission, "submission_type"))
         self.assertEqual(submission.submission_type, sub_type)
 
     def test_submit_fail(self, m):
@@ -135,40 +136,40 @@ class TestAssignment(unittest.TestCase):
             self.assignment.submit({})
 
     def test_submit_file(self, m):
-        register_uris({'assignment': ['submit', 'upload', 'upload_final']}, m)
+        register_uris({"assignment": ["submit", "upload", "upload_final"]}, m)
 
-        filename = 'testfile_assignment_{}'.format(uuid.uuid4().hex)
+        filename = "testfile_assignment_{}".format(uuid.uuid4().hex)
 
         try:
-            with open(filename, 'w+') as file:
+            with open(filename, "w+") as file:
                 sub_type = "online_upload"
-                sub_dict = {'submission_type': sub_type}
+                sub_dict = {"submission_type": sub_type}
                 submission = self.assignment.submit(sub_dict, file)
 
             self.assertIsInstance(submission, Submission)
-            self.assertTrue(hasattr(submission, 'submission_type'))
+            self.assertTrue(hasattr(submission, "submission_type"))
             self.assertEqual(submission.submission_type, sub_type)
 
         finally:
             cleanup_file(filename)
 
     def test_submit_file_wrong_type(self, m):
-        filename = 'testfile_assignment_{}'.format(uuid.uuid4().hex)
+        filename = "testfile_assignment_{}".format(uuid.uuid4().hex)
         sub_type = "online_text_entry"
-        sub_dict = {'submission_type': sub_type}
+        sub_dict = {"submission_type": sub_type}
 
         with self.assertRaises(ValueError):
             self.assignment.submit(sub_dict, filename)
 
     def test_submit_file_upload_failure(self, m):
-        register_uris({'assignment': ['submit', 'upload', 'upload_fail']}, m)
+        register_uris({"assignment": ["submit", "upload", "upload_fail"]}, m)
 
-        filename = 'testfile_assignment_{}'.format(uuid.uuid4().hex)
+        filename = "testfile_assignment_{}".format(uuid.uuid4().hex)
 
         try:
-            with open(filename, 'w+') as file:
+            with open(filename, "w+") as file:
                 sub_type = "online_upload"
-                sub_dict = {'submission_type': sub_type}
+                sub_dict = {"submission_type": sub_type}
                 with self.assertRaises(CanvasException):
                     self.assignment.submit(sub_dict, file)
         finally:
@@ -181,16 +182,11 @@ class TestAssignment(unittest.TestCase):
 
     # submissions_bulk_update()
     def test_submissions_bulk_update(self, m):
-        register_uris({'assignment': ['update_submissions']}, m)
-        register_uris({'progress': ['course_progress']}, m)
-        progress = self.assignment.submissions_bulk_update(grade_data={
-            '1': {
-                'posted_grade': 97
-             },
-            '2': {
-                'posted_grade': 98
-            }
-        })
+        register_uris({"assignment": ["update_submissions"]}, m)
+        register_uris({"progress": ["course_progress"]}, m)
+        progress = self.assignment.submissions_bulk_update(
+            grade_data={"1": {"posted_grade": 97}, "2": {"posted_grade": 98}}
+        )
         self.assertIsInstance(progress, Progress)
         self.assertTrue(progress.context_type == "Course")
         progress = progress.query()
@@ -198,75 +194,73 @@ class TestAssignment(unittest.TestCase):
 
     # upload_to_submission()
     def test_upload_to_submission_self(self, m):
-        register_uris({'assignment': ['upload', 'upload_final']}, m)
+        register_uris({"assignment": ["upload", "upload_final"]}, m)
 
-        filename = 'testfile_assignment_{}'.format(uuid.uuid4().hex)
+        filename = "testfile_assignment_{}".format(uuid.uuid4().hex)
 
         try:
-            with open(filename, 'w+') as file:
+            with open(filename, "w+") as file:
                 response = self.assignment.upload_to_submission(file)
 
             self.assertTrue(response[0])
             self.assertIsInstance(response[1], dict)
-            self.assertIn('url', response[1])
+            self.assertIn("url", response[1])
         finally:
             cleanup_file(filename)
 
     def test_upload_to_submission_user(self, m):
-        register_uris({'assignment': ['upload_by_id', 'upload_final']}, m)
+        register_uris({"assignment": ["upload_by_id", "upload_final"]}, m)
 
-        filename = 'testfile_assignment_{}'.format(uuid.uuid4().hex)
+        filename = "testfile_assignment_{}".format(uuid.uuid4().hex)
 
         user_id = 1
 
         try:
-            with open(filename, 'w+') as file:
+            with open(filename, "w+") as file:
                 response = self.assignment.upload_to_submission(file, user_id)
 
             self.assertTrue(response[0])
             self.assertIsInstance(response[1], dict)
-            self.assertIn('url', response[1])
+            self.assertIn("url", response[1])
         finally:
             cleanup_file(filename)
 
 
 @requests_mock.Mocker()
 class TestAssignmentGroup(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({
-                'course': ['get_by_id'],
-                'assignment': ['get_assignment_group']
-            }, m)
+            register_uris(
+                {"course": ["get_by_id"], "assignment": ["get_assignment_group"]}, m
+            )
 
             self.course = self.canvas.get_course(1)
             self.assignment_group = self.course.get_assignment_group(5)
 
     # edit()
     def test_edit_assignment_group(self, m):
-        register_uris({'assignment': ['edit_assignment_group']}, m)
+        register_uris({"assignment": ["edit_assignment_group"]}, m)
 
-        name = 'New Name'
+        name = "New Name"
         edited_assignment_group = self.assignment_group.edit(
-            assignment_group={'name': name}
+            assignment_group={"name": name}
         )
 
         self.assertIsInstance(edited_assignment_group, AssignmentGroup)
-        self.assertTrue(hasattr(edited_assignment_group, 'name'))
+        self.assertTrue(hasattr(edited_assignment_group, "name"))
         self.assertEqual(edited_assignment_group.name, name)
 
     # delete()
     def test_delete_assignment_group(self, m):
-        register_uris({'assignment': ['delete_assignment_group']}, m)
+        register_uris({"assignment": ["delete_assignment_group"]}, m)
 
         deleted_assignment_group = self.assignment_group.delete()
 
         self.assertIsInstance(deleted_assignment_group, AssignmentGroup)
-        self.assertTrue(hasattr(deleted_assignment_group, 'name'))
-        self.assertEqual(deleted_assignment_group.name, 'Assignment Group 5')
+        self.assertTrue(hasattr(deleted_assignment_group, "name"))
+        self.assertEqual(deleted_assignment_group.name, "Assignment Group 5")
 
     # __str__()
     def test__str__(self, m):
@@ -276,15 +270,17 @@ class TestAssignmentGroup(unittest.TestCase):
 
 @requests_mock.Mocker()
 class TestAssignmentOverride(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({
-                'course': ['get_by_id', 'get_assignment_by_id'],
-                'assignment': ['get_assignment_override'],
-            }, m)
+            register_uris(
+                {
+                    "course": ["get_by_id", "get_assignment_by_id"],
+                    "assignment": ["get_assignment_override"],
+                },
+                m,
+            )
 
             self.course = self.canvas.get_course(1)
             self.assignment = self.course.get_assignment(1)
@@ -294,11 +290,11 @@ class TestAssignmentOverride(unittest.TestCase):
     def test__str__(self, m):
         string = str(self.assignment_override)
         self.assertIsInstance(string, str)
-        self.assertEqual(string, 'Assignment Override 1 (1)')
+        self.assertEqual(string, "Assignment Override 1 (1)")
 
     # delete()
     def test_delete(self, m):
-        register_uris({'assignment': ['delete_override']}, m)
+        register_uris({"assignment": ["delete_override"]}, m)
 
         deleted = self.assignment_override.delete()
         self.assertIsInstance(deleted, AssignmentOverride)
@@ -306,13 +302,15 @@ class TestAssignmentOverride(unittest.TestCase):
 
     # edit()
     def test_edit(self, m):
-        register_uris({'assignment': ['edit_override']}, m)
+        register_uris({"assignment": ["edit_override"]}, m)
 
-        edited = self.assignment_override.edit(assignment_override={
-            'title': 'New Title',
-            'student_ids': self.assignment_override.student_ids
-        })
+        edited = self.assignment_override.edit(
+            assignment_override={
+                "title": "New Title",
+                "student_ids": self.assignment_override.student_ids,
+            }
+        )
 
         self.assertEqual(edited, self.assignment_override)
         self.assertIsInstance(self.assignment_override, AssignmentOverride)
-        self.assertEqual(edited.title, 'New Title')
+        self.assertEqual(edited.title, "New Title")

--- a/tests/test_authentication_providers.py
+++ b/tests/test_authentication_providers.py
@@ -11,40 +11,43 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestAuthenticationProvider(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({
-                'account': ['get_by_id', 'add_authentication_providers']
-            }, m)
+            register_uris({"account": ["get_by_id", "add_authentication_providers"]}, m)
 
             self.account = self.canvas.get_account(1)
             self.authentication_providers = self.account.add_authentication_providers(
-                authentication_providers={
-                    "auth_type": "Authentication Providers"
-                }
+                authentication_providers={"auth_type": "Authentication Providers"}
             )
 
     # update()
     def test_update_authentication_providers(self, m):
-        register_uris({'authentication_providers': ['update_authentication_providers']}, m)
+        register_uris(
+            {"authentication_providers": ["update_authentication_providers"]}, m
+        )
 
-        new_auth_type = 'New Authentication Providers'
+        new_auth_type = "New Authentication Providers"
 
-        self.authentication_providers.update(authentication_providers={"auth_type": new_auth_type})
+        self.authentication_providers.update(
+            authentication_providers={"auth_type": new_auth_type}
+        )
         self.assertEqual(self.authentication_providers.auth_type, new_auth_type)
 
     # delete()
     def test_delete_authentication_providers(self, m):
-        register_uris({'authentication_providers': ['delete_authentication_providers']}, m)
+        register_uris(
+            {"authentication_providers": ["delete_authentication_providers"]}, m
+        )
 
         deleted_authentication_providers = self.authentication_providers.delete()
 
         self.assertIsInstance(deleted_authentication_providers, AuthenticationProvider)
-        self.assertTrue(hasattr(deleted_authentication_providers, 'auth_type'))
-        self.assertEqual(deleted_authentication_providers.auth_type, 'Authentication Providers')
+        self.assertTrue(hasattr(deleted_authentication_providers, "auth_type"))
+        self.assertEqual(
+            deleted_authentication_providers.auth_type, "Authentication Providers"
+        )
 
     # __str__()
     def test_str__(self, m):

--- a/tests/test_bookmark.py
+++ b/tests/test_bookmark.py
@@ -11,39 +11,37 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestBookmark(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({
-                'bookmark': ['get_bookmark'],
-                'current_user': ['get_by_id']
-            }, m)
+            register_uris(
+                {"bookmark": ["get_bookmark"], "current_user": ["get_by_id"]}, m
+            )
 
             self.user = self.canvas.get_current_user()
             self.bookmark = self.user.get_bookmark(45)
 
     # delete()
     def test_delete_bookmark(self, m):
-        register_uris({'bookmark': ['delete_bookmark']}, m)
+        register_uris({"bookmark": ["delete_bookmark"]}, m)
 
         deleted_bookmark = self.bookmark.delete()
 
         self.assertIsInstance(deleted_bookmark, Bookmark)
-        self.assertTrue(hasattr(deleted_bookmark, 'name'))
-        self.assertEqual(deleted_bookmark.name, 'Test Bookmark 3')
+        self.assertTrue(hasattr(deleted_bookmark, "name"))
+        self.assertEqual(deleted_bookmark.name, "Test Bookmark 3")
 
     # edit()
     def test_edit_bookmark(self, m):
-        register_uris({'bookmark': ['edit_bookmark']}, m)
+        register_uris({"bookmark": ["edit_bookmark"]}, m)
 
-        name = 'New Name'
-        url = 'http//happy-place.com'
+        name = "New Name"
+        url = "http//happy-place.com"
         edited_bookmark = self.bookmark.edit(name=name, url=url)
 
         self.assertIsInstance(edited_bookmark, Bookmark)
-        self.assertTrue(hasattr(edited_bookmark, 'name'))
+        self.assertTrue(hasattr(edited_bookmark, "name"))
         self.assertEqual(edited_bookmark.name, name)
 
     # __str__()

--- a/tests/test_calendar_event.py
+++ b/tests/test_calendar_event.py
@@ -11,36 +11,35 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestCalendarEvent(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({'calendar_event': ['get_calendar_event']}, m)
+            register_uris({"calendar_event": ["get_calendar_event"]}, m)
 
             self.calendar_event = self.canvas.get_calendar_event(567)
 
     # delete()
     def test_delete_calendar_event(self, m):
-        register_uris({'calendar_event': ['delete_calendar_event']}, m)
+        register_uris({"calendar_event": ["delete_calendar_event"]}, m)
 
         deleted_calendar_event = self.calendar_event.delete()
 
         self.assertIsInstance(deleted_calendar_event, CalendarEvent)
-        self.assertTrue(hasattr(deleted_calendar_event, 'title'))
-        self.assertEqual(deleted_calendar_event.title, 'Test Event 3')
+        self.assertTrue(hasattr(deleted_calendar_event, "title"))
+        self.assertEqual(deleted_calendar_event.title, "Test Event 3")
 
     # edit()
     def test_edit_calendar_event(self, m):
-        register_uris({'calendar_event': ['edit_calendar_event']}, m)
+        register_uris({"calendar_event": ["edit_calendar_event"]}, m)
 
-        title = 'New Name'
+        title = "New Name"
         edited_calendar_event = self.calendar_event.edit(
-            calendar_event={'title': title}
+            calendar_event={"title": title}
         )
 
         self.assertIsInstance(edited_calendar_event, CalendarEvent)
-        self.assertTrue(hasattr(edited_calendar_event, 'title'))
+        self.assertTrue(hasattr(edited_calendar_event, "title"))
         self.assertEqual(edited_calendar_event.title, title)
 
     # __str__()

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -30,7 +30,6 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestCanvas(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
@@ -48,22 +47,20 @@ class TestCanvas(unittest.TestCase):
 
     # create_account()
     def test_create_account(self, m):
-        register_uris({'account': ['create']}, m)
+        register_uris({"account": ["create"]}, m)
 
-        name = 'Newly Created Account'
+        name = "Newly Created Account"
 
-        account_dict = {
-            'name': name
-        }
+        account_dict = {"name": name}
         account = self.canvas.create_account(account=account_dict)
 
         self.assertIsInstance(account, Account)
-        self.assertTrue(hasattr(account, 'name'))
+        self.assertTrue(hasattr(account, "name"))
         self.assertEqual(account.name, name)
 
     # get_account()
     def test_get_account(self, m):
-        register_uris({'account': ['get_by_id']}, m)
+        register_uris({"account": ["get_by_id"]}, m)
 
         account_by_id = self.canvas.get_account(1)
         self.assertIsInstance(account_by_id, Account)
@@ -72,22 +69,22 @@ class TestCanvas(unittest.TestCase):
         self.assertIsInstance(account_by_obj, Account)
 
     def test_get_account_sis_id(self, m):
-        register_uris({'account': ['get_by_sis_id']}, m)
+        register_uris({"account": ["get_by_sis_id"]}, m)
 
-        account = self.canvas.get_account('test-sis-id', use_sis_id=True)
+        account = self.canvas.get_account("test-sis-id", use_sis_id=True)
 
         self.assertIsInstance(account, Account)
-        self.assertEqual(account.name, 'Account From SIS')
+        self.assertEqual(account.name, "Account From SIS")
 
     def test_get_account_fail(self, m):
-        register_uris({'generic': ['not_found']}, m)
+        register_uris({"generic": ["not_found"]}, m)
 
         with self.assertRaises(ResourceDoesNotExist):
             self.canvas.get_account(settings.INVALID_ID)
 
     # get_accounts()
     def test_get_accounts(self, m):
-        register_uris({'account': ['multiple']}, m)
+        register_uris({"account": ["multiple"]}, m)
 
         accounts = self.canvas.get_accounts()
         account_list = [account for account in accounts]
@@ -95,7 +92,7 @@ class TestCanvas(unittest.TestCase):
 
     # get_course_accounts()
     def test_get_course_accounts(self, m):
-        register_uris({'account': ['multiple_course']}, m)
+        register_uris({"account": ["multiple_course"]}, m)
 
         accounts = self.canvas.get_course_accounts()
         account_list = [account for account in accounts]
@@ -103,85 +100,85 @@ class TestCanvas(unittest.TestCase):
 
     # get_course()
     def test_get_course(self, m):
-        register_uris({'course': ['get_by_id']}, m)
+        register_uris({"course": ["get_by_id"]}, m)
 
         course_by_id = self.canvas.get_course(1)
         self.assertIsInstance(course_by_id, Course)
-        self.assertTrue(hasattr(course_by_id, 'name'))
+        self.assertTrue(hasattr(course_by_id, "name"))
 
         course_by_obj = self.canvas.get_course(course_by_id)
         self.assertIsInstance(course_by_obj, Course)
-        self.assertTrue(hasattr(course_by_obj, 'name'))
+        self.assertTrue(hasattr(course_by_obj, "name"))
 
     def test_get_course_sis_id(self, m):
-        register_uris({'course': ['get_by_sis_id']}, m)
+        register_uris({"course": ["get_by_sis_id"]}, m)
 
-        course = self.canvas.get_course('test-sis-id', use_sis_id=True)
+        course = self.canvas.get_course("test-sis-id", use_sis_id=True)
 
         self.assertIsInstance(course, Course)
-        self.assertEqual(course.name, 'SIS Course')
+        self.assertEqual(course.name, "SIS Course")
 
     def test_get_course_with_start_date(self, m):
-        register_uris({'course': ['start_at_date']}, m)
+        register_uris({"course": ["start_at_date"]}, m)
 
         course = self.canvas.get_course(2)
 
-        self.assertTrue(hasattr(course, 'start_at'))
+        self.assertTrue(hasattr(course, "start_at"))
         self.assertIsInstance(course.start_at, text_type)
-        self.assertTrue(hasattr(course, 'start_at_date'))
+        self.assertTrue(hasattr(course, "start_at_date"))
         self.assertIsInstance(course.start_at_date, datetime)
         self.assertEqual(course.start_at_date.tzinfo, pytz.utc)
 
     def test_get_course_non_unicode_char(self, m):
-        register_uris({'course': ['unicode_encode_error']}, m)
+        register_uris({"course": ["unicode_encode_error"]}, m)
 
         course = self.canvas.get_course(3)
 
-        self.assertTrue(hasattr(course, 'name'))
+        self.assertTrue(hasattr(course, "name"))
 
     def test_get_course_fail(self, m):
-        register_uris({'generic': ['not_found']}, m)
+        register_uris({"generic": ["not_found"]}, m)
 
         with self.assertRaises(ResourceDoesNotExist):
             self.canvas.get_course(settings.INVALID_ID)
 
     # get_user()
     def test_get_user(self, m):
-        register_uris({'user': ['get_by_id']}, m)
+        register_uris({"user": ["get_by_id"]}, m)
 
         user_by_id = self.canvas.get_user(1)
         self.assertIsInstance(user_by_id, User)
-        self.assertTrue(hasattr(user_by_id, 'name'))
+        self.assertTrue(hasattr(user_by_id, "name"))
 
         user_by_obj = self.canvas.get_user(user_by_id)
         self.assertIsInstance(user_by_obj, User)
-        self.assertTrue(hasattr(user_by_obj, 'name'))
+        self.assertTrue(hasattr(user_by_obj, "name"))
 
     def test_get_user_by_id_type(self, m):
-        register_uris({'user': ['get_by_id_type']}, m)
+        register_uris({"user": ["get_by_id_type"]}, m)
 
-        user = self.canvas.get_user('jdoe', 'sis_user_id')
+        user = self.canvas.get_user("jdoe", "sis_user_id")
 
         self.assertIsInstance(user, User)
-        self.assertTrue(hasattr(user, 'name'))
+        self.assertTrue(hasattr(user, "name"))
 
     def test_get_user_self(self, m):
-        register_uris({'user': ['get_by_id_self']}, m)
+        register_uris({"user": ["get_by_id_self"]}, m)
 
-        user = self.canvas.get_user('self')
+        user = self.canvas.get_user("self")
 
         self.assertIsInstance(user, User)
-        self.assertTrue(hasattr(user, 'name'))
+        self.assertTrue(hasattr(user, "name"))
 
     def test_get_user_fail(self, m):
-        register_uris({'generic': ['not_found']}, m)
+        register_uris({"generic": ["not_found"]}, m)
 
         with self.assertRaises(ResourceDoesNotExist):
             self.canvas.get_user(settings.INVALID_ID)
 
     # get_courses()
     def test_get_courses(self, m):
-        register_uris({'course': ['multiple', 'multiple_page_2']}, m)
+        register_uris({"course": ["multiple", "multiple_page_2"]}, m)
 
         courses = self.canvas.get_courses(per_page=1)
 
@@ -191,7 +188,7 @@ class TestCanvas(unittest.TestCase):
 
     # get_activity_stream_summary()
     def test_get_activity_stream_summary(self, m):
-        register_uris({'user': ['activity_stream_summary']}, m)
+        register_uris({"user": ["activity_stream_summary"]}, m)
 
         summary = self.canvas.get_activity_stream_summary()
 
@@ -199,7 +196,7 @@ class TestCanvas(unittest.TestCase):
 
     # get_todo_items()
     def test_get_todo_items(self, m):
-        register_uris({'user': ['todo_items']}, m)
+        register_uris({"user": ["todo_items"]}, m)
 
         todo_items = self.canvas.get_todo_items()
 
@@ -207,7 +204,7 @@ class TestCanvas(unittest.TestCase):
 
     # get_upcoming_events()
     def test_get_upcoming_events(self, m):
-        register_uris({'user': ['upcoming_events']}, m)
+        register_uris({"user": ["upcoming_events"]}, m)
 
         events = self.canvas.get_upcoming_events()
 
@@ -215,69 +212,69 @@ class TestCanvas(unittest.TestCase):
 
     # get_course_nicknames()
     def test_get_course_nicknames(self, m):
-        register_uris({'user': ['course_nicknames', 'course_nicknames_page_2']}, m)
+        register_uris({"user": ["course_nicknames", "course_nicknames_page_2"]}, m)
 
         nicknames = self.canvas.get_course_nicknames()
 
         nickname_list = [name for name in nicknames]
         self.assertEqual(len(nickname_list), 4)
         self.assertIsInstance(nickname_list[0], CourseNickname)
-        self.assertTrue(hasattr(nickname_list[0], 'nickname'))
+        self.assertTrue(hasattr(nickname_list[0], "nickname"))
 
     # get_course_nickname()
     def test_get_course_nickname(self, m):
-        register_uris({'course': ['get_by_id'], 'user': ['course_nickname']}, m)
+        register_uris({"course": ["get_by_id"], "user": ["course_nickname"]}, m)
 
         nickname_by_id = self.canvas.get_course_nickname(1)
         self.assertIsInstance(nickname_by_id, CourseNickname)
-        self.assertTrue(hasattr(nickname_by_id, 'nickname'))
+        self.assertTrue(hasattr(nickname_by_id, "nickname"))
 
         course_for_obj = self.canvas.get_course(1)
         nickname_by_obj = self.canvas.get_course_nickname(course_for_obj)
         self.assertIsInstance(nickname_by_obj, CourseNickname)
-        self.assertTrue(hasattr(nickname_by_obj, 'nickname'))
+        self.assertTrue(hasattr(nickname_by_obj, "nickname"))
 
     def test_get_course_nickname_fail(self, m):
-        register_uris({'generic': ['not_found']}, m)
+        register_uris({"generic": ["not_found"]}, m)
 
         with self.assertRaises(ResourceDoesNotExist):
             self.canvas.get_course_nickname(settings.INVALID_ID)
 
     # set_course_nickname()
     def test_set_course_nickname(self, m):
-        register_uris({'course': ['get_by_id'], 'user': ['course_nickname_set']}, m)
+        register_uris({"course": ["get_by_id"], "user": ["course_nickname_set"]}, m)
 
-        name = 'New Course Nickname'
+        name = "New Course Nickname"
         nickname_by_id = self.canvas.set_course_nickname(1, name)
         self.assertIsInstance(nickname_by_id, CourseNickname)
-        self.assertTrue(hasattr(nickname_by_id, 'nickname'))
+        self.assertTrue(hasattr(nickname_by_id, "nickname"))
         self.assertEqual(nickname_by_id.nickname, name)
 
         course_for_obj = self.canvas.get_course(1)
         nickname_by_obj = self.canvas.set_course_nickname(course_for_obj, name)
         self.assertIsInstance(nickname_by_obj, CourseNickname)
-        self.assertTrue(hasattr(nickname_by_obj, 'nickname'))
+        self.assertTrue(hasattr(nickname_by_obj, "nickname"))
 
     # clear_course_nicknames()
     def test_clear_course_nicknames(self, m):
-        register_uris({'user': ['course_nicknames_delete']}, m)
+        register_uris({"user": ["course_nicknames_delete"]}, m)
 
         success = self.canvas.clear_course_nicknames()
         self.assertTrue(success)
 
     # search_accounts()
     def test_search_accounts(self, m):
-        register_uris({'account': ['domains']}, m)
+        register_uris({"account": ["domains"]}, m)
 
         domains = self.canvas.search_accounts()
 
         self.assertIsInstance(domains, list)
         self.assertEqual(len(domains), 1)
-        self.assertIn('name', domains[0])
+        self.assertIn("name", domains[0])
 
     # get_section()
     def test_get_section(self, m):
-        register_uris({'section': ['get_by_id']}, m)
+        register_uris({"section": ["get_by_id"]}, m)
 
         section_by_id = self.canvas.get_section(1)
         self.assertIsInstance(section_by_id, Section)
@@ -286,48 +283,48 @@ class TestCanvas(unittest.TestCase):
         self.assertIsInstance(section_by_obj, Section)
 
     def test_get_section_sis_id(self, m):
-        register_uris({'section': ['get_by_sis_id']}, m)
+        register_uris({"section": ["get_by_sis_id"]}, m)
 
-        section = self.canvas.get_section('test-sis-id', use_sis_id=True)
+        section = self.canvas.get_section("test-sis-id", use_sis_id=True)
 
         self.assertIsInstance(section, Section)
-        self.assertEqual(section.name, 'SIS Section')
+        self.assertEqual(section.name, "SIS Section")
 
     # create_group()
     def test_create_group(self, m):
-        register_uris({'group': ['create']}, m)
+        register_uris({"group": ["create"]}, m)
 
         group = self.canvas.create_group()
 
         self.assertIsInstance(group, Group)
-        self.assertTrue(hasattr(group, 'name'))
-        self.assertTrue(hasattr(group, 'description'))
+        self.assertTrue(hasattr(group, "name"))
+        self.assertTrue(hasattr(group, "description"))
 
     # get_group()
     def test_get_group(self, m):
-        register_uris({'group': ['get_by_id']}, m)
+        register_uris({"group": ["get_by_id"]}, m)
 
         group_by_id = self.canvas.get_group(1)
         self.assertIsInstance(group_by_id, Group)
-        self.assertTrue(hasattr(group_by_id, 'name'))
-        self.assertTrue(hasattr(group_by_id, 'description'))
+        self.assertTrue(hasattr(group_by_id, "name"))
+        self.assertTrue(hasattr(group_by_id, "description"))
 
         group_by_obj = self.canvas.get_group(group_by_id)
         self.assertIsInstance(group_by_obj, Group)
-        self.assertTrue(hasattr(group_by_obj, 'name'))
-        self.assertTrue(hasattr(group_by_obj, 'description'))
+        self.assertTrue(hasattr(group_by_obj, "name"))
+        self.assertTrue(hasattr(group_by_obj, "description"))
 
     def test_get_group_sis_id(self, m):
-        register_uris({'group': ['get_by_sis_id']}, m)
+        register_uris({"group": ["get_by_sis_id"]}, m)
 
-        group = self.canvas.get_group('test-sis-id', use_sis_id=True)
+        group = self.canvas.get_group("test-sis-id", use_sis_id=True)
 
         self.assertIsInstance(group, Group)
-        self.assertEqual(group.name, 'SIS Group')
+        self.assertEqual(group.name, "SIS Group")
 
     # get_group_category()
     def test_get_group_category(self, m):
-        register_uris({'group': ['get_category_by_id']}, m)
+        register_uris({"group": ["get_category_by_id"]}, m)
 
         group_category_by_id = self.canvas.get_group_category(1)
         self.assertIsInstance(group_category_by_id, GroupCategory)
@@ -337,59 +334,55 @@ class TestCanvas(unittest.TestCase):
 
     # create_conversation()
     def test_create_conversation(self, m):
-        register_uris({'conversation': ['create_conversation']}, m)
+        register_uris({"conversation": ["create_conversation"]}, m)
 
-        recipients = ['2']
-        body = 'Hello, World!'
+        recipients = ["2"]
+        body = "Hello, World!"
 
         conversations = self.canvas.create_conversation(
-            recipients=recipients,
-            body=body
+            recipients=recipients, body=body
         )
         self.assertIsInstance(conversations, list)
         self.assertEqual(len(conversations), 1)
         self.assertIsInstance(conversations[0], Conversation)
-        self.assertTrue(hasattr(conversations[0], 'last_message'))
+        self.assertTrue(hasattr(conversations[0], "last_message"))
         self.assertEqual(conversations[0].last_message, body)
 
     def test_create_conversation_multiple_people(self, m):
-        register_uris({'conversation': ['create_conversation_multiple']}, m)
+        register_uris({"conversation": ["create_conversation_multiple"]}, m)
 
-        recipients = ['2', '3']
-        body = 'Hey guys!'
+        recipients = ["2", "3"]
+        body = "Hey guys!"
 
         conversations = self.canvas.create_conversation(
-            recipients=recipients,
-            body=body
+            recipients=recipients, body=body
         )
         self.assertIsInstance(conversations, list)
         self.assertEqual(len(conversations), 2)
 
         self.assertIsInstance(conversations[0], Conversation)
-        self.assertTrue(hasattr(conversations[0], 'last_message'))
+        self.assertTrue(hasattr(conversations[0], "last_message"))
         self.assertEqual(conversations[0].last_message, body)
 
         self.assertIsInstance(conversations[1], Conversation)
-        self.assertTrue(hasattr(conversations[1], 'last_message'))
+        self.assertTrue(hasattr(conversations[1], "last_message"))
         self.assertEqual(conversations[1].last_message, body)
 
     # get_conversation()
     def test_get_conversation(self, m):
-        register_uris({'conversation': ['get_by_id']}, m)
+        register_uris({"conversation": ["get_by_id"]}, m)
 
         conversation_by_id = self.canvas.get_conversation(1)
         self.assertIsInstance(conversation_by_id, Conversation)
-        self.assertTrue(hasattr(conversation_by_id, 'subject'))
+        self.assertTrue(hasattr(conversation_by_id, "subject"))
 
         conversation_by_obj = self.canvas.get_conversation(conversation_by_id)
         self.assertIsInstance(conversation_by_obj, Conversation)
-        self.assertTrue(hasattr(conversation_by_obj, 'subject'))
+        self.assertTrue(hasattr(conversation_by_obj, "subject"))
 
     # get_conversations()
     def test_get_conversations(self, m):
-        requires = {
-            'conversation': ['get_conversations', 'get_conversations_2']
-        }
+        requires = {"conversation": ["get_conversations", "get_conversations_2"]}
         register_uris(requires, m)
 
         convos = self.canvas.get_conversations()
@@ -400,36 +393,35 @@ class TestCanvas(unittest.TestCase):
 
     # mark_all_as_read()
     def test_conversations_mark_all_as_read(self, m):
-        register_uris({'conversation': ['mark_all_as_read']}, m)
+        register_uris({"conversation": ["mark_all_as_read"]}, m)
 
         result = self.canvas.conversations_mark_all_as_read()
         self.assertTrue(result)
 
     # unread_count()
     def test_conversations_unread_count(self, m):
-        register_uris({'conversation': ['unread_count']}, m)
+        register_uris({"conversation": ["unread_count"]}, m)
 
         result = self.canvas.conversations_unread_count()
-        self.assertEqual(result['unread_count'], "7")
+        self.assertEqual(result["unread_count"], "7")
 
     # get_running_batches()
     def test_conversations_get_running_batches(self, m):
-        register_uris({'conversation': ['get_running_batches']}, m)
+        register_uris({"conversation": ["get_running_batches"]}, m)
 
         result = self.canvas.conversations_get_running_batches()
         self.assertEqual(len(result), 2)
-        self.assertIn('body', result[0]['message'])
-        self.assertEqual(result[1]['message']['author_id'], 1)
+        self.assertIn("body", result[0]["message"])
+        self.assertEqual(result[1]["message"]["author_id"], 1)
 
     # batch_update()
     def test_conversations_batch_update(self, m):
-        register_uris({'conversation': ['batch_update']}, m)
+        register_uris({"conversation": ["batch_update"]}, m)
 
         conversation_ids = [1, 2]
         this_event = "mark_as_read"
         result = self.canvas.conversations_batch_update(
-            event=this_event,
-            conversation_ids=conversation_ids
+            event=this_event, conversation_ids=conversation_ids
         )
         self.assertIsInstance(result, Progress)
 
@@ -437,8 +429,7 @@ class TestCanvas(unittest.TestCase):
         conversation_ids = [1, 2]
         this_event = "this doesn't work"
         result = self.canvas.conversations_batch_update(
-            event=this_event,
-            conversation_ids=conversation_ids
+            event=this_event, conversation_ids=conversation_ids
         )
         self.assertIsInstance(result, ValueError)
 
@@ -446,18 +437,15 @@ class TestCanvas(unittest.TestCase):
         conversation_ids = [None] * 501
         this_event = "mark_as_read"
         result = self.canvas.conversations_batch_update(
-            event=this_event,
-            conversation_ids=conversation_ids
+            event=this_event, conversation_ids=conversation_ids
         )
         self.assertIsInstance(result, ValueError)
 
     # create_calendar_event()
     def test_create_calendar_event(self, m):
-        register_uris({'calendar_event': ['create_calendar_event']}, m)
+        register_uris({"calendar_event": ["create_calendar_event"]}, m)
 
-        cal_event = {
-            "context_code": "course_123"
-        }
+        cal_event = {"context_code": "course_123"}
         evnt = self.canvas.create_calendar_event(calendar_event=cal_event)
 
         self.assertIsInstance(evnt, CalendarEvent)
@@ -470,7 +458,7 @@ class TestCanvas(unittest.TestCase):
 
     # list_calendar_events()
     def test_list_calendar_events(self, m):
-        register_uris({'calendar_event': ['list_calendar_events']}, m)
+        register_uris({"calendar_event": ["list_calendar_events"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             cal_events = self.canvas.list_calendar_events()
@@ -482,7 +470,7 @@ class TestCanvas(unittest.TestCase):
 
     # get_calendar_events()
     def test_get_calendar_events(self, m):
-        register_uris({'calendar_event': ['list_calendar_events']}, m)
+        register_uris({"calendar_event": ["list_calendar_events"]}, m)
 
         cal_events = self.canvas.get_calendar_events()
         cal_event_list = [cal_event for cal_event in cal_events]
@@ -490,7 +478,7 @@ class TestCanvas(unittest.TestCase):
 
     # get_calendar_event()
     def test_get_calendar_event(self, m):
-        register_uris({'calendar_event': ['get_calendar_event']}, m)
+        register_uris({"calendar_event": ["get_calendar_event"]}, m)
 
         calendar_event_by_id = self.canvas.get_calendar_event(567)
         self.assertIsInstance(calendar_event_by_id, CalendarEvent)
@@ -502,29 +490,31 @@ class TestCanvas(unittest.TestCase):
 
     # reserve_time_slot()
     def test_reserve_time_slot(self, m):
-        register_uris({'calendar_event': ['reserve_time_slot']}, m)
+        register_uris({"calendar_event": ["reserve_time_slot"]}, m)
 
         calendar_event_by_id = self.canvas.reserve_time_slot(calendar_event=567)
         self.assertIsInstance(calendar_event_by_id, CalendarEvent)
         self.assertEqual(calendar_event_by_id.title, "Test Reservation")
 
-        calendar_event_by_obj = self.canvas.reserve_time_slot(calendar_event=calendar_event_by_id)
+        calendar_event_by_obj = self.canvas.reserve_time_slot(
+            calendar_event=calendar_event_by_id
+        )
         self.assertIsInstance(calendar_event_by_obj, CalendarEvent)
         self.assertEqual(calendar_event_by_obj.title, "Test Reservation")
 
     def test_reserve_time_slot_by_participant_id(self, m):
-        register_uris({
-            'calendar_event': ['reserve_time_slot_participant_id']
-        }, m)
+        register_uris({"calendar_event": ["reserve_time_slot_participant_id"]}, m)
 
-        cal_event = self.canvas.reserve_time_slot(calendar_event=567, participant_id=777)
+        cal_event = self.canvas.reserve_time_slot(
+            calendar_event=567, participant_id=777
+        )
         self.assertIsInstance(cal_event, CalendarEvent)
         self.assertEqual(cal_event.title, "Test Reservation")
         self.assertEqual(cal_event.user, 777)
 
     # list_appointment_groups()
     def test_list_appointment_groups(self, m):
-        register_uris({'appointment_group': ['list_appointment_groups']}, m)
+        register_uris({"appointment_group": ["list_appointment_groups"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             appt_groups = self.canvas.list_appointment_groups()
@@ -536,7 +526,7 @@ class TestCanvas(unittest.TestCase):
 
     # get_appointment_groups()
     def test_get_appointment_groups(self, m):
-        register_uris({'appointment_group': ['list_appointment_groups']}, m)
+        register_uris({"appointment_group": ["list_appointment_groups"]}, m)
 
         appt_groups = self.canvas.get_appointment_groups()
         appt_groups_list = [appt_group for appt_group in appt_groups]
@@ -544,24 +534,25 @@ class TestCanvas(unittest.TestCase):
 
     # get_appointment_group()
     def test_get_appointment_group(self, m):
-        register_uris({'appointment_group': ['get_appointment_group']}, m)
+        register_uris({"appointment_group": ["get_appointment_group"]}, m)
 
         appointment_group_by_id = self.canvas.get_appointment_group(567)
         self.assertIsInstance(appointment_group_by_id, AppointmentGroup)
         self.assertEqual(appointment_group_by_id.title, "Test Group 3")
 
-        appointment_group_by_obj = self.canvas.get_appointment_group(appointment_group_by_id)
+        appointment_group_by_obj = self.canvas.get_appointment_group(
+            appointment_group_by_id
+        )
         self.assertIsInstance(appointment_group_by_obj, AppointmentGroup)
         self.assertEqual(appointment_group_by_obj.title, "Test Group 3")
 
     # create_appointment_group()
     def test_create_appointment_group(self, m):
-        register_uris({'appointment_group': ['create_appointment_group']}, m)
+        register_uris({"appointment_group": ["create_appointment_group"]}, m)
 
-        evnt = self.canvas.create_appointment_group({
-            "context_codes": ["course_123"],
-            "title": "Test Group"
-        })
+        evnt = self.canvas.create_appointment_group(
+            {"context_codes": ["course_123"], "title": "Test Group"}
+        )
 
         self.assertIsInstance(evnt, AppointmentGroup)
         self.assertEqual(evnt.context_codes[0], "course_123")
@@ -569,9 +560,7 @@ class TestCanvas(unittest.TestCase):
 
     def test_create_appointment_group_fail_on_context_codes(self, m):
         with self.assertRaises(RequiredFieldMissing):
-            self.canvas.create_appointment_group({
-                "title": "Test Group"
-            })
+            self.canvas.create_appointment_group({"title": "Test Group"})
 
     def test_create_appointment_group_fail_on_title(self, m):
         with self.assertRaises(RequiredFieldMissing):
@@ -581,11 +570,13 @@ class TestCanvas(unittest.TestCase):
     def test_list_user_participants(self, m):
         register_uris(
             {
-                'appointment_group': [
-                    'get_appointment_group_222',
-                    'list_user_participants'
+                "appointment_group": [
+                    "get_appointment_group_222",
+                    "list_user_participants",
                 ]
-            }, m)
+            },
+            m,
+        )
 
         with warnings.catch_warnings(record=True) as warning_list:
             users_by_id = self.canvas.list_user_participants(222)
@@ -608,11 +599,13 @@ class TestCanvas(unittest.TestCase):
     def test_get_user_participants(self, m):
         register_uris(
             {
-                'appointment_group': [
-                    'get_appointment_group_222',
-                    'list_user_participants'
+                "appointment_group": [
+                    "get_appointment_group_222",
+                    "list_user_participants",
                 ]
-            }, m)
+            },
+            m,
+        )
 
         users_by_id = self.canvas.get_user_participants(222)
         users_get_by_id = [user for user in users_by_id]
@@ -627,11 +620,13 @@ class TestCanvas(unittest.TestCase):
     def test_list_group_participants(self, m):
         register_uris(
             {
-                'appointment_group': [
-                    'get_appointment_group_222',
-                    'list_group_participants'
+                "appointment_group": [
+                    "get_appointment_group_222",
+                    "list_group_participants",
                 ]
-            }, m)
+            },
+            m,
+        )
 
         with warnings.catch_warnings(record=True) as warning_list:
             groups_by_id = self.canvas.list_group_participants(222)
@@ -643,7 +638,9 @@ class TestCanvas(unittest.TestCase):
 
         with warnings.catch_warnings(record=True) as warning_list:
             appointment_group_for_obj = self.canvas.get_appointment_group(222)
-            groups_by_obj = self.canvas.list_group_participants(appointment_group_for_obj)
+            groups_by_obj = self.canvas.list_group_participants(
+                appointment_group_for_obj
+            )
             groups_list_by_obj = [group for group in groups_by_obj]
             self.assertEqual(len(groups_list_by_obj), 2)
 
@@ -654,11 +651,13 @@ class TestCanvas(unittest.TestCase):
     def test_get_group_participants(self, m):
         register_uris(
             {
-                'appointment_group': [
-                    'get_appointment_group_222',
-                    'list_group_participants'
+                "appointment_group": [
+                    "get_appointment_group_222",
+                    "list_group_participants",
                 ]
-            }, m)
+            },
+            m,
+        )
 
         groups_by_id = self.canvas.get_group_participants(222)
         groups_get_by_id = [group for group in groups_by_id]
@@ -671,7 +670,7 @@ class TestCanvas(unittest.TestCase):
 
     # get_file()
     def test_get_file(self, m):
-        register_uris({'file': ['get_by_id']}, m)
+        register_uris({"file": ["get_by_id"]}, m)
 
         file_by_id = self.canvas.get_file(1)
         self.assertIsInstance(file_by_id, File)
@@ -685,7 +684,7 @@ class TestCanvas(unittest.TestCase):
 
     # search_recipients()
     def test_search_recipients(self, m):
-        register_uris({'user': ['search_recipients']}, m)
+        register_uris({"user": ["search_recipients"]}, m)
 
         recipients = self.canvas.search_recipients()
         self.assertIsInstance(recipients, list)
@@ -693,7 +692,7 @@ class TestCanvas(unittest.TestCase):
 
     # search_all_courses()
     def test_search_all_courses(self, m):
-        register_uris({'course': ['search_all_courses']}, m)
+        register_uris({"course": ["search_all_courses"]}, m)
 
         courses = self.canvas.search_all_courses()
         self.assertIsInstance(courses, list)
@@ -701,7 +700,7 @@ class TestCanvas(unittest.TestCase):
 
     # get_outcome()
     def test_get_outcome(self, m):
-        register_uris({'outcome': ['canvas_get_outcome']}, m)
+        register_uris({"outcome": ["canvas_get_outcome"]}, m)
 
         outcome_group_by_id = self.canvas.get_outcome(3)
         self.assertIsInstance(outcome_group_by_id, Outcome)
@@ -715,7 +714,7 @@ class TestCanvas(unittest.TestCase):
 
     # get_root_outcome_group()
     def test_get_root_outcome_group(self, m):
-        register_uris({'outcome': ['canvas_root_outcome_group']}, m)
+        register_uris({"outcome": ["canvas_root_outcome_group"]}, m)
 
         outcome_group = self.canvas.get_root_outcome_group()
         self.assertIsInstance(outcome_group, OutcomeGroup)
@@ -724,7 +723,7 @@ class TestCanvas(unittest.TestCase):
 
     # get_outcome_group()
     def test_get_outcome_group(self, m):
-        register_uris({'outcome': ['canvas_get_outcome_group']}, m)
+        register_uris({"outcome": ["canvas_get_outcome_group"]}, m)
 
         outcome_group_by_id = self.canvas.get_outcome_group(1)
         self.assertIsInstance(outcome_group_by_id, OutcomeGroup)
@@ -738,16 +737,16 @@ class TestCanvas(unittest.TestCase):
 
     # get_progress()
     def test_get_progress(self, m):
-        register_uris({'content_migration': ['get_progress']}, m)
+        register_uris({"content_migration": ["get_progress"]}, m)
 
         progress = self.canvas.get_progress(1)
         self.assertIsInstance(progress, Progress)
-        self.assertTrue(hasattr(progress, 'id'))
+        self.assertTrue(hasattr(progress, "id"))
         self.assertEqual(progress.id, 1)
 
     # get_announcements()
     def test_get_announcements(self, m):
-        register_uris({'announcements': ['list_announcements']}, m)
+        register_uris({"announcements": ["list_announcements"]}, m)
         announcements = self.canvas.get_announcements()
         announcement_list = [announcement for announcement in announcements]
         self.assertIsInstance(announcements, PaginatedList)

--- a/tests/test_canvas_object.py
+++ b/tests/test_canvas_object.py
@@ -8,13 +8,13 @@ class TestCanvasObject(unittest.TestCase):
 
     # to_json()
     def test_canvas_object_to_json(self):
-        attributes = {'name': 'Test Object', 'id': 1}
+        attributes = {"name": "Test Object", "id": 1}
         canvas_obj = CanvasObject(None, attributes)
 
         prev_json = canvas_obj.to_json()
         self.assertIsInstance(prev_json, str)
 
-        attributes.update({'name': 'Test Object 2'})
+        attributes.update({"name": "Test Object 2"})
         canvas_obj.set_attributes(attributes)
 
         self.assertNotEqual(canvas_obj.to_json(), prev_json)

--- a/tests/test_communication_channel.py
+++ b/tests/test_communication_channel.py
@@ -12,12 +12,11 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestCommunicationChannel(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({'user': ['get_by_id', 'list_comm_channels']}, m)
+            register_uris({"user": ["get_by_id", "list_comm_channels"]}, m)
 
             self.user = self.canvas.get_user(1)
             self.comm_chan = self.user.get_communication_channels()[0]
@@ -29,107 +28,98 @@ class TestCommunicationChannel(unittest.TestCase):
 
     # list_preferences()
     def test_list_preferences(self, m):
-        register_uris({'communication_channel': ['list_preferences']}, m)
+        register_uris({"communication_channel": ["list_preferences"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             preferences = self.comm_chan.list_preferences()
             preference_list = [preference for preference in preferences]
 
             self.assertEqual(len(preference_list), 2)
-            self.assertEqual(preference_list[0]['notification'], 'new_announcement')
+            self.assertEqual(preference_list[0]["notification"], "new_announcement")
 
             self.assertEqual(len(warning_list), 1)
             self.assertEqual(warning_list[-1].category, DeprecationWarning)
 
     # get_preferences()
     def test_get_preferences(self, m):
-        register_uris({'communication_channel': ['list_preferences']}, m)
+        register_uris({"communication_channel": ["list_preferences"]}, m)
 
         preferences = self.comm_chan.get_preferences()
         preference_list = [preference for preference in preferences]
 
         self.assertEqual(len(preference_list), 2)
-        self.assertEqual(preference_list[0]['notification'], 'new_announcement')
+        self.assertEqual(preference_list[0]["notification"], "new_announcement")
 
     # list_preference_categories()
     def test_list_preference_categories(self, m):
-        register_uris({'communication_channel': ['list_preference_categories']}, m)
+        register_uris({"communication_channel": ["list_preference_categories"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             categories = self.comm_chan.list_preference_categories()
 
             self.assertEqual(len(categories), 2)
             self.assertIsInstance(categories, list)
-            self.assertEqual(categories[0], 'announcement')
+            self.assertEqual(categories[0], "announcement")
 
             self.assertEqual(len(warning_list), 1)
             self.assertEqual(warning_list[-1].category, DeprecationWarning)
 
     # get_preference_categories()
     def test_get_preference_categories(self, m):
-        register_uris({'communication_channel': ['list_preference_categories']}, m)
+        register_uris({"communication_channel": ["list_preference_categories"]}, m)
 
         categories = self.comm_chan.get_preference_categories()
 
         self.assertEqual(len(categories), 2)
         self.assertIsInstance(categories, list)
-        self.assertEqual(categories[0], 'announcement')
+        self.assertEqual(categories[0], "announcement")
 
     # get_preference()
     def test_get_preference(self, m):
-        register_uris({'communication_channel': ['get_preference']}, m)
+        register_uris({"communication_channel": ["get_preference"]}, m)
 
-        preference = self.comm_chan.get_preference('new_announcement')
+        preference = self.comm_chan.get_preference("new_announcement")
         self.assertIsInstance(preference, NotificationPreference)
-        self.assertTrue(hasattr(preference, 'notification'))
-        self.assertEqual(preference.notification, 'new_announcement')
+        self.assertTrue(hasattr(preference, "notification"))
+        self.assertEqual(preference.notification, "new_announcement")
 
     # update_preference()
     def test_update_preference(self, m):
-        register_uris({'communication_channel': ['update_preference']}, m)
-        notification = 'new_announcement'
-        frequency = 'daily'
+        register_uris({"communication_channel": ["update_preference"]}, m)
+        notification = "new_announcement"
+        frequency = "daily"
 
         updated_pref = self.comm_chan.update_preference(
-            notification=notification,
-            frequency=frequency
+            notification=notification, frequency=frequency
         )
 
         self.assertIsInstance(updated_pref, NotificationPreference)
         self.assertEqual(updated_pref.frequency, frequency)
         self.assertEqual(updated_pref.notification, notification)
-        self.assertEqual(updated_pref.category, 'announcement')
+        self.assertEqual(updated_pref.category, "announcement")
 
     # update_preferences_by_category()
     def test_update_preferences_by_category(self, m):
-        register_uris(
-            {
-                'communication_channel': ['update_preferences_by_category']
-            }, m)
-        category = 'course_content'
-        frequency = 'daily'
+        register_uris({"communication_channel": ["update_preferences_by_category"]}, m)
+        category = "course_content"
+        frequency = "daily"
 
         updated_prefs = self.comm_chan.update_preferences_by_catagory(
-            category=category,
-            frequency=frequency
+            category=category, frequency=frequency
         )
 
         self.assertEqual(len(updated_prefs), 3)
-        self.assertEqual(updated_prefs[0]['frequency'], frequency)
-        self.assertEqual(updated_prefs[0]['category'], category)
-        self.assertEqual(updated_prefs[0]['notification'], 'assignment_changed')
+        self.assertEqual(updated_prefs[0]["frequency"], frequency)
+        self.assertEqual(updated_prefs[0]["category"], category)
+        self.assertEqual(updated_prefs[0]["notification"], "assignment_changed")
 
     # update_multiple_preferences()
     def test_update_multiple_preferences(self, m):
-        register_uris({'communication_channel': ['update_multiple_preferences']}, m)
+        register_uris({"communication_channel": ["update_multiple_preferences"]}, m)
 
         notification_preferences = {
-            "assignment_due_date_changed": {
-                "frequency": "daily"
-            },
-            "assignment_changed": {
-                "frequency": "daily"
-            }
+            "assignment_due_date_changed": {"frequency": "daily"},
+            "assignment_changed": {"frequency": "daily"},
         }
 
         updated_prefs = self.comm_chan.update_multiple_preferences(
@@ -137,7 +127,7 @@ class TestCommunicationChannel(unittest.TestCase):
         )
 
         self.assertEqual(len(updated_prefs), 2)
-        self.assertEqual(updated_prefs[0]['frequency'], "daily")
+        self.assertEqual(updated_prefs[0]["frequency"], "daily")
 
         empty_notification_preferences = {}
         self.assertFalse(

--- a/tests/test_content_migration.py
+++ b/tests/test_content_migration.py
@@ -21,10 +21,10 @@ class TestContentMigration(unittest.TestCase):
 
         with requests_mock.Mocker() as m:
             requires = {
-                'course': ['get_by_id', 'get_content_migration_single'],
-                'group': ['get_by_id', 'get_content_migration_single'],
-                'account': ['get_by_id', 'get_content_migration_single'],
-                'user': ['get_by_id', 'get_content_migration_single']
+                "course": ["get_by_id", "get_content_migration_single"],
+                "group": ["get_by_id", "get_content_migration_single"],
+                "account": ["get_by_id", "get_content_migration_single"],
+                "user": ["get_by_id", "get_content_migration_single"],
             }
             register_uris(requires, m)
 
@@ -45,19 +45,19 @@ class TestContentMigration(unittest.TestCase):
 
     # _parent_type
     def test_parent_type_account(self, m):
-        self.assertEqual(self.content_migration._parent_type, 'account')
+        self.assertEqual(self.content_migration._parent_type, "account")
 
     def test_parent_type_course(self, m):
-        self.assertEqual(self.content_migration_course._parent_type, 'course')
+        self.assertEqual(self.content_migration_course._parent_type, "course")
 
     def test_parent_type_group(self, m):
-        self.assertEqual(self.content_migration_group._parent_type, 'group')
+        self.assertEqual(self.content_migration_group._parent_type, "group")
 
     def test_parent_type_user(self, m):
-        self.assertEqual(self.content_migration_user._parent_type, 'user')
+        self.assertEqual(self.content_migration_user._parent_type, "user")
 
     def test_parent_type_no_type(self, m):
-        migration = ContentMigration(self.canvas._Canvas__requester, {'id': 1})
+        migration = ContentMigration(self.canvas._Canvas__requester, {"id": 1})
         with self.assertRaises(ValueError):
             migration._parent_type
 
@@ -75,87 +75,87 @@ class TestContentMigration(unittest.TestCase):
         self.assertEqual(self.content_migration_user._parent_id, 1)
 
     def test_parent_id_no_id(self, m):
-        migration = ContentMigration(self.canvas._Canvas__requester, {'id': 1})
+        migration = ContentMigration(self.canvas._Canvas__requester, {"id": 1})
         with self.assertRaises(ValueError):
             migration._parent_id
 
     # get_migration_issue()
     def test_get_migration_issue(self, m):
-        register_uris({'content_migration': ['get_migration_issue_single']}, m)
+        register_uris({"content_migration": ["get_migration_issue_single"]}, m)
 
         issue = self.content_migration.get_migration_issue(1)
         self.assertIsInstance(issue, MigrationIssue)
-        self.assertTrue(hasattr(issue, 'id'))
+        self.assertTrue(hasattr(issue, "id"))
         self.assertEqual(issue.id, 1)
 
     # get_migration_issues()
     def test_get_migration_issues(self, m):
-        register_uris({'content_migration': ['get_migration_issue_multiple']}, m)
+        register_uris({"content_migration": ["get_migration_issue_multiple"]}, m)
 
         issues = self.content_migration.get_migration_issues()
 
         self.assertEqual(len(list(issues)), 2)
 
         self.assertIsInstance(issues[0], MigrationIssue)
-        self.assertTrue(hasattr(issues[0], 'id'))
+        self.assertTrue(hasattr(issues[0], "id"))
         self.assertEqual(issues[0].id, 1)
         self.assertIsInstance(issues[1], MigrationIssue)
-        self.assertTrue(hasattr(issues[1], 'id'))
+        self.assertTrue(hasattr(issues[1], "id"))
         self.assertEqual(issues[1].id, 2)
 
     # get_parent()
     def test_get_parent_account(self, m):
-        register_uris({'content_migration': ['get_parent_account']}, m)
+        register_uris({"content_migration": ["get_parent_account"]}, m)
 
         account = self.content_migration.get_parent()
         self.assertIsInstance(account, Account)
-        self.assertTrue(hasattr(account, 'id'))
+        self.assertTrue(hasattr(account, "id"))
         self.assertEqual(account.id, 1)
 
     def test_get_parent_course(self, m):
-        register_uris({'content_migration': ['get_parent_course']}, m)
+        register_uris({"content_migration": ["get_parent_course"]}, m)
 
         course = self.content_migration_course.get_parent()
         self.assertIsInstance(course, Course)
-        self.assertTrue(hasattr(course, 'id'))
+        self.assertTrue(hasattr(course, "id"))
         self.assertEqual(course.id, 1)
 
     def test_get_parent_group(self, m):
-        register_uris({'content_migration': ['get_parent_group']}, m)
+        register_uris({"content_migration": ["get_parent_group"]}, m)
 
         group = self.content_migration_group.get_parent()
         self.assertIsInstance(group, Group)
-        self.assertTrue(hasattr(group, 'id'))
+        self.assertTrue(hasattr(group, "id"))
         self.assertEqual(group.id, 1)
 
     def test_get_parent_user(self, m):
-        register_uris({'content_migration': ['get_parent_user']}, m)
+        register_uris({"content_migration": ["get_parent_user"]}, m)
 
         user = self.content_migration_user.get_parent()
         self.assertIsInstance(user, User)
-        self.assertTrue(hasattr(user, 'id'))
+        self.assertTrue(hasattr(user, "id"))
         self.assertEqual(user.id, 1)
 
     # get_progress()
     def test_get_progress(self, m):
-        register_uris({'content_migration': ['get_progress']}, m)
+        register_uris({"content_migration": ["get_progress"]}, m)
 
         progress = self.content_migration.get_progress()
         self.assertIsInstance(progress, Progress)
-        self.assertTrue(hasattr(progress, 'id'))
+        self.assertTrue(hasattr(progress, "id"))
         self.assertEqual(progress.id, 1)
 
     # update()
     def test_update(self, m):
-        register_uris({'content_migration': ['update']}, m)
+        register_uris({"content_migration": ["update"]}, m)
 
         worked = self.content_migration.update()
         self.assertTrue(worked)
-        self.assertTrue(hasattr(self.content_migration, 'migration_type'))
+        self.assertTrue(hasattr(self.content_migration, "migration_type"))
         self.assertEqual(self.content_migration.migration_type, "dummy_importer")
 
     def test_update_fail(self, m):
-        register_uris({'content_migration': ['update_fail']}, m)
+        register_uris({"content_migration": ["update_fail"]}, m)
 
         worked = self.content_migration.update()
         self.assertFalse(worked)
@@ -163,20 +163,21 @@ class TestContentMigration(unittest.TestCase):
 
 @requests_mock.Mocker()
 class TestMigrationIssue(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
             requires = {
-                'course': ['get_by_id', 'get_content_migration_single'],
-                'group': ['get_by_id', 'get_content_migration_single'],
-                'account': ['get_by_id', 'get_content_migration_single'],
-                'user': ['get_by_id', 'get_content_migration_single'],
-                'content_migration': ['get_migration_issue_single',
-                                      'get_migration_issue_single_course',
-                                      'get_migration_issue_single_group',
-                                      'get_migration_issue_single_user']
+                "course": ["get_by_id", "get_content_migration_single"],
+                "group": ["get_by_id", "get_content_migration_single"],
+                "account": ["get_by_id", "get_content_migration_single"],
+                "user": ["get_by_id", "get_content_migration_single"],
+                "content_migration": [
+                    "get_migration_issue_single",
+                    "get_migration_issue_single_course",
+                    "get_migration_issue_single_group",
+                    "get_migration_issue_single_user",
+                ],
             }
             register_uris(requires, m)
 
@@ -191,9 +192,15 @@ class TestMigrationIssue(unittest.TestCase):
             self.content_migration_user = self.user.get_content_migration(1)
 
             self.migration_issue = self.content_migration.get_migration_issue(1)
-            self.migration_issue_course = self.content_migration_course.get_migration_issue(1)
-            self.migration_issue_group = self.content_migration_group.get_migration_issue(1)
-            self.migration_issue_user = self.content_migration_user.get_migration_issue(1)
+            self.migration_issue_course = self.content_migration_course.get_migration_issue(
+                1
+            )
+            self.migration_issue_group = self.content_migration_group.get_migration_issue(
+                1
+            )
+            self.migration_issue_user = self.content_migration_user.get_migration_issue(
+                1
+            )
 
     # __str__()
     def test__str__(self, m):
@@ -202,15 +209,15 @@ class TestMigrationIssue(unittest.TestCase):
 
     # update()
     def test_update(self, m):
-        register_uris({'content_migration': ['update_issue']}, m)
+        register_uris({"content_migration": ["update_issue"]}, m)
 
         worked = self.migration_issue.update()
         self.assertTrue(worked)
-        self.assertTrue(hasattr(self.migration_issue, 'id'))
+        self.assertTrue(hasattr(self.migration_issue, "id"))
         self.assertEqual(self.migration_issue.id, 1)
 
     def test_update_fail(self, m):
-        register_uris({'content_migration': ['update_issue_fail']}, m)
+        register_uris({"content_migration": ["update_issue_fail"]}, m)
 
         worked = self.migration_issue.update()
         self.assertFalse(worked)
@@ -223,14 +230,16 @@ class TestMigrator(unittest.TestCase):
 
         with requests_mock.Mocker() as m:
             requires = {
-                'course': ['get_by_id', 'get_migration_systems_multiple'],
-                'group': ['get_by_id', 'get_migration_systems_multiple'],
-                'account': ['get_by_id', 'get_migration_systems_multiple'],
-                'user': ['get_by_id', 'get_migration_systems_multiple'],
-                'content_migration': ['get_migration_issue_single',
-                                      'get_migration_issue_single_course',
-                                      'get_migration_issue_single_group',
-                                      'get_migration_issue_single_user']
+                "course": ["get_by_id", "get_migration_systems_multiple"],
+                "group": ["get_by_id", "get_migration_systems_multiple"],
+                "account": ["get_by_id", "get_migration_systems_multiple"],
+                "user": ["get_by_id", "get_migration_systems_multiple"],
+                "content_migration": [
+                    "get_migration_issue_single",
+                    "get_migration_issue_single_course",
+                    "get_migration_issue_single_group",
+                    "get_migration_issue_single_user",
+                ],
             }
             register_uris(requires, m)
 

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -11,12 +11,11 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestConversation(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({'conversation': ['get_by_id']}, m)
+            register_uris({"conversation": ["get_by_id"]}, m)
 
             self.conversation = self.canvas.get_conversation(1)
 
@@ -27,14 +26,14 @@ class TestConversation(unittest.TestCase):
 
     # edit()
     def test_edit(self, m):
-        register_uris({'conversation': ['edit_conversation']}, m)
+        register_uris({"conversation": ["edit_conversation"]}, m)
 
         new_subject = "conversations api example"
         success = self.conversation.edit(subject=new_subject)
         self.assertTrue(success)
 
     def test_edit_fail(self, m):
-        requires = {'conversation': ['get_by_id_2', 'edit_conversation_fail']}
+        requires = {"conversation": ["get_by_id_2", "edit_conversation_fail"]}
         register_uris(requires, m)
 
         temp_convo = self.canvas.get_conversation(2)
@@ -42,13 +41,13 @@ class TestConversation(unittest.TestCase):
 
     # delete()
     def test_delete(self, m):
-        register_uris({'conversation': ['delete_conversation']}, m)
+        register_uris({"conversation": ["delete_conversation"]}, m)
 
         success = self.conversation.delete()
         self.assertTrue(success)
 
     def test_delete_fail(self, m):
-        requires = {'conversation': ['get_by_id_2', 'delete_conversation_fail']}
+        requires = {"conversation": ["get_by_id_2", "delete_conversation_fail"]}
         register_uris(requires, m)
 
         temp_convo = self.canvas.get_conversation(2)
@@ -56,32 +55,34 @@ class TestConversation(unittest.TestCase):
 
     # add_recipients()
     def test_add_recipients(self, m):
-        register_uris({'conversation': ['add_recipients']}, m)
+        register_uris({"conversation": ["add_recipients"]}, m)
 
-        recipients = {'bob': 1, 'joe': 2}
+        recipients = {"bob": 1, "joe": 2}
         string_bob = "Bob was added to the conversation by Hank TA"
         string_joe = "Joe was added to the conversation by Hank TA"
-        result = self.conversation.add_recipients([recipients['bob'], recipients['joe']])
-        self.assertTrue(hasattr(result, 'messages'))
+        result = self.conversation.add_recipients(
+            [recipients["bob"], recipients["joe"]]
+        )
+        self.assertTrue(hasattr(result, "messages"))
         self.assertEqual(len(result.messages), 2)
         self.assertEqual(result.messages[0]["body"], string_bob)
         self.assertEqual(result.messages[1]["body"], string_joe)
 
     # add_message()
     def test_add_message(self, m):
-        register_uris({'conversation': ['add_message']}, m)
+        register_uris({"conversation": ["add_message"]}, m)
 
         test_string = "add_message test body"
         result = self.conversation.add_message(test_string)
         self.assertIsInstance(result, Conversation)
         self.assertEqual(len(result.messages), 1)
-        self.assertEqual(result.messages[0]['id'], 3)
+        self.assertEqual(result.messages[0]["id"], 3)
 
     # delete_message()
     def test_delete_message(self, m):
-        register_uris({'conversation': ['delete_message']}, m)
+        register_uris({"conversation": ["delete_message"]}, m)
 
         id_list = [1]
         result = self.conversation.delete_messages(id_list)
-        self.assertIn('subject', result)
-        self.assertEqual(result['id'], 1)
+        self.assertIn("subject", result)
+        self.assertEqual(result["id"], 1)

--- a/tests/test_course.py
+++ b/tests/test_course.py
@@ -37,20 +37,19 @@ from tests.util import cleanup_file, register_uris
 
 @requests_mock.Mocker()
 class TestCourse(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
             requires = {
-                'course': ['get_assignment_by_id', 'get_by_id', 'get_page'],
-                'quiz': ['get_by_id'],
-                'user': ['get_by_id']
+                "course": ["get_assignment_by_id", "get_by_id", "get_page"],
+                "quiz": ["get_by_id"],
+                "user": ["get_by_id"],
             }
             register_uris(requires, m)
 
             self.course = self.canvas.get_course(1)
-            self.page = self.course.get_page('my-url')
+            self.page = self.course.get_page("my-url")
             self.quiz = self.course.get_quiz(1)
             self.user = self.canvas.get_user(1)
             self.assignment = self.course.get_assignment(1)
@@ -62,26 +61,26 @@ class TestCourse(unittest.TestCase):
 
     # conclude()
     def test_conclude(self, m):
-        register_uris({'course': ['conclude']}, m)
+        register_uris({"course": ["conclude"]}, m)
 
         success = self.course.conclude()
         self.assertTrue(success)
 
     # create_assignment_overrides()
     def test_create_assignment_overrides(self, m):
-        register_uris({'assignment': ['batch_create_assignment_overrides']}, m)
+        register_uris({"assignment": ["batch_create_assignment_overrides"]}, m)
 
         override_list = [
             {
-                'student_ids': [1, 2, 3],
-                'title': 'New Assignment Override',
-                'assignment_id': 1
+                "student_ids": [1, 2, 3],
+                "title": "New Assignment Override",
+                "assignment_id": 1,
             },
             {
-                'assignment_id': 2,
-                'student_ids': [1, 2, 3],
-                'title': 'New Assignment Override 2'
-            }
+                "assignment_id": 2,
+                "student_ids": [1, 2, 3],
+                "title": "New Assignment Override 2",
+            },
         ]
         created_overrides = self.course.create_assignment_overrides(override_list)
         created_list = [created for created in created_overrides]
@@ -92,34 +91,34 @@ class TestCourse(unittest.TestCase):
 
     # delete()
     def test_delete(self, m):
-        register_uris({'course': ['delete']}, m)
+        register_uris({"course": ["delete"]}, m)
 
         success = self.course.delete()
         self.assertTrue(success)
 
     # update()
     def test_update(self, m):
-        register_uris({'course': ['update']}, m)
+        register_uris({"course": ["update"]}, m)
 
-        new_name = 'New Name'
-        self.course.update(course={'name': new_name})
+        new_name = "New Name"
+        self.course.update(course={"name": new_name})
         self.assertEqual(self.course.name, new_name)
 
     # update_assignment_overrides()
     def test_update_assignment_overrides(self, m):
-        register_uris({'assignment': ['batch_update_assignment_overrides']}, m)
+        register_uris({"assignment": ["batch_update_assignment_overrides"]}, m)
 
         override_list = [
             {
-                'student_ids': [4, 5, 6],
-                'title': 'Updated Assignment Override',
-                'assignment_id': 1
+                "student_ids": [4, 5, 6],
+                "title": "Updated Assignment Override",
+                "assignment_id": 1,
             },
             {
-                'assignment_id': 2,
-                'student_ids': [6, 7],
-                'title': 'Updated Assignment Override 2'
-            }
+                "assignment_id": 2,
+                "student_ids": [6, 7],
+                "title": "Updated Assignment Override 2",
+            },
         ]
         updated_overrides = self.course.update_assignment_overrides(override_list)
         updated_list = [updated for updated in updated_overrides]
@@ -130,27 +129,27 @@ class TestCourse(unittest.TestCase):
 
     # get_user()
     def test_get_user(self, m):
-        register_uris({'course': ['get_user']}, m)
+        register_uris({"course": ["get_user"]}, m)
 
         user_by_id = self.course.get_user(1)
         self.assertIsInstance(user_by_id, User)
-        self.assertTrue(hasattr(user_by_id, 'name'))
+        self.assertTrue(hasattr(user_by_id, "name"))
 
         user_by_obj = self.course.get_user(user_by_id)
         self.assertIsInstance(user_by_obj, User)
-        self.assertTrue(hasattr(user_by_obj, 'name'))
+        self.assertTrue(hasattr(user_by_obj, "name"))
 
     def test_get_user_id_type(self, m):
-        register_uris({'course': ['get_user_id_type']}, m)
+        register_uris({"course": ["get_user_id_type"]}, m)
 
         user = self.course.get_user("LOGINID", "login_id")
 
         self.assertIsInstance(user, User)
-        self.assertTrue(hasattr(user, 'name'))
+        self.assertTrue(hasattr(user, "name"))
 
     # get_users()
     def test_get_users(self, m):
-        register_uris({'course': ['get_users', 'get_users_p2']}, m)
+        register_uris({"course": ["get_users", "get_users_p2"]}, m)
 
         users = self.course.get_users()
         user_list = [user for user in users]
@@ -160,30 +159,27 @@ class TestCourse(unittest.TestCase):
 
     # enroll_user()
     def test_enroll_user(self, m):
-        requires = {
-            'course': ['enroll_user'],
-            'user': ['get_by_id']
-        }
+        requires = {"course": ["enroll_user"], "user": ["get_by_id"]}
         register_uris(requires, m)
 
-        enrollment_type = 'TeacherEnrollment'
+        enrollment_type = "TeacherEnrollment"
         user_by_id = self.canvas.get_user(1)
         enrollment_by_id = self.course.enroll_user(user_by_id, enrollment_type)
 
         self.assertIsInstance(enrollment_by_id, Enrollment)
-        self.assertTrue(hasattr(enrollment_by_id, 'type'))
+        self.assertTrue(hasattr(enrollment_by_id, "type"))
         self.assertEqual(enrollment_by_id.type, enrollment_type)
 
         user_by_obj = self.canvas.get_user(self.user)
         enrollment_by_obj = self.course.enroll_user(user_by_obj, enrollment_type)
 
         self.assertIsInstance(enrollment_by_obj, Enrollment)
-        self.assertTrue(hasattr(enrollment_by_obj, 'type'))
+        self.assertTrue(hasattr(enrollment_by_obj, "type"))
         self.assertEqual(enrollment_by_obj.type, enrollment_type)
 
     # get_recent_students()
     def test_get_recent_students(self, m):
-        recent = {'course': ['get_recent_students', 'get_recent_students_p2']}
+        recent = {"course": ["get_recent_students", "get_recent_students_p2"]}
         register_uris(recent, m)
 
         students = self.course.get_recent_students()
@@ -191,11 +187,11 @@ class TestCourse(unittest.TestCase):
 
         self.assertEqual(len(student_list), 4)
         self.assertIsInstance(student_list[0], User)
-        self.assertTrue(hasattr(student_list[0], 'name'))
+        self.assertTrue(hasattr(student_list[0], "name"))
 
     # preview_html()
     def test_preview_html(self, m):
-        register_uris({'course': ['preview_html']}, m)
+        register_uris({"course": ["preview_html"]}, m)
 
         html_str = "<script></script><p>hello</p>"
         prev_html = self.course.preview_html(html_str)
@@ -205,7 +201,7 @@ class TestCourse(unittest.TestCase):
 
     # get_settings()
     def test_get_settings(self, m):
-        register_uris({'course': ['settings']}, m)
+        register_uris({"course": ["settings"]}, m)
 
         settings = self.course.get_settings()
 
@@ -213,49 +209,49 @@ class TestCourse(unittest.TestCase):
 
     # update_settings()
     def test_update_settings(self, m):
-        register_uris({'course': ['update_settings']}, m)
+        register_uris({"course": ["update_settings"]}, m)
 
         settings = self.course.update_settings()
 
         self.assertIsInstance(settings, dict)
-        self.assertTrue(settings['hide_final_grades'])
+        self.assertTrue(settings["hide_final_grades"])
 
     # upload()
     def test_upload(self, m):
-        register_uris({'course': ['upload', 'upload_final']}, m)
+        register_uris({"course": ["upload", "upload_final"]}, m)
 
-        filename = 'testfile_course_{}'.format(uuid.uuid4().hex)
+        filename = "testfile_course_{}".format(uuid.uuid4().hex)
 
         try:
-            with open(filename, 'w+') as file:
+            with open(filename, "w+") as file:
                 response = self.course.upload(file)
 
             self.assertTrue(response[0])
             self.assertIsInstance(response[1], dict)
-            self.assertIn('url', response[1])
+            self.assertIn("url", response[1])
         finally:
             cleanup_file(filename)
 
     # reset()
     def test_reset(self, m):
-        register_uris({'course': ['reset']}, m)
+        register_uris({"course": ["reset"]}, m)
 
         course = self.course.reset()
 
         self.assertIsInstance(course, Course)
-        self.assertTrue(hasattr(course, 'name'))
+        self.assertTrue(hasattr(course, "name"))
 
     # create_quiz()
     def test_create_quiz(self, m):
-        register_uris({'course': ['create_quiz']}, m)
+        register_uris({"course": ["create_quiz"]}, m)
 
-        title = 'Newer Title'
-        new_quiz = self.course.create_quiz({'title': title})
+        title = "Newer Title"
+        new_quiz = self.course.create_quiz({"title": title})
 
         self.assertIsInstance(new_quiz, Quiz)
-        self.assertTrue(hasattr(new_quiz, 'title'))
+        self.assertTrue(hasattr(new_quiz, "title"))
         self.assertEqual(new_quiz.title, title)
-        self.assertTrue(hasattr(new_quiz, 'course_id'))
+        self.assertTrue(hasattr(new_quiz, "course_id"))
         self.assertEqual(new_quiz.course_id, self.course.id)
 
     def test_create_quiz_fail(self, m):
@@ -264,76 +260,76 @@ class TestCourse(unittest.TestCase):
 
     # get_quiz()
     def test_get_quiz(self, m):
-        register_uris({'course': ['get_quiz']}, m)
+        register_uris({"course": ["get_quiz"]}, m)
 
         target_quiz_by_id = self.course.get_quiz(1)
 
         self.assertIsInstance(target_quiz_by_id, Quiz)
-        self.assertTrue(hasattr(target_quiz_by_id, 'course_id'))
+        self.assertTrue(hasattr(target_quiz_by_id, "course_id"))
         self.assertEqual(target_quiz_by_id.course_id, self.course.id)
 
         target_quiz_by_obj = self.course.get_quiz(target_quiz_by_id)
 
         self.assertIsInstance(target_quiz_by_obj, Quiz)
-        self.assertTrue(hasattr(target_quiz_by_obj, 'course_id'))
+        self.assertTrue(hasattr(target_quiz_by_obj, "course_id"))
         self.assertEqual(target_quiz_by_obj.course_id, self.course.id)
 
     def test_get_quiz_fail(self, m):
-        register_uris({'generic': ['not_found']}, m)
+        register_uris({"generic": ["not_found"]}, m)
 
         with self.assertRaises(ResourceDoesNotExist):
             self.course.get_quiz(settings.INVALID_ID)
 
     # get_quizzes()
     def test_get_quizzes(self, m):
-        register_uris({'course': ['list_quizzes', 'list_quizzes2']}, m)
+        register_uris({"course": ["list_quizzes", "list_quizzes2"]}, m)
 
         quizzes = self.course.get_quizzes()
         quiz_list = [quiz for quiz in quizzes]
 
         self.assertEqual(len(quiz_list), 4)
         self.assertIsInstance(quiz_list[0], Quiz)
-        self.assertTrue(hasattr(quiz_list[0], 'course_id'))
+        self.assertTrue(hasattr(quiz_list[0], "course_id"))
         self.assertEqual(quiz_list[0].course_id, self.course.id)
 
     # get_modules()
     def test_get_modules(self, m):
-        register_uris({'course': ['list_modules', 'list_modules2']}, m)
+        register_uris({"course": ["list_modules", "list_modules2"]}, m)
 
         modules = self.course.get_modules()
         module_list = [module for module in modules]
 
         self.assertEqual(len(module_list), 4)
         self.assertIsInstance(module_list[0], Module)
-        self.assertTrue(hasattr(module_list[0], 'course_id'))
+        self.assertTrue(hasattr(module_list[0], "course_id"))
         self.assertEqual(module_list[0].course_id, self.course.id)
 
     # get_module()
     def test_get_module(self, m):
-        register_uris({'course': ['get_module_by_id']}, m)
+        register_uris({"course": ["get_module_by_id"]}, m)
 
         target_module_by_id = self.course.get_module(1)
 
         self.assertIsInstance(target_module_by_id, Module)
-        self.assertTrue(hasattr(target_module_by_id, 'course_id'))
+        self.assertTrue(hasattr(target_module_by_id, "course_id"))
         self.assertEqual(target_module_by_id.course_id, self.course.id)
 
         target_module_by_obj = self.course.get_module(target_module_by_id)
 
         self.assertIsInstance(target_module_by_obj, Module)
-        self.assertTrue(hasattr(target_module_by_obj, 'course_id'))
+        self.assertTrue(hasattr(target_module_by_obj, "course_id"))
         self.assertEqual(target_module_by_obj.course_id, self.course.id)
 
     # create_module()
     def test_create_module(self, m):
-        register_uris({'course': ['create_module']}, m)
+        register_uris({"course": ["create_module"]}, m)
 
-        name = 'Name'
-        new_module = self.course.create_module(module={'name': name})
+        name = "Name"
+        new_module = self.course.create_module(module={"name": name})
 
         self.assertIsInstance(new_module, Module)
-        self.assertTrue(hasattr(new_module, 'name'))
-        self.assertTrue(hasattr(new_module, 'course_id'))
+        self.assertTrue(hasattr(new_module, "name"))
+        self.assertTrue(hasattr(new_module, "course_id"))
         self.assertEqual(new_module.course_id, self.course.id)
 
     def test_create_module_fail(self, m):
@@ -342,7 +338,7 @@ class TestCourse(unittest.TestCase):
 
     # get_enrollments()
     def test_get_enrollments(self, m):
-        register_uris({'course': ['list_enrollments', 'list_enrollments_2']}, m)
+        register_uris({"course": ["list_enrollments", "list_enrollments_2"]}, m)
 
         enrollments = self.course.get_enrollments()
         enrollment_list = [enrollment for enrollment in enrollments]
@@ -352,7 +348,7 @@ class TestCourse(unittest.TestCase):
 
     # get_sections()
     def test_get_sections(self, m):
-        register_uris({'course': ['get_sections', 'get_sections_p2']}, m)
+        register_uris({"course": ["get_sections", "get_sections_p2"]}, m)
 
         sections = self.course.get_sections()
         section_list = [section for section in sections]
@@ -362,7 +358,7 @@ class TestCourse(unittest.TestCase):
 
     # get_section
     def test_get_section(self, m):
-        register_uris({'course': ['get_section']}, m)
+        register_uris({"course": ["get_section"]}, m)
 
         section_by_id = self.course.get_section(1)
         self.assertIsInstance(section_by_id, Section)
@@ -372,14 +368,14 @@ class TestCourse(unittest.TestCase):
 
     # create_assignment()
     def test_create_assignment(self, m):
-        register_uris({'course': ['create_assignment']}, m)
+        register_uris({"course": ["create_assignment"]}, m)
 
-        name = 'Newly Created Assignment'
+        name = "Newly Created Assignment"
 
-        assignment = self.course.create_assignment(assignment={'name': name})
+        assignment = self.course.create_assignment(assignment={"name": name})
 
         self.assertIsInstance(assignment, Assignment)
-        self.assertTrue(hasattr(assignment, 'name'))
+        self.assertTrue(hasattr(assignment, "name"))
         self.assertEqual(assignment.name, name)
         self.assertEqual(assignment.id, 1)
 
@@ -389,27 +385,29 @@ class TestCourse(unittest.TestCase):
 
     # get_assignment()
     def test_get_assignment(self, m):
-        register_uris({'course': ['get_assignment_by_id']}, m)
+        register_uris({"course": ["get_assignment_by_id"]}, m)
 
         assignment_by_id = self.course.get_assignment(1)
         self.assertIsInstance(assignment_by_id, Assignment)
-        self.assertTrue(hasattr(assignment_by_id, 'name'))
+        self.assertTrue(hasattr(assignment_by_id, "name"))
 
         assignment_by_obj = self.course.get_assignment(self.assignment)
         self.assertIsInstance(assignment_by_obj, Assignment)
-        self.assertTrue(hasattr(assignment_by_obj, 'name'))
+        self.assertTrue(hasattr(assignment_by_obj, "name"))
 
     # get_assignment_overrides()
     def test_get_assignment_overrides(self, m):
-        register_uris({'assignment': [
-            'batch_get_assignment_overrides',
-            'batch_get_assignment_overrides_p2'
-        ]}, m)
+        register_uris(
+            {
+                "assignment": [
+                    "batch_get_assignment_overrides",
+                    "batch_get_assignment_overrides_p2",
+                ]
+            },
+            m,
+        )
 
-        bulk_select = [
-            {'id': 1, 'assignment_id': 1},
-            {'id': 20, 'assignment_id': 2}
-        ]
+        bulk_select = [{"id": 1, "assignment_id": 1}, {"id": 20, "assignment_id": 2}]
         overrides = self.course.get_assignment_overrides(bulk_select)
 
         override_list = [override for override in overrides]
@@ -419,7 +417,7 @@ class TestCourse(unittest.TestCase):
 
     # get_assignments()
     def test_get_assignments(self, m):
-        requires = {'course': ['get_all_assignments', 'get_all_assignments2']}
+        requires = {"course": ["get_all_assignments", "get_all_assignments2"]}
         register_uris(requires, m)
 
         assignments = self.course.get_assignments()
@@ -430,56 +428,56 @@ class TestCourse(unittest.TestCase):
 
     # show_front_page()
     def test_show_front_page(self, m):
-        register_uris({'course': ['show_front_page']}, m)
+        register_uris({"course": ["show_front_page"]}, m)
 
         front_page = self.course.show_front_page()
 
         self.assertIsInstance(front_page, Page)
-        self.assertTrue(hasattr(front_page, 'url'))
-        self.assertTrue(hasattr(front_page, 'title'))
+        self.assertTrue(hasattr(front_page, "url"))
+        self.assertTrue(hasattr(front_page, "title"))
 
     # create_front_page()
     def test_edit_front_page(self, m):
-        register_uris({'course': ['edit_front_page']}, m)
+        register_uris({"course": ["edit_front_page"]}, m)
 
         new_front_page = self.course.edit_front_page()
 
         self.assertIsInstance(new_front_page, Page)
-        self.assertTrue(hasattr(new_front_page, 'url'))
-        self.assertTrue(hasattr(new_front_page, 'title'))
+        self.assertTrue(hasattr(new_front_page, "url"))
+        self.assertTrue(hasattr(new_front_page, "title"))
 
     # get_page()
     def test_get_page(self, m):
-        register_uris({'course': ['get_page']}, m)
+        register_uris({"course": ["get_page"]}, m)
 
-        url = 'my-url'
+        url = "my-url"
         page = self.course.get_page(url)
 
         self.assertIsInstance(page, Page)
 
     # get_pages()
     def test_get_pages(self, m):
-        register_uris({'course': ['get_pages', 'get_pages2']}, m)
+        register_uris({"course": ["get_pages", "get_pages2"]}, m)
 
         pages = self.course.get_pages()
         page_list = [page for page in pages]
 
         self.assertEqual(len(page_list), 4)
         self.assertIsInstance(page_list[0], Page)
-        self.assertTrue(hasattr(page_list[0], 'course_id'))
+        self.assertTrue(hasattr(page_list[0], "course_id"))
         self.assertEqual(page_list[0].course_id, self.course.id)
 
     # create_page()
     def test_create_page(self, m):
-        register_uris({'course': ['create_page']}, m)
+        register_uris({"course": ["create_page"]}, m)
 
         title = "Newest Page"
-        new_page = self.course.create_page(wiki_page={'title': title})
+        new_page = self.course.create_page(wiki_page={"title": title})
 
         self.assertIsInstance(new_page, Page)
-        self.assertTrue(hasattr(new_page, 'title'))
+        self.assertTrue(hasattr(new_page, "title"))
         self.assertEqual(new_page.title, title)
-        self.assertTrue(hasattr(new_page, 'course_id'))
+        self.assertTrue(hasattr(new_page, "course_id"))
         self.assertEqual(new_page.course_id, self.course.id)
 
     def test_create_page_fail(self, m):
@@ -488,19 +486,19 @@ class TestCourse(unittest.TestCase):
 
     # get_external_tool()
     def test_get_external_tool(self, m):
-        register_uris({'external_tool': ['get_by_id_course']}, m)
+        register_uris({"external_tool": ["get_by_id_course"]}, m)
 
         tool_by_id = self.course.get_external_tool(1)
         self.assertIsInstance(tool_by_id, ExternalTool)
-        self.assertTrue(hasattr(tool_by_id, 'name'))
+        self.assertTrue(hasattr(tool_by_id, "name"))
 
         tool_by_obj = self.course.get_external_tool(tool_by_id)
         self.assertIsInstance(tool_by_obj, ExternalTool)
-        self.assertTrue(hasattr(tool_by_obj, 'name'))
+        self.assertTrue(hasattr(tool_by_obj, "name"))
 
     # get_external_tools()
     def test_get_external_tools(self, m):
-        requires = {'course': ['get_external_tools', 'get_external_tools_p2']}
+        requires = {"course": ["get_external_tools", "get_external_tools_p2"]}
         register_uris(requires, m)
 
         tools = self.course.get_external_tools()
@@ -510,7 +508,7 @@ class TestCourse(unittest.TestCase):
         self.assertEqual(len(tool_list), 4)
 
     def test_list_sections(self, m):
-        register_uris({'course': ['get_sections', 'get_sections_p2']}, m)
+        register_uris({"course": ["get_sections", "get_sections_p2"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             sections = self.course.list_sections()
@@ -523,7 +521,7 @@ class TestCourse(unittest.TestCase):
             self.assertEqual(warning_list[-1].category, DeprecationWarning)
 
     def test_create_course_section(self, m):
-        register_uris({'course': ['create_section']}, m)
+        register_uris({"course": ["create_section"]}, m)
 
         section = self.course.create_course_section()
 
@@ -531,7 +529,7 @@ class TestCourse(unittest.TestCase):
 
     # list_groups()
     def test_list_groups(self, m):
-        requires = {'course': ['list_groups_context', 'list_groups_context2']}
+        requires = {"course": ["list_groups_context", "list_groups_context2"]}
         register_uris(requires, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
@@ -546,7 +544,7 @@ class TestCourse(unittest.TestCase):
 
     # get_groups()
     def test_get_groups(self, m):
-        requires = {'course': ['list_groups_context', 'list_groups_context2']}
+        requires = {"course": ["list_groups_context", "list_groups_context2"]}
         register_uris(requires, m)
 
         groups = self.course.get_groups()
@@ -557,7 +555,7 @@ class TestCourse(unittest.TestCase):
 
     # create_group_category()
     def test_create_group_category(self, m):
-        register_uris({'course': ['create_group_category']}, m)
+        register_uris({"course": ["create_group_category"]}, m)
 
         name_str = "Test String"
         response = self.course.create_group_category(name=name_str)
@@ -565,7 +563,7 @@ class TestCourse(unittest.TestCase):
 
     # list_group_categories()
     def test_list_group_categories(self, m):
-        register_uris({'course': ['list_group_categories']}, m)
+        register_uris({"course": ["list_group_categories"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             response = self.course.list_group_categories()
@@ -577,7 +575,7 @@ class TestCourse(unittest.TestCase):
 
     # get_group_categories()
     def test_get_group_categories(self, m):
-        register_uris({'course': ['list_group_categories']}, m)
+        register_uris({"course": ["list_group_categories"]}, m)
 
         response = self.course.get_group_categories()
         category_list = [category for category in response]
@@ -585,77 +583,73 @@ class TestCourse(unittest.TestCase):
 
     # get_discussion_topic()
     def test_get_discussion_topic(self, m):
-        register_uris({'course': ['get_discussion_topic']}, m)
+        register_uris({"course": ["get_discussion_topic"]}, m)
 
         topic_id = 1
         discussion_by_id = self.course.get_discussion_topic(topic_id)
         self.assertIsInstance(discussion_by_id, DiscussionTopic)
-        self.assertTrue(hasattr(discussion_by_id, 'course_id'))
+        self.assertTrue(hasattr(discussion_by_id, "course_id"))
         self.assertEqual(discussion_by_id.course_id, 1)
 
         discussion_by_obj = self.course.get_discussion_topic(discussion_by_id)
         self.assertIsInstance(discussion_by_obj, DiscussionTopic)
-        self.assertTrue(hasattr(discussion_by_obj, 'course_id'))
+        self.assertTrue(hasattr(discussion_by_obj, "course_id"))
         self.assertEqual(discussion_by_obj.course_id, 1)
 
     # get_file()
     def test_get_file(self, m):
-        register_uris({'course': ['get_file']}, m)
+        register_uris({"course": ["get_file"]}, m)
 
         file_by_id = self.course.get_file(1)
         self.assertIsInstance(file_by_id, File)
-        self.assertEqual(file_by_id.display_name, 'Course_File.docx')
+        self.assertEqual(file_by_id.display_name, "Course_File.docx")
         self.assertEqual(file_by_id.size, 2048)
 
         file_by_obj = self.course.get_file(file_by_id)
         self.assertIsInstance(file_by_obj, File)
-        self.assertEqual(file_by_obj.display_name, 'Course_File.docx')
+        self.assertEqual(file_by_obj.display_name, "Course_File.docx")
         self.assertEqual(file_by_obj.size, 2048)
 
     # get_full_discussion_topic()
     def test_get_full_discussion_topic(self, m):
         register_uris(
-            {
-                'course': [
-                    'get_discussion_topics',
-                    'get_full_discussion_topic'
-                ]
-            }, m)
+            {"course": ["get_discussion_topics", "get_full_discussion_topic"]}, m
+        )
 
         topic_id = 1
         discussion_by_id = self.course.get_full_discussion_topic(topic_id)
         self.assertIsInstance(discussion_by_id, dict)
-        self.assertIn('view', discussion_by_id)
-        self.assertIn('participants', discussion_by_id)
-        self.assertIn('id', discussion_by_id)
-        self.assertEqual(discussion_by_id['id'], topic_id)
+        self.assertIn("view", discussion_by_id)
+        self.assertIn("participants", discussion_by_id)
+        self.assertIn("id", discussion_by_id)
+        self.assertEqual(discussion_by_id["id"], topic_id)
 
         discussion_topics = self.course.get_discussion_topics()
         discussion_by_obj = self.course.get_full_discussion_topic(discussion_topics[0])
         self.assertIsInstance(discussion_by_obj, dict)
-        self.assertIn('view', discussion_by_obj)
-        self.assertIn('participants', discussion_by_obj)
-        self.assertIn('id', discussion_by_obj)
-        self.assertEqual(discussion_by_obj['id'], topic_id)
+        self.assertIn("view", discussion_by_obj)
+        self.assertIn("participants", discussion_by_obj)
+        self.assertIn("id", discussion_by_obj)
+        self.assertEqual(discussion_by_obj["id"], topic_id)
 
     # get_discussion_topics()
     def test_get_discussion_topics(self, m):
-        register_uris({'course': ['get_discussion_topics']}, m)
+        register_uris({"course": ["get_discussion_topics"]}, m)
 
         response = self.course.get_discussion_topics()
         discussion_list = [discussion for discussion in response]
         self.assertIsInstance(discussion_list[0], DiscussionTopic)
-        self.assertTrue(hasattr(discussion_list[0], 'course_id'))
+        self.assertTrue(hasattr(discussion_list[0], "course_id"))
         self.assertEqual(2, len(discussion_list))
 
     # create_discussion_topic()
     def test_create_discussion_topic(self, m):
-        register_uris({'course': ['create_discussion_topic']}, m)
+        register_uris({"course": ["create_discussion_topic"]}, m)
 
         title = "Topic 1"
         discussion = self.course.create_discussion_topic()
         self.assertIsInstance(discussion, DiscussionTopic)
-        self.assertTrue(hasattr(discussion, 'course_id'))
+        self.assertTrue(hasattr(discussion, "course_id"))
         self.assertEqual(title, discussion.title)
         self.assertEqual(discussion.course_id, 1)
 
@@ -663,8 +657,8 @@ class TestCourse(unittest.TestCase):
     def test_reorder_pinned_topics(self, m):
         # Custom matcher to test that params are set correctly
         def custom_matcher(request):
-            match_text = '1,2,3'
-            if request.text == 'order={}'.format(quote(match_text)):
+            match_text = "1,2,3"
+            if request.text == "order={}".format(quote(match_text)):
                 resp = requests.Response()
                 resp._content = b'{"reorder": true, "order": [1, 2, 3]}'
                 resp.status_code = 200
@@ -677,14 +671,14 @@ class TestCourse(unittest.TestCase):
         self.assertTrue(discussions)
 
     def test_reorder_pinned_topics_tuple(self, m):
-        register_uris({'course': ['reorder_pinned_topics']}, m)
+        register_uris({"course": ["reorder_pinned_topics"]}, m)
 
         order = (1, 2, 3)
         discussions = self.course.reorder_pinned_topics(order=order)
         self.assertTrue(discussions)
 
     def test_reorder_pinned_topics_comma_separated_string(self, m):
-        register_uris({'course': ['reorder_pinned_topics']}, m)
+        register_uris({"course": ["reorder_pinned_topics"]}, m)
 
         order = "1,2,3"
         discussions = self.course.reorder_pinned_topics(order=order)
@@ -697,37 +691,39 @@ class TestCourse(unittest.TestCase):
 
     # get_assignment_group()
     def test_get_assignment_group(self, m):
-        register_uris({'assignment': ['get_assignment_group']}, m)
+        register_uris({"assignment": ["get_assignment_group"]}, m)
 
         assignment_group_by_id = self.course.get_assignment_group(5)
 
         self.assertIsInstance(assignment_group_by_id, AssignmentGroup)
-        self.assertTrue(hasattr(assignment_group_by_id, 'id'))
-        self.assertTrue(hasattr(assignment_group_by_id, 'name'))
-        self.assertTrue(hasattr(assignment_group_by_id, 'course_id'))
+        self.assertTrue(hasattr(assignment_group_by_id, "id"))
+        self.assertTrue(hasattr(assignment_group_by_id, "name"))
+        self.assertTrue(hasattr(assignment_group_by_id, "course_id"))
         self.assertEqual(assignment_group_by_id.course_id, 1)
 
-        assignment_group_by_obj = self.course.get_assignment_group(assignment_group_by_id)
+        assignment_group_by_obj = self.course.get_assignment_group(
+            assignment_group_by_id
+        )
 
         self.assertIsInstance(assignment_group_by_obj, AssignmentGroup)
-        self.assertTrue(hasattr(assignment_group_by_obj, 'id'))
-        self.assertTrue(hasattr(assignment_group_by_obj, 'name'))
-        self.assertTrue(hasattr(assignment_group_by_obj, 'course_id'))
+        self.assertTrue(hasattr(assignment_group_by_obj, "id"))
+        self.assertTrue(hasattr(assignment_group_by_obj, "name"))
+        self.assertTrue(hasattr(assignment_group_by_obj, "course_id"))
         self.assertEqual(assignment_group_by_obj.course_id, 1)
 
     # list_assignment_groups()
     def test_list_assignment_groups(self, m):
-        register_uris({
-            'assignment': ['list_assignment_groups', 'get_assignment_group']
-        }, m)
+        register_uris(
+            {"assignment": ["list_assignment_groups", "get_assignment_group"]}, m
+        )
 
         with warnings.catch_warnings(record=True) as warning_list:
             response = self.course.list_assignment_groups()
             asnt_group_list = [assignment_group for assignment_group in response]
             self.assertIsInstance(asnt_group_list[0], AssignmentGroup)
-            self.assertTrue(hasattr(asnt_group_list[0], 'id'))
-            self.assertTrue(hasattr(asnt_group_list[0], 'name'))
-            self.assertTrue(hasattr(asnt_group_list[0], 'course_id'))
+            self.assertTrue(hasattr(asnt_group_list[0], "id"))
+            self.assertTrue(hasattr(asnt_group_list[0], "name"))
+            self.assertTrue(hasattr(asnt_group_list[0], "course_id"))
             self.assertEqual(asnt_group_list[0].course_id, 1)
 
             self.assertEqual(len(warning_list), 1)
@@ -735,46 +731,46 @@ class TestCourse(unittest.TestCase):
 
     # get_assignment_groups()
     def test_get_assignment_groups(self, m):
-        register_uris({
-            'assignment': ['list_assignment_groups', 'get_assignment_group']
-        }, m)
+        register_uris(
+            {"assignment": ["list_assignment_groups", "get_assignment_group"]}, m
+        )
 
         response = self.course.get_assignment_groups()
         asnt_group_list = [assignment_group for assignment_group in response]
         self.assertIsInstance(asnt_group_list[0], AssignmentGroup)
-        self.assertTrue(hasattr(asnt_group_list[0], 'id'))
-        self.assertTrue(hasattr(asnt_group_list[0], 'name'))
-        self.assertTrue(hasattr(asnt_group_list[0], 'course_id'))
+        self.assertTrue(hasattr(asnt_group_list[0], "id"))
+        self.assertTrue(hasattr(asnt_group_list[0], "name"))
+        self.assertTrue(hasattr(asnt_group_list[0], "course_id"))
         self.assertEqual(asnt_group_list[0].course_id, 1)
 
     # create_assignment_group()
     def test_create_assignment_group(self, m):
-        register_uris({'assignment': ['create_assignment_group']}, m)
+        register_uris({"assignment": ["create_assignment_group"]}, m)
 
         response = self.course.create_assignment_group()
 
         self.assertIsInstance(response, AssignmentGroup)
-        self.assertTrue(hasattr(response, 'id'))
+        self.assertTrue(hasattr(response, "id"))
         self.assertEqual(response.id, 3)
 
     # create_external_tool()
     def test_create_external_tool(self, m):
-        register_uris({'external_tool': ['create_tool_course']}, m)
+        register_uris({"external_tool": ["create_tool_course"]}, m)
 
         response = self.course.create_external_tool(
             name="External Tool - Course",
             privacy_level="public",
             consumer_key="key",
-            shared_secret="secret"
+            shared_secret="secret",
         )
 
         self.assertIsInstance(response, ExternalTool)
-        self.assertTrue(hasattr(response, 'id'))
+        self.assertTrue(hasattr(response, "id"))
         self.assertEqual(response.id, 20)
 
     # get_course_level_participation_data()
     def test_get_course_level_participation_data(self, m):
-        register_uris({'course': ['get_course_level_participation_data']}, m)
+        register_uris({"course": ["get_course_level_participation_data"]}, m)
 
         response = self.course.get_course_level_participation_data()
 
@@ -782,7 +778,7 @@ class TestCourse(unittest.TestCase):
 
     # get_course_level_assignment_data()
     def test_get_course_level_assignment_data(self, m):
-        register_uris({'course': ['get_course_level_assignment_data']}, m)
+        register_uris({"course": ["get_course_level_assignment_data"]}, m)
 
         response = self.course.get_course_level_assignment_data()
 
@@ -790,7 +786,7 @@ class TestCourse(unittest.TestCase):
 
     # get_course_level_student_summary_data()
     def test_get_course_level_student_summary_data(self, m):
-        register_uris({'course': ['get_course_level_student_summary_data']}, m)
+        register_uris({"course": ["get_course_level_student_summary_data"]}, m)
 
         response = self.course.get_course_level_student_summary_data()
 
@@ -798,7 +794,7 @@ class TestCourse(unittest.TestCase):
 
     # get_user_in_a_course_level_participation_data()
     def test_get_user_in_a_course_level_participation_data(self, m):
-        register_uris({'course': ['get_user_in_a_course_level_participation_data']}, m)
+        register_uris({"course": ["get_user_in_a_course_level_participation_data"]}, m)
 
         response = self.course.get_user_in_a_course_level_participation_data(1)
         self.assertIsInstance(response, list)
@@ -808,7 +804,7 @@ class TestCourse(unittest.TestCase):
 
     # get_user_in_a_course_level_assignment_data()
     def test_get_user_in_a_course_level_assignment_data(self, m):
-        register_uris({'course': ['get_user_in_a_course_level_assignment_data']}, m)
+        register_uris({"course": ["get_user_in_a_course_level_assignment_data"]}, m)
 
         response = self.course.get_user_in_a_course_level_assignment_data(1)
         self.assertIsInstance(response, list)
@@ -818,7 +814,7 @@ class TestCourse(unittest.TestCase):
 
     # get_user_in_a_course_level_messaging_data()
     def test_get_user_in_a_course_level_messaging_data(self, m):
-        register_uris({'course': ['get_user_in_a_course_level_messaging_data']}, m)
+        register_uris({"course": ["get_user_in_a_course_level_messaging_data"]}, m)
 
         response = self.course.get_user_in_a_course_level_messaging_data(1)
         self.assertIsInstance(response, list)
@@ -828,16 +824,16 @@ class TestCourse(unittest.TestCase):
 
     # submit_assignment()
     def test_submit_assignment(self, m):
-        register_uris({'assignment': ['submit']}, m)
+        register_uris({"assignment": ["submit"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             assignment_id = 1
             sub_type = "online_upload"
-            sub_dict = {'submission_type': sub_type}
+            sub_dict = {"submission_type": sub_type}
             submission_by_id = self.course.submit_assignment(assignment_id, sub_dict)
 
             self.assertIsInstance(submission_by_id, Submission)
-            self.assertTrue(hasattr(submission_by_id, 'submission_type'))
+            self.assertTrue(hasattr(submission_by_id, "submission_type"))
             self.assertEqual(submission_by_id.submission_type, sub_type)
 
             self.assertEqual(len(warning_list), 1)
@@ -847,7 +843,7 @@ class TestCourse(unittest.TestCase):
             submission_by_obj = self.course.submit_assignment(self.assignment, sub_dict)
 
             self.assertIsInstance(submission_by_obj, Submission)
-            self.assertTrue(hasattr(submission_by_obj, 'submission_type'))
+            self.assertTrue(hasattr(submission_by_obj, "submission_type"))
             self.assertEqual(submission_by_obj.submission_type, sub_type)
 
             self.assertEqual(len(warning_list), 1)
@@ -863,7 +859,7 @@ class TestCourse(unittest.TestCase):
 
     # list_submissions()
     def test_list_submissions(self, m):
-        register_uris({'submission': ['list_submissions']}, m)
+        register_uris({"submission": ["list_submissions"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             assignment_id = 1
@@ -888,7 +884,7 @@ class TestCourse(unittest.TestCase):
 
     # list_multiple_submission()
     def test_list_multiple_submissions(self, m):
-        register_uris({'course': ['list_multiple_submissions']}, m)
+        register_uris({"course": ["list_multiple_submissions"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             submissions = self.course.list_multiple_submissions()
@@ -902,7 +898,7 @@ class TestCourse(unittest.TestCase):
 
     # get_multiple_submission()
     def test_get_multiple_submissions(self, m):
-        register_uris({'course': ['list_multiple_submissions']}, m)
+        register_uris({"course": ["list_multiple_submissions"]}, m)
 
         submissions = self.course.get_multiple_submissions()
         submission_list = [submission for submission in submissions]
@@ -911,10 +907,10 @@ class TestCourse(unittest.TestCase):
         self.assertIsInstance(submission_list[0], Submission)
 
     def test_get_multiple_submissions_grouped_param(self, m):
-        register_uris({'course': ['list_multiple_submissions']}, m)
+        register_uris({"course": ["list_multiple_submissions"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
-            warnings.simplefilter('always')
+            warnings.simplefilter("always")
             submissions = self.course.get_multiple_submissions(grouped=True)
             submission_list = [submission for submission in submissions]
 
@@ -923,7 +919,7 @@ class TestCourse(unittest.TestCase):
             self.assertEqual(warning_list[-1].category, UserWarning)
             self.assertEqual(
                 text_type(warning_list[-1].message),
-                'The `grouped` parameter must be empty. Removing kwarg `grouped`.'
+                "The `grouped` parameter must be empty. Removing kwarg `grouped`.",
             )
 
             self.assertEqual(len(submission_list), 2)
@@ -931,10 +927,9 @@ class TestCourse(unittest.TestCase):
 
     # get_submission()
     def test_get_submission(self, m):
-        register_uris({
-            'course': ['get_assignment_by_id'],
-            'submission': ['get_by_id_course']
-        }, m)
+        register_uris(
+            {"course": ["get_assignment_by_id"], "submission": ["get_by_id_course"]}, m
+        )
 
         assignment_for_id = 1
         user_id = 1
@@ -942,37 +937,40 @@ class TestCourse(unittest.TestCase):
         with warnings.catch_warnings(record=True) as warning_list:
             submission_by_id = self.course.get_submission(assignment_for_id, user_id)
             self.assertIsInstance(submission_by_id, Submission)
-            self.assertTrue(hasattr(submission_by_id, 'submission_type'))
+            self.assertTrue(hasattr(submission_by_id, "submission_type"))
 
             self.assertEqual(len(warning_list), 1)
             self.assertEqual(warning_list[-1].category, DeprecationWarning)
 
         with warnings.catch_warnings(record=True) as warning_list:
             assignment_for_obj = self.course.get_assignment(1)
-            submission_by_obj = self.course.get_submission(assignment_for_obj, self.user)
+            submission_by_obj = self.course.get_submission(
+                assignment_for_obj, self.user
+            )
             self.assertIsInstance(submission_by_obj, Submission)
-            self.assertTrue(hasattr(submission_by_obj, 'submission_type'))
+            self.assertTrue(hasattr(submission_by_obj, "submission_type"))
 
             self.assertEqual(len(warning_list), 1)
             self.assertEqual(warning_list[-1].category, DeprecationWarning)
 
     # update_submission()
     def test_update_submission(self, m):
-        register_uris({
-            'course': ['get_assignment_by_id'],
-            'submission': ['edit', 'get_by_id_course']
-        }, m)
+        register_uris(
+            {
+                "course": ["get_assignment_by_id"],
+                "submission": ["edit", "get_by_id_course"],
+            },
+            m,
+        )
 
         assignment_for_id = 1
         user_id = 1
         with warnings.catch_warnings(record=True) as warning_list:
             submission = self.course.update_submission(
-                assignment_for_id,
-                user_id,
-                submission={'excuse': True}
+                assignment_for_id, user_id, submission={"excuse": True}
             )
             self.assertIsInstance(submission, Submission)
-            self.assertTrue(hasattr(submission, 'excused'))
+            self.assertTrue(hasattr(submission, "excused"))
 
             self.assertEqual(len(warning_list), 1)
             self.assertEqual(warning_list[-1].category, DeprecationWarning)
@@ -980,19 +978,19 @@ class TestCourse(unittest.TestCase):
         assignment_for_obj = self.course.get_assignment(1)
         with warnings.catch_warnings(record=True) as warning_list:
             submission = self.course.update_submission(
-                assignment_for_obj,
-                self.user,
-                submission={'excuse': True}
+                assignment_for_obj, self.user, submission={"excuse": True}
             )
             self.assertIsInstance(submission, Submission)
-            self.assertTrue(hasattr(submission, 'excused'))
+            self.assertTrue(hasattr(submission, "excused"))
 
             self.assertEqual(len(warning_list), 1)
             self.assertEqual(warning_list[-1].category, DeprecationWarning)
 
     # list_gradeable_students()
     def test_list_gradeable_students(self, m):
-        register_uris({'course': ['get_assignment_by_id', 'list_gradeable_students']}, m)
+        register_uris(
+            {"course": ["get_assignment_by_id", "list_gradeable_students"]}, m
+        )
 
         assignment_for_id = 1
         with warnings.catch_warnings(record=True) as warning_list:
@@ -1018,12 +1016,16 @@ class TestCourse(unittest.TestCase):
 
     # mark_submission_as_read
     def test_mark_submission_as_read(self, m):
-        register_uris({'course': ['get_assignment_by_id', 'mark_submission_as_read']}, m)
+        register_uris(
+            {"course": ["get_assignment_by_id", "mark_submission_as_read"]}, m
+        )
 
         assignment_for_id = 1
         user_for_id = 1
         with warnings.catch_warnings(record=True) as warning_list:
-            submission_by_id = self.course.mark_submission_as_read(assignment_for_id, user_for_id)
+            submission_by_id = self.course.mark_submission_as_read(
+                assignment_for_id, user_for_id
+            )
             self.assertTrue(submission_by_id)
 
             self.assertEqual(len(warning_list), 1)
@@ -1031,7 +1033,9 @@ class TestCourse(unittest.TestCase):
 
         assignment_for_obj = self.course.get_assignment(1)
         with warnings.catch_warnings(record=True) as warning_list:
-            submission_by_obj = self.course.mark_submission_as_read(assignment_for_obj, self.user)
+            submission_by_obj = self.course.mark_submission_as_read(
+                assignment_for_obj, self.user
+            )
             self.assertTrue(submission_by_obj)
 
             self.assertEqual(len(warning_list), 1)
@@ -1039,15 +1043,16 @@ class TestCourse(unittest.TestCase):
 
     # mark_submission_as_unread
     def test_mark_submission_as_unread(self, m):
-        register_uris({'course': ['get_assignment_by_id', 'mark_submission_as_unread']}, m)
+        register_uris(
+            {"course": ["get_assignment_by_id", "mark_submission_as_unread"]}, m
+        )
 
         assignment_for_id = 1
         user_for_id = 1
 
         with warnings.catch_warnings(record=True) as warning_list:
             submission_by_id = self.course.mark_submission_as_unread(
-                assignment_for_id,
-                user_for_id
+                assignment_for_id, user_for_id
             )
             self.assertTrue(submission_by_id)
 
@@ -1057,8 +1062,7 @@ class TestCourse(unittest.TestCase):
         assignment_for_obj = self.course.get_assignment(1)
         with warnings.catch_warnings(record=True) as warning_list:
             submission_by_obj = self.course.mark_submission_as_unread(
-                assignment_for_obj,
-                self.user
+                assignment_for_obj, self.user
             )
             self.assertTrue(submission_by_obj)
 
@@ -1067,13 +1071,13 @@ class TestCourse(unittest.TestCase):
 
     # list_external_feeds()
     def test_list_external_feeds(self, m):
-        register_uris({'course': ['list_external_feeds']}, m)
+        register_uris({"course": ["list_external_feeds"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             feeds = self.course.list_external_feeds()
             feed_list = [feed for feed in feeds]
             self.assertEqual(len(feed_list), 2)
-            self.assertTrue(hasattr(feed_list[0], 'url'))
+            self.assertTrue(hasattr(feed_list[0], "url"))
             self.assertIsInstance(feed_list[0], ExternalFeed)
 
             self.assertEqual(len(warning_list), 1)
@@ -1081,17 +1085,17 @@ class TestCourse(unittest.TestCase):
 
     # get_external_feeds()
     def test_get_external_feeds(self, m):
-        register_uris({'course': ['list_external_feeds']}, m)
+        register_uris({"course": ["list_external_feeds"]}, m)
 
         feeds = self.course.get_external_feeds()
         feed_list = [feed for feed in feeds]
         self.assertEqual(len(feed_list), 2)
-        self.assertTrue(hasattr(feed_list[0], 'url'))
+        self.assertTrue(hasattr(feed_list[0], "url"))
         self.assertIsInstance(feed_list[0], ExternalFeed)
 
     # create_external_feed()
     def test_create_external_feed(self, m):
-        register_uris({'course': ['create_external_feed']}, m)
+        register_uris({"course": ["create_external_feed"]}, m)
 
         url_str = "https://example.com/myblog.rss"
         response = self.course.create_external_feed(url=url_str)
@@ -1099,22 +1103,22 @@ class TestCourse(unittest.TestCase):
 
     # delete_external_feed()
     def test_delete_external_feed(self, m):
-        register_uris({'course': ['delete_external_feed']}, m)
+        register_uris({"course": ["delete_external_feed"]}, m)
 
         ef_id = 1
         deleted_ef_by_id = self.course.delete_external_feed(ef_id)
         self.assertIsInstance(deleted_ef_by_id, ExternalFeed)
-        self.assertTrue(hasattr(deleted_ef_by_id, 'url'))
+        self.assertTrue(hasattr(deleted_ef_by_id, "url"))
         self.assertEqual(deleted_ef_by_id.display_name, "My Blog")
 
         deleted_ef_by_obj = self.course.delete_external_feed(deleted_ef_by_id)
         self.assertIsInstance(deleted_ef_by_obj, ExternalFeed)
-        self.assertTrue(hasattr(deleted_ef_by_obj, 'url'))
+        self.assertTrue(hasattr(deleted_ef_by_obj, "url"))
         self.assertEqual(deleted_ef_by_obj.display_name, "My Blog")
 
     # list_files()
     def test_list_files(self, m):
-        register_uris({'course': ['list_course_files', 'list_course_files2']}, m)
+        register_uris({"course": ["list_course_files", "list_course_files2"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             files = self.course.list_files()
@@ -1127,7 +1131,7 @@ class TestCourse(unittest.TestCase):
 
     # get_files()
     def test_get_files(self, m):
-        register_uris({'course': ['list_course_files', 'list_course_files2']}, m)
+        register_uris({"course": ["list_course_files", "list_course_files2"]}, m)
 
         files = self.course.get_files()
         file_list = [file for file in files]
@@ -1136,7 +1140,7 @@ class TestCourse(unittest.TestCase):
 
     # get_folder()
     def test_get_folder(self, m):
-        register_uris({'course': ['get_folder']}, m)
+        register_uris({"course": ["get_folder"]}, m)
 
         folder_by_id = self.course.get_folder(1)
         self.assertEqual(folder_by_id.name, "Folder 1")
@@ -1148,7 +1152,7 @@ class TestCourse(unittest.TestCase):
 
     # list_folders()
     def test_list_folders(self, m):
-        register_uris({'course': ['list_folders']}, m)
+        register_uris({"course": ["list_folders"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             folders = self.course.list_folders()
@@ -1161,7 +1165,7 @@ class TestCourse(unittest.TestCase):
 
     # get_folders()
     def test_get_folders(self, m):
-        register_uris({'course': ['list_folders']}, m)
+        register_uris({"course": ["list_folders"]}, m)
 
         folders = self.course.get_folders()
         folder_list = [folder for folder in folders]
@@ -1170,7 +1174,7 @@ class TestCourse(unittest.TestCase):
 
     # create_folder()
     def test_create_folder(self, m):
-        register_uris({'course': ['create_folder']}, m)
+        register_uris({"course": ["create_folder"]}, m)
 
         name_str = "Test String"
         response = self.course.create_folder(name=name_str)
@@ -1178,7 +1182,7 @@ class TestCourse(unittest.TestCase):
 
     # list_tabs()
     def test_list_tabs(self, m):
-        register_uris({'course': ['list_tabs']}, m)
+        register_uris({"course": ["list_tabs"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             tabs = self.course.list_tabs()
@@ -1191,7 +1195,7 @@ class TestCourse(unittest.TestCase):
 
     # get_tabs()
     def test_get_tabs(self, m):
-        register_uris({'course': ['list_tabs']}, m)
+        register_uris({"course": ["list_tabs"]}, m)
 
         tabs = self.course.get_tabs()
         tab_list = [tab for tab in tabs]
@@ -1200,7 +1204,7 @@ class TestCourse(unittest.TestCase):
 
     # update_tab()
     def test_update_tab(self, m):
-        register_uris({'course': ['update_tab']}, m)
+        register_uris({"course": ["update_tab"]}, m)
 
         tab_id = "pages"
         new_position = 3
@@ -1216,7 +1220,7 @@ class TestCourse(unittest.TestCase):
 
     # get_rubric
     def test_get_rubric(self, m):
-        register_uris({'course': ['get_rubric_single']}, m)
+        register_uris({"course": ["get_rubric_single"]}, m)
 
         rubric_id = 1
         rubric = self.course.get_rubric(rubric_id)
@@ -1227,7 +1231,7 @@ class TestCourse(unittest.TestCase):
 
     # list_rubrics
     def test_list_rubrics(self, m):
-        register_uris({'course': ['get_rubric_multiple']}, m)
+        register_uris({"course": ["get_rubric_multiple"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             rubrics = self.course.list_rubrics()
@@ -1246,7 +1250,7 @@ class TestCourse(unittest.TestCase):
 
     # get_rubrics
     def test_get_rubrics(self, m):
-        register_uris({'course': ['get_rubric_multiple']}, m)
+        register_uris({"course": ["get_rubric_multiple"]}, m)
 
         rubrics = self.course.get_rubrics()
 
@@ -1261,7 +1265,7 @@ class TestCourse(unittest.TestCase):
 
     # get_root_outcome_group()
     def test_get_root_outcome_group(self, m):
-        register_uris({'outcome': ['course_root_outcome_group']}, m)
+        register_uris({"outcome": ["course_root_outcome_group"]}, m)
 
         outcome_group = self.course.get_root_outcome_group()
 
@@ -1271,7 +1275,7 @@ class TestCourse(unittest.TestCase):
 
     # get_outcome_group()
     def test_get_outcome_group(self, m):
-        register_uris({'outcome': ['course_get_outcome_group']}, m)
+        register_uris({"outcome": ["course_get_outcome_group"]}, m)
 
         outcome_group_by_id = self.course.get_outcome_group(1)
         self.assertIsInstance(outcome_group_by_id, OutcomeGroup)
@@ -1285,7 +1289,7 @@ class TestCourse(unittest.TestCase):
 
     # get_outcome_groups_in_context()
     def test_get_outcome_groups_in_context(self, m):
-        register_uris({'outcome': ['course_outcome_groups_in_context']}, m)
+        register_uris({"outcome": ["course_outcome_groups_in_context"]}, m)
 
         outcome_group_list = self.course.get_outcome_groups_in_context()
 
@@ -1295,35 +1299,35 @@ class TestCourse(unittest.TestCase):
 
     # get_all_outcome_links_in_context()
     def test_get_outcome_links_in_context(self, m):
-        register_uris({'outcome': ['course_outcome_links_in_context']}, m)
+        register_uris({"outcome": ["course_outcome_links_in_context"]}, m)
 
         outcome_link_list = self.course.get_all_outcome_links_in_context()
 
         self.assertIsInstance(outcome_link_list[0], OutcomeLink)
-        self.assertEqual(outcome_link_list[0].outcome_group['id'], 2)
-        self.assertEqual(outcome_link_list[0].outcome_group['title'], "test outcome")
+        self.assertEqual(outcome_link_list[0].outcome_group["id"], 2)
+        self.assertEqual(outcome_link_list[0].outcome_group["title"], "test outcome")
 
     # get_outcome_results()
     def test_get_outcome_results(self, m):
-        register_uris({'outcome': ['course_get_outcome_results']}, m)
+        register_uris({"outcome": ["course_get_outcome_results"]}, m)
 
         result = self.course.get_outcome_results()
 
         self.assertIsInstance(result, dict)
-        self.assertIsInstance(result['outcome_results'], list)
+        self.assertIsInstance(result["outcome_results"], list)
 
     # get_outcome_result_rollups()
     def test_get_outcome_result_rollups(self, m):
-        register_uris({'outcome': ['course_get_outcome_result_rollups']}, m)
+        register_uris({"outcome": ["course_get_outcome_result_rollups"]}, m)
 
         result = self.course.get_outcome_result_rollups()
 
         self.assertIsInstance(result, dict)
-        self.assertIsInstance(result['rollups'], list)
+        self.assertIsInstance(result["rollups"], list)
 
     # add_grading_standards()
     def test_add_grading_standards(self, m):
-        register_uris({'course': ['add_grading_standards']}, m)
+        register_uris({"course": ["add_grading_standards"]}, m)
 
         title = "Grading Standard 1"
         grading_scheme = []
@@ -1334,36 +1338,36 @@ class TestCourse(unittest.TestCase):
         response = self.course.add_grading_standards(title, grading_scheme)
 
         self.assertIsInstance(response, GradingStandard)
-        self.assertTrue(hasattr(response, 'title'))
+        self.assertTrue(hasattr(response, "title"))
         self.assertEqual(title, response.title)
         self.assertTrue(hasattr(response, "grading_scheme"))
-        self.assertEqual(response.grading_scheme[0].get('name'), "A")
-        self.assertEqual(response.grading_scheme[0].get('value'), 0.9)
+        self.assertEqual(response.grading_scheme[0].get("name"), "A")
+        self.assertEqual(response.grading_scheme[0].get("value"), 0.9)
 
     # add_grading_standards()
     def test_add_grading_standards_empty_list(self, m):
-        register_uris({'course': ['add_grading_standards']}, m)
+        register_uris({"course": ["add_grading_standards"]}, m)
         with self.assertRaises(ValueError):
             self.course.add_grading_standards("title", [])
 
     def test_add_grading_standards_non_dict_list(self, m):
-        register_uris({'course': ['add_grading_standards']}, m)
+        register_uris({"course": ["add_grading_standards"]}, m)
         with self.assertRaises(ValueError):
             self.course.add_grading_standards("title", [1, 2, 3])
 
     def test_add_grading_standards_missing_value_key(self, m):
-        register_uris({'course': ['add_grading_standards']}, m)
+        register_uris({"course": ["add_grading_standards"]}, m)
         with self.assertRaises(ValueError):
-            self.course.add_grading_standards("title", [{'name': "test"}])
+            self.course.add_grading_standards("title", [{"name": "test"}])
 
     def test_add_grading_standards_missing_name_key(self, m):
-        register_uris({'course': ['add_grading_standards']}, m)
+        register_uris({"course": ["add_grading_standards"]}, m)
         with self.assertRaises(ValueError):
-            self.course.add_grading_standards("title", [{'value': 2}])
+            self.course.add_grading_standards("title", [{"value": 2}])
 
     # get_grading_standards()
     def test_get_grading_standards(self, m):
-        register_uris({'course': ['get_grading_standards']}, m)
+        register_uris({"course": ["get_grading_standards"]}, m)
 
         standards = self.course.get_grading_standards()
         standard_list = [standard for standard in standards]
@@ -1373,56 +1377,58 @@ class TestCourse(unittest.TestCase):
 
     # get_single_grading_standards()
     def test_get_single_grading_standard(self, m):
-        register_uris({'course': ['get_single_grading_standard']}, m)
+        register_uris({"course": ["get_single_grading_standard"]}, m)
 
         response = self.course.get_single_grading_standard(1)
 
         self.assertIsInstance(response, GradingStandard)
-        self.assertTrue(hasattr(response, 'id'))
+        self.assertTrue(hasattr(response, "id"))
         self.assertEqual(1, response.id)
-        self.assertTrue(hasattr(response, 'title'))
+        self.assertTrue(hasattr(response, "title"))
         self.assertEqual("Grading Standard 1", response.title)
         self.assertTrue(hasattr(response, "grading_scheme"))
-        self.assertEqual(response.grading_scheme[0].get('name'), "A")
-        self.assertEqual(response.grading_scheme[0].get('value'), 0.9)
+        self.assertEqual(response.grading_scheme[0].get("name"), "A")
+        self.assertEqual(response.grading_scheme[0].get("value"), 0.9)
 
     # create_content_migration
     def test_create_content_migration(self, m):
-        register_uris({'course': ['create_content_migration']}, m)
+        register_uris({"course": ["create_content_migration"]}, m)
 
-        content_migration = self.course.create_content_migration('dummy_importer')
+        content_migration = self.course.create_content_migration("dummy_importer")
 
         self.assertIsInstance(content_migration, ContentMigration)
-        self.assertTrue(hasattr(content_migration, 'migration_type'))
+        self.assertTrue(hasattr(content_migration, "migration_type"))
 
     def test_create_content_migration_migrator(self, m):
-        register_uris({'course': ['create_content_migration',
-                                  'get_migration_systems_multiple']}, m)
+        register_uris(
+            {"course": ["create_content_migration", "get_migration_systems_multiple"]},
+            m,
+        )
 
         migrators = self.course.get_migration_systems()
         content_migration = self.course.create_content_migration(migrators[0])
 
         self.assertIsInstance(content_migration, ContentMigration)
-        self.assertTrue(hasattr(content_migration, 'migration_type'))
+        self.assertTrue(hasattr(content_migration, "migration_type"))
 
     def test_create_content_migration_bad_migration_type(self, m):
-        register_uris({'course': ['create_content_migration']}, m)
+        register_uris({"course": ["create_content_migration"]}, m)
 
         with self.assertRaises(TypeError):
             self.course.create_content_migration(1)
 
     # get_content_migration
     def test_get_content_migration(self, m):
-        register_uris({'course': ['get_content_migration_single']}, m)
+        register_uris({"course": ["get_content_migration_single"]}, m)
 
         content_migration = self.course.get_content_migration(1)
 
         self.assertIsInstance(content_migration, ContentMigration)
-        self.assertTrue(hasattr(content_migration, 'migration_type'))
+        self.assertTrue(hasattr(content_migration, "migration_type"))
 
     # get_content_migrations
     def test_get_content_migrations(self, m):
-        register_uris({'course': ['get_content_migration_multiple']}, m)
+        register_uris({"course": ["get_content_migration_multiple"]}, m)
 
         content_migrations = self.course.get_content_migrations()
 
@@ -1437,7 +1443,7 @@ class TestCourse(unittest.TestCase):
 
     # get_migration_systems
     def test_get_migration_systems(self, m):
-        register_uris({'course': ['get_migration_systems_multiple']}, m)
+        register_uris({"course": ["get_migration_systems_multiple"]}, m)
 
         migration_systems = self.course.get_migration_systems()
 
@@ -1454,35 +1460,28 @@ class TestCourse(unittest.TestCase):
 
     # set_quiz_extensions
     def test_set_quiz_extensions(self, m):
-        register_uris({'course': ['set_quiz_extensions']}, m)
+        register_uris({"course": ["set_quiz_extensions"]}, m)
 
-        extension = self.course.set_quiz_extensions([
-            {
-                'user_id': 1,
-                'extra_time': 60
-            },
-            {
-                'user_id': 2,
-                'extra_attempts': 3
-            }
-        ])
+        extension = self.course.set_quiz_extensions(
+            [{"user_id": 1, "extra_time": 60}, {"user_id": 2, "extra_attempts": 3}]
+        )
 
         self.assertIsInstance(extension, list)
         self.assertEqual(len(extension), 2)
 
         self.assertIsInstance(extension[0], QuizExtension)
         self.assertEqual(extension[0].user_id, "1")
-        self.assertTrue(hasattr(extension[0], 'extra_time'))
+        self.assertTrue(hasattr(extension[0], "extra_time"))
         self.assertEqual(extension[0].extra_time, 60)
 
         self.assertIsInstance(extension[1], QuizExtension)
         self.assertEqual(extension[1].user_id, "2")
-        self.assertTrue(hasattr(extension[1], 'extra_attempts'))
+        self.assertTrue(hasattr(extension[1], "extra_attempts"))
         self.assertEqual(extension[1].extra_attempts, 3)
 
     def test_set_extensions_not_list(self, m):
         with self.assertRaises(ValueError):
-            self.course.set_quiz_extensions({'user_id': 1, 'extra_time': 60})
+            self.course.set_quiz_extensions({"user_id": 1, "extra_time": 60})
 
     def test_set_extensions_empty_list(self, m):
         with self.assertRaises(ValueError):
@@ -1490,26 +1489,19 @@ class TestCourse(unittest.TestCase):
 
     def test_set_extensions_non_dicts(self, m):
         with self.assertRaises(ValueError):
-            self.course.set_quiz_extensions([('user_id', 1), ('extra_time', 60)])
+            self.course.set_quiz_extensions([("user_id", 1), ("extra_time", 60)])
 
     def test_set_extensions_missing_key(self, m):
         with self.assertRaises(RequiredFieldMissing):
-            self.course.set_quiz_extensions([{'extra_time': 60, 'extra_attempts': 3}])
+            self.course.set_quiz_extensions([{"extra_time": 60, "extra_attempts": 3}])
 
     # submissions_bulk_update()
     def test_submissions_bulk_update(self, m):
-        register_uris({'course': ['update_submissions']}, m)
-        register_uris({'progress': ['course_progress']}, m)
-        progress = self.course.submissions_bulk_update(grade_data={
-            '1': {
-                '1': {
-                    'posted_grade': 97
-                },
-                '2': {
-                    'posted_grade': 98
-                }
-            }
-        })
+        register_uris({"course": ["update_submissions"]}, m)
+        register_uris({"progress": ["course_progress"]}, m)
+        progress = self.course.submissions_bulk_update(
+            grade_data={"1": {"1": {"posted_grade": 97}, "2": {"posted_grade": 98}}}
+        )
         self.assertIsInstance(progress, Progress)
         self.assertTrue(progress.context_type == "Course")
         progress = progress.query()
@@ -1518,12 +1510,11 @@ class TestCourse(unittest.TestCase):
 
 @requests_mock.Mocker()
 class TestCourseNickname(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({'user': ['course_nickname']}, m)
+            register_uris({"user": ["course_nickname"]}, m)
             self.nickname = self.canvas.get_course_nickname(1)
 
     # __str__()
@@ -1533,9 +1524,9 @@ class TestCourseNickname(unittest.TestCase):
 
     # remove()
     def test_remove(self, m):
-        register_uris({'user': ['remove_nickname']}, m)
+        register_uris({"user": ["remove_nickname"]}, m)
 
         deleted_nick = self.nickname.remove()
 
         self.assertIsInstance(deleted_nick, CourseNickname)
-        self.assertTrue(hasattr(deleted_nick, 'nickname'))
+        self.assertTrue(hasattr(deleted_nick, "nickname"))

--- a/tests/test_current_user.py
+++ b/tests/test_current_user.py
@@ -16,7 +16,7 @@ class TestCurrentUser(unittest.TestCase):
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
         with requests_mock.Mocker() as m:
-            register_uris({'current_user': ['get_by_id']}, m)
+            register_uris({"current_user": ["get_by_id"]}, m)
             self.user = self.canvas.get_current_user()
 
     # __str__()
@@ -26,7 +26,7 @@ class TestCurrentUser(unittest.TestCase):
 
     # list_groups()
     def test_list_groups(self, m):
-        register_uris({'current_user': ['list_groups', 'list_groups2']}, m)
+        register_uris({"current_user": ["list_groups", "list_groups2"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             groups = self.user.list_groups()
@@ -40,7 +40,7 @@ class TestCurrentUser(unittest.TestCase):
 
     # get_groups()
     def test_get_groups(self, m):
-        register_uris({'current_user': ['list_groups', 'list_groups2']}, m)
+        register_uris({"current_user": ["list_groups", "list_groups2"]}, m)
 
         groups = self.user.get_groups()
         group_list = [group for group in groups]
@@ -50,7 +50,7 @@ class TestCurrentUser(unittest.TestCase):
 
     # list_bookmarks()
     def test_list_bookmarks(self, m):
-        register_uris({'bookmark': ['list_bookmarks']}, m)
+        register_uris({"bookmark": ["list_bookmarks"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             bookmarks = self.user.list_bookmarks()
@@ -63,7 +63,7 @@ class TestCurrentUser(unittest.TestCase):
 
     # get_bookmarks()
     def test_get_bookmarks(self, m):
-        register_uris({'bookmark': ['list_bookmarks']}, m)
+        register_uris({"bookmark": ["list_bookmarks"]}, m)
 
         bookmarks = self.user.get_bookmarks()
         bookmark_list = [bookmark for bookmark in bookmarks]
@@ -72,7 +72,7 @@ class TestCurrentUser(unittest.TestCase):
 
     # get_bookmark()
     def test_get_bookmark(self, m):
-        register_uris({'bookmark': ['get_bookmark']}, m)
+        register_uris({"bookmark": ["get_bookmark"]}, m)
 
         bookmark_by_id = self.user.get_bookmark(45)
         self.assertIsInstance(bookmark_by_id, Bookmark)
@@ -83,10 +83,9 @@ class TestCurrentUser(unittest.TestCase):
 
     # create_bookmark()
     def test_create_bookmark(self, m):
-        register_uris({'bookmark': ['create_bookmark']}, m)
+        register_uris({"bookmark": ["create_bookmark"]}, m)
         evnt = self.user.create_bookmark(
-            name="Test Bookmark",
-            url="https://www.google.com"
+            name="Test Bookmark", url="https://www.google.com"
         )
         self.assertIsInstance(evnt, Bookmark)
         self.assertEqual(evnt.name, "Test Bookmark")

--- a/tests/test_discussion_topic.py
+++ b/tests/test_discussion_topic.py
@@ -15,14 +15,13 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestDiscussionTopic(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
             requires = {
-                'course': ['get_by_id', 'get_discussion_topic'],
-                'group': ['get_by_id', 'get_discussion_topic']
+                "course": ["get_by_id", "get_discussion_topic"],
+                "group": ["get_by_id", "get_discussion_topic"],
             }
             register_uris(requires, m)
 
@@ -38,30 +37,30 @@ class TestDiscussionTopic(unittest.TestCase):
 
     # delete()
     def test_delete(self, m):
-        register_uris({'discussion_topic': ['delete']}, m)
+        register_uris({"discussion_topic": ["delete"]}, m)
 
         response = self.discussion_topic.delete()
         self.assertTrue(response)
 
     # update()
     def test_update(self, m):
-        register_uris({'discussion_topic': ['update']}, m)
+        register_uris({"discussion_topic": ["update"]}, m)
 
         discussion = self.discussion_topic.update()
         self.assertIsInstance(discussion, DiscussionTopic)
-        self.assertTrue(hasattr(discussion, 'course_id'))
+        self.assertTrue(hasattr(discussion, "course_id"))
         self.assertEqual(discussion.course_id, 1)
 
     # post_entry()
     def test_post_entry(self, m):
-        register_uris({'discussion_topic': ['post_entry']}, m)
+        register_uris({"discussion_topic": ["post_entry"]}, m)
 
         entry = self.discussion_topic.post_entry()
         self.assertTrue(entry)
 
     # list_topic_entries()
     def test_list_topic_entries(self, m):
-        register_uris({'discussion_topic': ['list_topic_entries']}, m)
+        register_uris({"discussion_topic": ["list_topic_entries"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             entries = self.discussion_topic.list_topic_entries()
@@ -69,9 +68,9 @@ class TestDiscussionTopic(unittest.TestCase):
             self.assertEqual(len(entry_list), 2)
 
             self.assertIsInstance(entry_list[0], DiscussionEntry)
-            self.assertTrue(hasattr(entry_list[0], 'id'))
+            self.assertTrue(hasattr(entry_list[0], "id"))
             self.assertEqual(entry_list[0].id, 1)
-            self.assertTrue(hasattr(entry_list[0], 'user_id'))
+            self.assertTrue(hasattr(entry_list[0], "user_id"))
             self.assertEqual(entry_list[0].user_id, 1)
 
             self.assertEqual(len(warning_list), 1)
@@ -79,21 +78,21 @@ class TestDiscussionTopic(unittest.TestCase):
 
     # get_topic_entries()
     def test_get_topic_entries(self, m):
-        register_uris({'discussion_topic': ['list_topic_entries']}, m)
+        register_uris({"discussion_topic": ["list_topic_entries"]}, m)
 
         entries = self.discussion_topic.get_topic_entries()
         entry_list = [entry for entry in entries]
         self.assertEqual(len(entry_list), 2)
 
         self.assertIsInstance(entry_list[0], DiscussionEntry)
-        self.assertTrue(hasattr(entry_list[0], 'id'))
+        self.assertTrue(hasattr(entry_list[0], "id"))
         self.assertEqual(entry_list[0].id, 1)
-        self.assertTrue(hasattr(entry_list[0], 'user_id'))
+        self.assertTrue(hasattr(entry_list[0], "user_id"))
         self.assertEqual(entry_list[0].user_id, 1)
 
     # list_entries()
     def test_list_entries(self, m):
-        register_uris({'discussion_topic': ['list_entries']}, m)
+        register_uris({"discussion_topic": ["list_entries"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             entries_by_id = self.discussion_topic.list_entries([1, 2, 3])
@@ -102,10 +101,10 @@ class TestDiscussionTopic(unittest.TestCase):
 
             entry_by_id = entry_list_by_id[-1]
             self.assertIsInstance(entry_by_id, DiscussionEntry)
-            self.assertTrue(hasattr(entry_by_id, 'id'))
+            self.assertTrue(hasattr(entry_by_id, "id"))
             self.assertEqual(entry_by_id.id, 3)
-            self.assertTrue(hasattr(entry_by_id, 'message'))
-            self.assertEqual(entry_by_id.message, 'Lower level entry')
+            self.assertTrue(hasattr(entry_by_id, "message"))
+            self.assertEqual(entry_by_id.message, "Lower level entry")
 
             self.assertEqual(len(warning_list), 1)
             self.assertEqual(warning_list[-1].category, DeprecationWarning)
@@ -117,17 +116,17 @@ class TestDiscussionTopic(unittest.TestCase):
 
             entry_by_obj = entry_list_by_obj[-1]
             self.assertIsInstance(entry_by_obj, DiscussionEntry)
-            self.assertTrue(hasattr(entry_by_obj, 'id'))
+            self.assertTrue(hasattr(entry_by_obj, "id"))
             self.assertEqual(entry_by_obj.id, 3)
-            self.assertTrue(hasattr(entry_by_obj, 'message'))
-            self.assertEqual(entry_by_obj.message, 'Lower level entry')
+            self.assertTrue(hasattr(entry_by_obj, "message"))
+            self.assertEqual(entry_by_obj.message, "Lower level entry")
 
             self.assertEqual(len(warning_list), 1)
             self.assertEqual(warning_list[-1].category, DeprecationWarning)
 
     # get_entries()
     def test_get_entries(self, m):
-        register_uris({'discussion_topic': ['list_entries']}, m)
+        register_uris({"discussion_topic": ["list_entries"]}, m)
 
         entries_by_id = self.discussion_topic.get_entries([1, 2, 3])
         entry_list_by_id = [entry for entry in entries_by_id]
@@ -135,10 +134,10 @@ class TestDiscussionTopic(unittest.TestCase):
 
         entry_by_id = entry_list_by_id[-1]
         self.assertIsInstance(entry_by_id, DiscussionEntry)
-        self.assertTrue(hasattr(entry_by_id, 'id'))
+        self.assertTrue(hasattr(entry_by_id, "id"))
         self.assertEqual(entry_by_id.id, 3)
-        self.assertTrue(hasattr(entry_by_id, 'message'))
-        self.assertEqual(entry_by_id.message, 'Lower level entry')
+        self.assertTrue(hasattr(entry_by_id, "message"))
+        self.assertEqual(entry_by_id.message, "Lower level entry")
 
         entries_by_obj = self.discussion_topic.get_entries(entries_by_id)
         entry_list_by_obj = [entry for entry in entries_by_obj]
@@ -146,20 +145,20 @@ class TestDiscussionTopic(unittest.TestCase):
 
         entry_by_obj = entry_list_by_obj[-1]
         self.assertIsInstance(entry_by_obj, DiscussionEntry)
-        self.assertTrue(hasattr(entry_by_obj, 'id'))
+        self.assertTrue(hasattr(entry_by_obj, "id"))
         self.assertEqual(entry_by_obj.id, 3)
-        self.assertTrue(hasattr(entry_by_obj, 'message'))
-        self.assertEqual(entry_by_obj.message, 'Lower level entry')
+        self.assertTrue(hasattr(entry_by_obj, "message"))
+        self.assertEqual(entry_by_obj.message, "Lower level entry")
 
     # mark_as_read()
     def test_mark_as_read(self, m):
-        register_uris({'discussion_topic': ['mark_as_read']}, m)
+        register_uris({"discussion_topic": ["mark_as_read"]}, m)
 
         topic = self.discussion_topic.mark_as_read()
         self.assertTrue(topic)
 
     def test_mark_as_read_403(self, m):
-        register_uris({'discussion_topic': ['mark_as_read_403']}, m)
+        register_uris({"discussion_topic": ["mark_as_read_403"]}, m)
 
         with self.assertRaises(Forbidden):
             topic = self.discussion_topic.mark_as_read()
@@ -167,13 +166,13 @@ class TestDiscussionTopic(unittest.TestCase):
 
     # mark_as_unread()
     def test_mark_as_unread(self, m):
-        register_uris({'discussion_topic': ['mark_as_unread']}, m)
+        register_uris({"discussion_topic": ["mark_as_unread"]}, m)
 
         topic = self.discussion_topic.mark_as_unread()
         self.assertTrue(topic)
 
     def test_mark_as_unread_403(self, m):
-        register_uris({'discussion_topic': ['mark_as_unread_403']}, m)
+        register_uris({"discussion_topic": ["mark_as_unread_403"]}, m)
 
         with self.assertRaises(Forbidden):
             topic = self.discussion_topic.mark_as_unread()
@@ -181,13 +180,13 @@ class TestDiscussionTopic(unittest.TestCase):
 
     # mark_entries_as_read()
     def test_mark_entries_as_read(self, m):
-        register_uris({'discussion_topic': ['mark_entries_as_read']}, m)
+        register_uris({"discussion_topic": ["mark_entries_as_read"]}, m)
 
         entries = self.discussion_topic.mark_entries_as_read()
         self.assertTrue(entries)
 
     def test_mark_entries_as_read_403(self, m):
-        register_uris({'discussion_topic': ['mark_entries_as_read_403']}, m)
+        register_uris({"discussion_topic": ["mark_entries_as_read_403"]}, m)
 
         with self.assertRaises(Forbidden):
             entries = self.discussion_topic.mark_entries_as_read()
@@ -195,13 +194,13 @@ class TestDiscussionTopic(unittest.TestCase):
 
     # mark_entries_as_unread()
     def test_mark_entries_as_unread(self, m):
-        register_uris({'discussion_topic': ['mark_entries_as_unread']}, m)
+        register_uris({"discussion_topic": ["mark_entries_as_unread"]}, m)
 
         entries = self.discussion_topic.mark_entries_as_unread()
         self.assertTrue(entries)
 
     def test_mark_entries_as_unread_403(self, m):
-        register_uris({'discussion_topic': ['mark_entries_as_unread_403']}, m)
+        register_uris({"discussion_topic": ["mark_entries_as_unread_403"]}, m)
 
         with self.assertRaises(Forbidden):
             entries = self.discussion_topic.mark_entries_as_unread()
@@ -209,13 +208,13 @@ class TestDiscussionTopic(unittest.TestCase):
 
     # subscribe()
     def test_subscribe(self, m):
-        register_uris({'discussion_topic': ['subscribe']}, m)
+        register_uris({"discussion_topic": ["subscribe"]}, m)
 
         subscribe = self.discussion_topic.subscribe()
         self.assertTrue(subscribe)
 
     def test_subscribe_403(self, m):
-        register_uris({'discussion_topic': ['subscribe_403']}, m)
+        register_uris({"discussion_topic": ["subscribe_403"]}, m)
 
         with self.assertRaises(Forbidden):
             subscribe = self.discussion_topic.subscribe()
@@ -223,13 +222,13 @@ class TestDiscussionTopic(unittest.TestCase):
 
     # unsubscribe()
     def test_unsubscribe(self, m):
-        register_uris({'discussion_topic': ['unsubscribe']}, m)
+        register_uris({"discussion_topic": ["unsubscribe"]}, m)
 
         unsubscribe = self.discussion_topic.unsubscribe()
         self.assertTrue(unsubscribe)
 
     def test_unsubscribe_403(self, m):
-        register_uris({'discussion_topic': ['unsubscribe_403']}, m)
+        register_uris({"discussion_topic": ["unsubscribe_403"]}, m)
 
         with self.assertRaises(Forbidden):
             unsubscribe = self.discussion_topic.unsubscribe()
@@ -243,45 +242,47 @@ class TestDiscussionTopic(unittest.TestCase):
         self.assertEqual(self.discussion_topic_group._parent_id, 1)
 
     def test_parent_id_no_id(self, m):
-        discussion = DiscussionTopic(self.canvas._Canvas__requester, {'id': 1})
+        discussion = DiscussionTopic(self.canvas._Canvas__requester, {"id": 1})
         with self.assertRaises(ValueError):
             discussion._parent_id
 
     # _parent_type
     def test_parent_type_course(self, m):
-        self.assertEqual(self.discussion_topic._parent_type, 'course')
+        self.assertEqual(self.discussion_topic._parent_type, "course")
 
     def test_parent_type_group(self, m):
-        self.assertEqual(self.discussion_topic_group._parent_type, 'group')
+        self.assertEqual(self.discussion_topic_group._parent_type, "group")
 
     def test_parent_type_no_id(self, m):
-        discussion = DiscussionTopic(self.canvas._Canvas__requester, {'id': 1})
+        discussion = DiscussionTopic(self.canvas._Canvas__requester, {"id": 1})
         with self.assertRaises(ValueError):
             discussion._parent_type
 
     # get_parent()
     def test_get_parent_course(self, m):
-        register_uris({'course': ['get_by_id']}, m)
+        register_uris({"course": ["get_by_id"]}, m)
 
         self.assertIsInstance(self.discussion_topic.get_parent(), Course)
 
     def test_get_parent_group(self, m):
-        register_uris({'group': ['get_by_id']}, m)
+        register_uris({"group": ["get_by_id"]}, m)
 
         self.assertIsInstance(self.discussion_topic_group.get_parent(), Group)
 
 
 @requests_mock.Mocker()
 class TestDiscussionEntry(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
             requires = {
-                'course': ['get_by_id', 'get_discussion_topic'],
-                'discussion_topic': ['list_entries_single', 'list_entries_single_group'],
-                'group': ['get_by_id', 'get_discussion_topic']
+                "course": ["get_by_id", "get_discussion_topic"],
+                "discussion_topic": [
+                    "list_entries_single",
+                    "list_entries_single_group",
+                ],
+                "group": ["get_by_id", "get_discussion_topic"],
             }
             register_uris(requires, m)
 
@@ -290,7 +291,9 @@ class TestDiscussionEntry(unittest.TestCase):
             self.discussion_topic = self.course.get_discussion_topic(1)
             self.discussion_topic_group = self.group.get_discussion_topic(1)
             self.discussion_entry = self.discussion_topic.get_entries([1])[0]
-            self.discussion_entry_group = self.discussion_topic_group.get_entries([1])[0]
+            self.discussion_entry_group = self.discussion_topic_group.get_entries([1])[
+                0
+            ]
 
     # __str__()
     def test__str__(self, m):
@@ -305,54 +308,54 @@ class TestDiscussionEntry(unittest.TestCase):
         self.assertEqual(self.discussion_entry_group._discussion_parent_id, 1)
 
     def test_discussion_parent_id_no_id(self, m):
-        discussion = DiscussionEntry(self.canvas._Canvas__requester, {'id': 1})
+        discussion = DiscussionEntry(self.canvas._Canvas__requester, {"id": 1})
         with self.assertRaises(ValueError):
             discussion._discussion_parent_id
 
     # _discussion_parent_type
     def test_discussion_parent_type_course(self, m):
-        self.assertEqual(self.discussion_entry._discussion_parent_type, 'course')
+        self.assertEqual(self.discussion_entry._discussion_parent_type, "course")
 
     def test_discussion_parent_type_group(self, m):
-        self.assertEqual(self.discussion_entry_group._discussion_parent_type, 'group')
+        self.assertEqual(self.discussion_entry_group._discussion_parent_type, "group")
 
     def test_discussion_parent_type_no_id(self, m):
-        discussion = DiscussionEntry(self.canvas._Canvas__requester, {'id': 1})
+        discussion = DiscussionEntry(self.canvas._Canvas__requester, {"id": 1})
         with self.assertRaises(ValueError):
             discussion._discussion_parent_type
 
     # get_discussion()
     def test_get_discussion(self, m):
-        register_uris({'course': ['get_discussion_topic']}, m)
+        register_uris({"course": ["get_discussion_topic"]}, m)
 
         discussion = self.discussion_entry.get_discussion()
         self.assertIsInstance(discussion, DiscussionTopic)
-        self.assertTrue(hasattr(discussion, 'id'))
+        self.assertTrue(hasattr(discussion, "id"))
         self.assertEqual(self.discussion_topic.id, discussion.id)
-        self.assertTrue(hasattr(discussion, 'title'))
+        self.assertTrue(hasattr(discussion, "title"))
         self.assertEqual(self.discussion_topic.title, discussion.title)
 
     # delete()
     def test_delete(self, m):
-        register_uris({'discussion_topic': ['delete_entry']}, m)
+        register_uris({"discussion_topic": ["delete_entry"]}, m)
 
         response = self.discussion_entry.delete()
         self.assertTrue(response)
 
     # post_reply()
     def test_post_reply(self, m):
-        register_uris({'discussion_topic': ['post_reply']}, m)
+        register_uris({"discussion_topic": ["post_reply"]}, m)
 
         message = "Reply message 1"
         reply = self.discussion_entry.post_reply(message=message)
         self.assertIsInstance(reply, DiscussionEntry)
-        self.assertTrue(hasattr(reply, 'message'))
+        self.assertTrue(hasattr(reply, "message"))
         self.assertEqual(reply.message, message)
-        self.assertTrue(hasattr(reply, 'created_at'))
+        self.assertTrue(hasattr(reply, "created_at"))
 
     # list_replies()
     def test_list_replies(self, m):
-        register_uris({'discussion_topic': ['list_entry_replies']}, m)
+        register_uris({"discussion_topic": ["list_entry_replies"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             replies = self.discussion_entry.list_replies()
@@ -361,17 +364,17 @@ class TestDiscussionEntry(unittest.TestCase):
 
             reply = reply_list[0]
             self.assertIsInstance(reply, DiscussionEntry)
-            self.assertTrue(hasattr(reply, 'id'))
+            self.assertTrue(hasattr(reply, "id"))
             self.assertEqual(reply.id, 5)
-            self.assertTrue(hasattr(reply, 'message'))
-            self.assertEqual(reply.message, 'Reply message 1')
+            self.assertTrue(hasattr(reply, "message"))
+            self.assertEqual(reply.message, "Reply message 1")
 
             self.assertEqual(len(warning_list), 1)
             self.assertEqual(warning_list[-1].category, DeprecationWarning)
 
     # get_replies()
     def test_get_replies(self, m):
-        register_uris({'discussion_topic': ['list_entry_replies']}, m)
+        register_uris({"discussion_topic": ["list_entry_replies"]}, m)
 
         replies = self.discussion_entry.get_replies()
         reply_list = [reply for reply in replies]
@@ -379,33 +382,33 @@ class TestDiscussionEntry(unittest.TestCase):
 
         reply = reply_list[0]
         self.assertIsInstance(reply, DiscussionEntry)
-        self.assertTrue(hasattr(reply, 'id'))
+        self.assertTrue(hasattr(reply, "id"))
         self.assertEqual(reply.id, 5)
-        self.assertTrue(hasattr(reply, 'message'))
-        self.assertEqual(reply.message, 'Reply message 1')
+        self.assertTrue(hasattr(reply, "message"))
+        self.assertEqual(reply.message, "Reply message 1")
 
     # mark_as_read()
     def test_mark_as_read(self, m):
-        register_uris({'discussion_topic': ['mark_entry_as_read']}, m)
+        register_uris({"discussion_topic": ["mark_entry_as_read"]}, m)
 
         response = self.discussion_entry.mark_as_read()
         self.assertTrue(response)
 
     def test_mark_as_read_403(self, m):
-        register_uris({'discussion_topic': ['mark_entry_as_read_403']}, m)
+        register_uris({"discussion_topic": ["mark_entry_as_read_403"]}, m)
 
         with self.assertRaises(Forbidden):
             self.discussion_entry.mark_as_read()
 
     # mark_as_unread()
     def test_mark_as_unread(self, m):
-        register_uris({'discussion_topic': ['mark_entry_as_unread']}, m)
+        register_uris({"discussion_topic": ["mark_entry_as_unread"]}, m)
 
         response = self.discussion_entry.mark_as_unread()
         self.assertTrue(response)
 
     def test_mark_as_unread_403(self, m):
-        register_uris({'discussion_topic': ['mark_entry_as_unread_403']}, m)
+        register_uris({"discussion_topic": ["mark_entry_as_unread_403"]}, m)
 
         with self.assertRaises(Forbidden):
             response = self.discussion_entry.mark_as_unread()
@@ -413,11 +416,11 @@ class TestDiscussionEntry(unittest.TestCase):
 
     # update()
     def test_update(self, m):
-        register_uris({'discussion_topic': ['update_entry']}, m)
+        register_uris({"discussion_topic": ["update_entry"]}, m)
 
-        self.assertEqual(self.discussion_entry.message, 'Top Level Entry')
+        self.assertEqual(self.discussion_entry.message, "Top Level Entry")
 
-        new_message = 'Top Level Entry [Updated]'
+        new_message = "Top Level Entry [Updated]"
         response = self.discussion_entry.update(message=new_message)
 
         self.assertTrue(response)
@@ -426,7 +429,7 @@ class TestDiscussionEntry(unittest.TestCase):
 
     # rate()
     def test_rate(self, m):
-        register_uris({'discussion_topic': ['rate_entry']}, m)
+        register_uris({"discussion_topic": ["rate_entry"]}, m)
 
         response = self.discussion_entry.rate(1)
         self.assertTrue(response)

--- a/tests/test_enrollment.py
+++ b/tests/test_enrollment.py
@@ -11,15 +11,11 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestEnrollment(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            requires = {
-                'account': ['get_by_id'],
-                'enrollment': ['get_by_id']
-            }
+            requires = {"account": ["get_by_id"], "enrollment": ["get_by_id"]}
             register_uris(requires, m)
 
             self.account = self.canvas.get_account(1)
@@ -32,19 +28,19 @@ class TestEnrollment(unittest.TestCase):
 
     # deactivate()
     def test_deactivate(self, m):
-        register_uris({'enrollment': ['deactivate']}, m)
+        register_uris({"enrollment": ["deactivate"]}, m)
 
-        target_enrollment = self.enrollment.deactivate('conclude')
+        target_enrollment = self.enrollment.deactivate("conclude")
 
         self.assertIsInstance(target_enrollment, Enrollment)
 
     def test_deactivate_invalid_task(self, m):
         with self.assertRaises(ValueError):
-            self.enrollment.deactivate('finish')
+            self.enrollment.deactivate("finish")
 
     # reactivate()
     def test_reactivate(self, m):
-        register_uris({'enrollment': ['reactivate']}, m)
+        register_uris({"enrollment": ["reactivate"]}, m)
 
         target_enrollment = self.enrollment.reactivate()
 

--- a/tests/test_enrollment_term.py
+++ b/tests/test_enrollment_term.py
@@ -11,41 +11,38 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestEnrollmentTerm(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({
-                'account': ['get_by_id', 'create_enrollment_term']
-            }, m)
+            register_uris({"account": ["get_by_id", "create_enrollment_term"]}, m)
 
             self.account = self.canvas.get_account(1)
-            self.enrollment_term = self.account.create_enrollment_term(enrollment_term={
-                "name": "Test Enrollment Term"
-            })
+            self.enrollment_term = self.account.create_enrollment_term(
+                enrollment_term={"name": "Test Enrollment Term"}
+            )
 
     # delete()
     def test_delete_enrollment_term(self, m):
-        register_uris({'enrollment_term': ['delete_enrollment_term']}, m)
+        register_uris({"enrollment_term": ["delete_enrollment_term"]}, m)
 
         deleted_enrollment_term = self.enrollment_term.delete()
 
         self.assertIsInstance(deleted_enrollment_term, EnrollmentTerm)
-        self.assertTrue(hasattr(deleted_enrollment_term, 'name'))
-        self.assertEqual(deleted_enrollment_term.name, 'Test Enrollment Term')
+        self.assertTrue(hasattr(deleted_enrollment_term, "name"))
+        self.assertEqual(deleted_enrollment_term.name, "Test Enrollment Term")
 
     # edit()
     def test_edit_enrollment_term(self, m):
-        register_uris({'enrollment_term': ['edit_enrollment_term']}, m)
+        register_uris({"enrollment_term": ["edit_enrollment_term"]}, m)
 
-        name = 'New Name'
-        edited_enrollment_term = self.enrollment_term.edit(enrollment_term={
-            "name": name
-        })
+        name = "New Name"
+        edited_enrollment_term = self.enrollment_term.edit(
+            enrollment_term={"name": name}
+        )
 
         self.assertIsInstance(edited_enrollment_term, EnrollmentTerm)
-        self.assertTrue(hasattr(edited_enrollment_term, 'name'))
+        self.assertTrue(hasattr(edited_enrollment_term, "name"))
         self.assertEqual(edited_enrollment_term.name, name)
 
     # __str__()

--- a/tests/test_external_feed.py
+++ b/tests/test_external_feed.py
@@ -10,12 +10,11 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestExternalFeed(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({'course': ['get_by_id', 'list_external_feeds']}, m)
+            register_uris({"course": ["get_by_id", "list_external_feeds"]}, m)
 
             self.course = self.canvas.get_course(1)
             self.external_feed = self.course.get_external_feeds()[0]

--- a/tests/test_external_tool.py
+++ b/tests/test_external_tool.py
@@ -15,15 +15,14 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestExternalTool(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
             requires = {
-                'account': ['get_by_id'],
-                'course': ['get_by_id'],
-                'external_tool': ['get_by_id_account', 'get_by_id_course'],
+                "account": ["get_by_id"],
+                "course": ["get_by_id"],
+                "external_tool": ["get_by_id_account", "get_by_id_course"],
             }
             register_uris(requires, m)
 
@@ -45,42 +44,42 @@ class TestExternalTool(unittest.TestCase):
         self.assertEqual(self.ext_tool_course.parent_id, 1)
 
     def test_parent_id_no_id(self, m):
-        tool = ExternalTool(self.canvas._Canvas__requester, {'id': 1})
+        tool = ExternalTool(self.canvas._Canvas__requester, {"id": 1})
         with self.assertRaises(ValueError):
             tool.parent_id
 
     # parent_type
     def test_parent_type_account(self, m):
-        self.assertEqual(self.ext_tool_account.parent_type, 'account')
+        self.assertEqual(self.ext_tool_account.parent_type, "account")
 
     def test_parent_type_course(self, m):
-        self.assertEqual(self.ext_tool_course.parent_type, 'course')
+        self.assertEqual(self.ext_tool_course.parent_type, "course")
 
     def test_parent_type_no_id(self, m):
-        tool = ExternalTool(self.canvas._Canvas__requester, {'id': 1})
+        tool = ExternalTool(self.canvas._Canvas__requester, {"id": 1})
         with self.assertRaises(ValueError):
             tool.parent_type
 
     # get_parent()
     def test_get_parent_account(self, m):
-        register_uris({'account': ['get_by_id']}, m)
+        register_uris({"account": ["get_by_id"]}, m)
         self.assertIsInstance(self.ext_tool_account.get_parent(), Account)
 
     def test_get_parent_course(self, m):
-        register_uris({'course': ['get_by_id']}, m)
+        register_uris({"course": ["get_by_id"]}, m)
         self.assertIsInstance(self.ext_tool_course.get_parent(), Course)
 
     # delete()
     def test_delete(self, m):
-        register_uris({'external_tool': ['delete_tool_course']}, m)
+        register_uris({"external_tool": ["delete_tool_course"]}, m)
         deleted_tool = self.ext_tool_course.delete()
 
         self.assertIsInstance(deleted_tool, ExternalTool)
-        self.assertTrue(hasattr(deleted_tool, 'name'))
+        self.assertTrue(hasattr(deleted_tool, "name"))
 
     # edit()
     def test_edit(self, m):
-        register_uris({'external_tool': ['edit_tool_course']}, m)
+        register_uris({"external_tool": ["edit_tool_course"]}, m)
         new_name = "New Tool Name"
 
         edited_tool = self.ext_tool_course.edit(name=new_name)
@@ -91,17 +90,17 @@ class TestExternalTool(unittest.TestCase):
 
     # get_sessionless_launch_url()
     def test_get_sessionless_launch_url(self, m):
-        requires = {'external_tool': ['get_sessionless_launch_url_course']}
+        requires = {"external_tool": ["get_sessionless_launch_url_course"]}
         register_uris(requires, m)
 
-        self.assertIsInstance(self.ext_tool_course.get_sessionless_launch_url(), text_type)
+        self.assertIsInstance(
+            self.ext_tool_course.get_sessionless_launch_url(), text_type
+        )
 
     def test_get_sessionless_launch_url_no_url(self, m):
         requires = {
-            'course': ['get_by_id_2'],
-            'external_tool': [
-                'get_by_id_course_2', 'sessionless_launch_no_url'
-            ]
+            "course": ["get_by_id_2"],
+            "external_tool": ["get_by_id_course_2", "sessionless_launch_no_url"],
         }
         register_uris(requires, m)
 

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -13,12 +13,13 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestFile(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({'course': ['get_by_id', 'list_course_files', 'list_course_files2']}, m)
+            register_uris(
+                {"course": ["get_by_id", "list_course_files", "list_course_files2"]}, m
+            )
 
             self.course = self.canvas.get_course(1)
             self.file = self.course.get_files()[0]
@@ -30,27 +31,27 @@ class TestFile(unittest.TestCase):
 
     # delete()
     def test_delete_file(self, m):
-        register_uris({'file': ['delete_file']}, m)
+        register_uris({"file": ["delete_file"]}, m)
 
         deleted_file = self.file.delete()
 
         self.assertIsInstance(deleted_file, File)
-        self.assertTrue(hasattr(deleted_file, 'display_name'))
+        self.assertTrue(hasattr(deleted_file, "display_name"))
         self.assertEqual(deleted_file.display_name, "Bad File.docx")
 
     # download()
     def test_download_file(self, m):
-        register_uris({'file': ['file_download']}, m)
+        register_uris({"file": ["file_download"]}, m)
         try:
-            self.file.download('canvasapi_file_download_test.txt')
-            self.assertTrue(isfile('canvasapi_file_download_test.txt'))
-            with open('canvasapi_file_download_test.txt') as downloaded_file:
+            self.file.download("canvasapi_file_download_test.txt")
+            self.assertTrue(isfile("canvasapi_file_download_test.txt"))
+            with open("canvasapi_file_download_test.txt") as downloaded_file:
                 self.assertEqual(downloaded_file.read(), '"file contents are here"')
         finally:
-            cleanup_file('canvasapi_file_download_test.txt')
+            cleanup_file("canvasapi_file_download_test.txt")
 
     # contents()
     def test_contents_file(self, m):
-        register_uris({'file': ['file_contents']}, m)
+        register_uris({"file": ["file_contents"]}, m)
         contents = self.file.get_contents()
         self.assertEqual(contents, '"Hello there"')

--- a/tests/test_folder.py
+++ b/tests/test_folder.py
@@ -14,12 +14,11 @@ from tests.util import register_uris, cleanup_file
 
 @requests_mock.Mocker()
 class TestFolder(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({'folder': ['get_by_id']}, m)
+            register_uris({"folder": ["get_by_id"]}, m)
 
             self.folder = self.canvas.get_folder(1)
 
@@ -30,7 +29,7 @@ class TestFolder(unittest.TestCase):
 
     # list_files()
     def test_list_files(self, m):
-        register_uris({'folder': ['list_folder_files', 'list_folder_files2']}, m)
+        register_uris({"folder": ["list_folder_files", "list_folder_files2"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             files = self.folder.list_files()
@@ -43,7 +42,7 @@ class TestFolder(unittest.TestCase):
 
     # get_files()
     def test_get_files(self, m):
-        register_uris({'folder': ['list_folder_files', 'list_folder_files2']}, m)
+        register_uris({"folder": ["list_folder_files", "list_folder_files2"]}, m)
 
         files = self.folder.get_files()
         file_list = [file for file in files]
@@ -52,17 +51,17 @@ class TestFolder(unittest.TestCase):
 
     # delete()
     def test_delete_file(self, m):
-        register_uris({'folder': ['delete_folder']}, m)
+        register_uris({"folder": ["delete_folder"]}, m)
 
         deleted_folder = self.folder.delete()
 
         self.assertIsInstance(deleted_folder, Folder)
-        self.assertTrue(hasattr(deleted_folder, 'name'))
+        self.assertTrue(hasattr(deleted_folder, "name"))
         self.assertEqual(deleted_folder.full_name, "course_files/Folder 1")
 
     # list_folders()
     def test_list_folders(self, m):
-        register_uris({'folder': ['list_folders']}, m)
+        register_uris({"folder": ["list_folders"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             folders = self.folder.list_folders()
@@ -75,7 +74,7 @@ class TestFolder(unittest.TestCase):
 
     # get_folders()
     def test_get_folders(self, m):
-        register_uris({'folder': ['list_folders']}, m)
+        register_uris({"folder": ["list_folders"]}, m)
 
         folders = self.folder.get_folders()
         folder_list = [folder for folder in folders]
@@ -84,7 +83,7 @@ class TestFolder(unittest.TestCase):
 
     # create_folder()
     def test_create_folder(self, m):
-        register_uris({'folder': ['create_folder']}, m)
+        register_uris({"folder": ["create_folder"]}, m)
 
         name_str = "Test String"
         response = self.folder.create_folder(name=name_str)
@@ -92,33 +91,33 @@ class TestFolder(unittest.TestCase):
 
     # upload()
     def test_upload(self, m):
-        register_uris({'folder': ['upload', 'upload_final']}, m)
+        register_uris({"folder": ["upload", "upload_final"]}, m)
 
-        filename = 'testfile_course_{}'.format(uuid.uuid4().hex)
+        filename = "testfile_course_{}".format(uuid.uuid4().hex)
 
         try:
-            with open(filename, 'w+') as file:
+            with open(filename, "w+") as file:
                 response = self.folder.upload(file)
             self.assertTrue(response[0])
             self.assertIsInstance(response[1], dict)
-            self.assertIn('url', response[1])
+            self.assertIn("url", response[1])
         finally:
             cleanup_file(filename)
 
     # update()
     def test_update(self, m):
-        register_uris({'folder': ['update']}, m)
+        register_uris({"folder": ["update"]}, m)
 
-        new_name = 'New Name'
+        new_name = "New Name"
         response = self.folder.update(name=new_name)
         self.assertIsInstance(response, Folder)
         self.assertEqual(self.folder.name, new_name)
 
     # copy_file()
     def test_copy_file(self, m):
-        register_uris({'folder': ['copy_file']}, m)
+        register_uris({"folder": ["copy_file"]}, m)
 
         new_file = self.folder.copy_file(1)
         self.assertIsInstance(new_file, File)
-        self.assertEqual(new_file.display_name, 'Dummy File-1')
+        self.assertEqual(new_file.display_name, "Dummy File-1")
         self.assertEqual(new_file.id, 1)

--- a/tests/test_grading_standard.py
+++ b/tests/test_grading_standard.py
@@ -10,14 +10,11 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestGradingStandard(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({
-                'course': ['get_by_id', 'get_single_grading_standard']
-            }, m)
+            register_uris({"course": ["get_by_id", "get_single_grading_standard"]}, m)
 
             self.course = self.canvas.get_course(1)
             self.grading_standard = self.course.get_single_grading_standard(1)

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -24,12 +24,11 @@ from tests.util import cleanup_file, register_uris
 
 @requests_mock.Mocker()
 class TestGroup(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({'course': ['get_by_id'], 'group': ['get_by_id']}, m)
+            register_uris({"course": ["get_by_id"], "group": ["get_by_id"]}, m)
 
             self.course = self.canvas.get_course(1)
             self.group = self.canvas.get_group(1)
@@ -41,43 +40,43 @@ class TestGroup(unittest.TestCase):
 
     # show_front_page()
     def test_show_front_page(self, m):
-        register_uris({'group': ['show_front_page']}, m)
+        register_uris({"group": ["show_front_page"]}, m)
 
         front_page = self.group.show_front_page()
         self.assertIsInstance(front_page, Page)
-        self.assertTrue(hasattr(front_page, 'url'))
-        self.assertTrue(hasattr(front_page, 'title'))
+        self.assertTrue(hasattr(front_page, "url"))
+        self.assertTrue(hasattr(front_page, "title"))
 
     # create_front_page()
     def test_edit_front_page(self, m):
-        register_uris({'group': ['edit_front_page']}, m)
+        register_uris({"group": ["edit_front_page"]}, m)
 
         new_front_page = self.group.edit_front_page()
         self.assertIsInstance(new_front_page, Page)
-        self.assertTrue(hasattr(new_front_page, 'url'))
-        self.assertTrue(hasattr(new_front_page, 'title'))
+        self.assertTrue(hasattr(new_front_page, "url"))
+        self.assertTrue(hasattr(new_front_page, "title"))
 
     # get_pages()
     def test_get_pages(self, m):
-        register_uris({'group': ['get_pages', 'get_pages2']}, m)
+        register_uris({"group": ["get_pages", "get_pages2"]}, m)
 
         pages = self.group.get_pages()
         page_list = [page for page in pages]
         self.assertEqual(len(page_list), 4)
         self.assertIsInstance(page_list[0], Page)
-        self.assertTrue(hasattr(page_list[0], 'id'))
+        self.assertTrue(hasattr(page_list[0], "id"))
         self.assertEqual(page_list[0].group_id, self.group.id)
 
     # create_page()
     def test_create_page(self, m):
-        register_uris({'group': ['create_page']}, m)
+        register_uris({"group": ["create_page"]}, m)
 
-        title = 'New Page'
-        new_page = self.group.create_page(wiki_page={'title': title})
+        title = "New Page"
+        new_page = self.group.create_page(wiki_page={"title": title})
         self.assertIsInstance(new_page, Page)
-        self.assertTrue(hasattr(new_page, 'title'))
+        self.assertTrue(hasattr(new_page, "title"))
         self.assertEqual(new_page.title, title)
-        self.assertTrue(hasattr(new_page, 'id'))
+        self.assertTrue(hasattr(new_page, "id"))
         self.assertEqual(new_page.group_id, self.group.id)
 
     def test_create_page_fail(self, m):
@@ -86,34 +85,34 @@ class TestGroup(unittest.TestCase):
 
     # get_page()
     def test_get_page(self, m):
-        register_uris({'group': ['get_page']}, m)
+        register_uris({"group": ["get_page"]}, m)
 
-        url = 'my-url'
+        url = "my-url"
         page = self.group.get_page(url)
         self.assertIsInstance(page, Page)
 
     # edit()
     def test_edit(self, m):
-        register_uris({'group': ['edit']}, m)
+        register_uris({"group": ["edit"]}, m)
 
         new_title = "New Group"
         response = self.group.edit(description=new_title)
         self.assertIsInstance(response, Group)
-        self.assertTrue(hasattr(response, 'description'))
+        self.assertTrue(hasattr(response, "description"))
         self.assertEqual(response.description, new_title)
 
     # delete()
     def test_delete(self, m):
-        register_uris({'group': ['delete']}, m)
+        register_uris({"group": ["delete"]}, m)
 
         group = self.group.delete()
         self.assertIsInstance(group, Group)
-        self.assertTrue(hasattr(group, 'name'))
-        self.assertTrue(hasattr(group, 'description'))
+        self.assertTrue(hasattr(group, "name"))
+        self.assertTrue(hasattr(group, "description"))
 
     # invite()
     def test_invite(self, m):
-        register_uris({'group': ['invite']}, m)
+        register_uris({"group": ["invite"]}, m)
 
         user_list = ["1", "2"]
         response = self.group.invite(user_list)
@@ -123,10 +122,11 @@ class TestGroup(unittest.TestCase):
 
     # list_users()
     def test_list_users(self, m):
-        register_uris({'group': ['list_users', 'list_users_p2']}, m)
+        register_uris({"group": ["list_users", "list_users_p2"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             from canvasapi.user import User
+
             users = self.group.list_users()
             user_list = [user for user in users]
             self.assertIsInstance(user_list[0], User)
@@ -137,9 +137,10 @@ class TestGroup(unittest.TestCase):
 
     # get_users()
     def test_get_users(self, m):
-        register_uris({'group': ['list_users', 'list_users_p2']}, m)
+        register_uris({"group": ["list_users", "list_users_p2"]}, m)
 
         from canvasapi.user import User
+
         users = self.group.get_users()
         user_list = [user for user in users]
         self.assertIsInstance(user_list[0], User)
@@ -147,16 +148,10 @@ class TestGroup(unittest.TestCase):
 
     # remove_user()
     def test_remove_user(self, m):
-        register_uris(
-            {
-                'group': [
-                    'list_users',
-                    'list_users_p2',
-                    'remove_user'
-                ]
-            }, m)
+        register_uris({"group": ["list_users", "list_users_p2", "remove_user"]}, m)
 
         from canvasapi.user import User
+
         user_by_id = self.group.remove_user(1)
         self.assertIsInstance(user_by_id, User)
 
@@ -166,21 +161,21 @@ class TestGroup(unittest.TestCase):
 
     # upload()
     def test_upload(self, m):
-        register_uris({'group': ['upload', 'upload_final']}, m)
+        register_uris({"group": ["upload", "upload_final"]}, m)
 
-        filename = 'testfile_group_{}'.format(uuid.uuid4().hex)
+        filename = "testfile_group_{}".format(uuid.uuid4().hex)
         try:
-            with open(filename, 'w+') as file:
+            with open(filename, "w+") as file:
                 response = self.group.upload(file)
             self.assertTrue(response[0])
             self.assertIsInstance(response[1], dict)
-            self.assertIn('url', response[1])
+            self.assertIn("url", response[1])
         finally:
             cleanup_file(filename)
 
     # preview_processed_html()
     def test_preview_processed_html(self, m):
-        register_uris({'group': ['preview_processed_html']}, m)
+        register_uris({"group": ["preview_processed_html"]}, m)
 
         html_str = "<p>processed html</p>"
         response = self.group.preview_html(html_str)
@@ -188,46 +183,39 @@ class TestGroup(unittest.TestCase):
 
     # get_activity_stream_summary()
     def test_get_activity_stream_summary(self, m):
-        register_uris({'group': ['activity_stream_summary']}, m)
+        register_uris({"group": ["activity_stream_summary"]}, m)
 
         response = self.group.get_activity_stream_summary()
         self.assertEqual(len(response), 2)
-        self.assertIn('type', response[0])
+        self.assertIn("type", response[0])
 
     # list_memberships()
     def test_list_memberships(self, m):
-        register_uris({'group': ['list_memberships', 'list_memberships_p2']}, m)
+        register_uris({"group": ["list_memberships", "list_memberships_p2"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             response = self.group.list_memberships()
             membership_list = [membership for membership in response]
             self.assertEqual(len(membership_list), 4)
             self.assertIsInstance(membership_list[0], GroupMembership)
-            self.assertTrue(hasattr(membership_list[0], 'id'))
+            self.assertTrue(hasattr(membership_list[0], "id"))
 
             self.assertEqual(len(warning_list), 1)
             self.assertEqual(warning_list[-1].category, DeprecationWarning)
 
     # get_memberships()
     def test_get_memberships(self, m):
-        register_uris({'group': ['list_memberships', 'list_memberships_p2']}, m)
+        register_uris({"group": ["list_memberships", "list_memberships_p2"]}, m)
 
         response = self.group.get_memberships()
         membership_list = [membership for membership in response]
         self.assertEqual(len(membership_list), 4)
         self.assertIsInstance(membership_list[0], GroupMembership)
-        self.assertTrue(hasattr(membership_list[0], 'id'))
+        self.assertTrue(hasattr(membership_list[0], "id"))
 
     # get_membership()
     def test_get_membership(self, m):
-        register_uris(
-            {
-                'group': [
-                    'get_membership',
-                    'list_users',
-                    'list_users_p2'
-                ]
-            }, m)
+        register_uris({"group": ["get_membership", "list_users", "list_users_p2"]}, m)
 
         membership_by_id = self.group.get_membership(1, "users")
         self.assertIsInstance(membership_by_id, GroupMembership)
@@ -239,13 +227,8 @@ class TestGroup(unittest.TestCase):
     # create_membership()
     def test_create_membership(self, m):
         register_uris(
-            {
-                'group': [
-                    'create_membership',
-                    'list_users',
-                    'list_users_p2'
-                ]
-            }, m)
+            {"group": ["create_membership", "list_users", "list_users_p2"]}, m
+        )
 
         response = self.group.create_membership(1)
         self.assertIsInstance(response, GroupMembership)
@@ -257,13 +240,8 @@ class TestGroup(unittest.TestCase):
     # update_membership()
     def test_update_membership(self, m):
         register_uris(
-            {
-                'group': [
-                    'list_users',
-                    'list_users_p2',
-                    'update_membership_user'
-                ]
-            }, m)
+            {"group": ["list_users", "list_users_p2", "update_membership_user"]}, m
+        )
 
         updated_membership_by_id = self.group.update_membership(1)
         self.assertIsInstance(updated_membership_by_id, GroupMembership)
@@ -274,84 +252,74 @@ class TestGroup(unittest.TestCase):
 
     # get_discussion_topic()
     def test_get_discussion_topic(self, m):
-        register_uris(
-            {
-                'group': [
-                    'get_discussion_topic',
-                    'get_discussion_topics'
-                    ]
-            }, m)
+        register_uris({"group": ["get_discussion_topic", "get_discussion_topics"]}, m)
 
         group_id = 1
         discussion_by_id = self.group.get_discussion_topic(group_id)
         self.assertIsInstance(discussion_by_id, DiscussionTopic)
-        self.assertTrue(hasattr(discussion_by_id, 'group_id'))
+        self.assertTrue(hasattr(discussion_by_id, "group_id"))
         self.assertEqual(group_id, discussion_by_id.id)
         self.assertEqual(discussion_by_id.group_id, 1)
 
         discussion_topic = self.group.get_discussion_topics()[0]
         discussion_by_obj = self.group.get_discussion_topic(discussion_topic)
         self.assertIsInstance(discussion_by_obj, DiscussionTopic)
-        self.assertTrue(hasattr(discussion_by_obj, 'group_id'))
+        self.assertTrue(hasattr(discussion_by_obj, "group_id"))
         self.assertEqual(group_id, discussion_by_obj.id)
         self.assertEqual(discussion_by_obj.group_id, 1)
 
     # get_file()
     def test_get_file(self, m):
-        register_uris({'group': ['get_file']}, m)
+        register_uris({"group": ["get_file"]}, m)
 
         file_by_id = self.group.get_file(1)
         self.assertIsInstance(file_by_id, File)
-        self.assertEqual(file_by_id.display_name, 'Group_File.docx')
+        self.assertEqual(file_by_id.display_name, "Group_File.docx")
         self.assertEqual(file_by_id.size, 4096)
 
         file_by_obj = self.group.get_file(file_by_id)
         self.assertIsInstance(file_by_obj, File)
-        self.assertEqual(file_by_obj.display_name, 'Group_File.docx')
+        self.assertEqual(file_by_obj.display_name, "Group_File.docx")
         self.assertEqual(file_by_obj.size, 4096)
 
     # get_full_discussion_topic
     def test_get_full_discussion_topic(self, m):
         register_uris(
-            {
-                'group': [
-                    'get_full_discussion_topic',
-                    'get_discussion_topics'
-                ]
-            }, m)
+            {"group": ["get_full_discussion_topic", "get_discussion_topics"]}, m
+        )
 
         discussion_by_id = self.group.get_full_discussion_topic(1)
         self.assertIsInstance(discussion_by_id, dict)
-        self.assertIn('view', discussion_by_id)
-        self.assertIn('participants', discussion_by_id)
-        self.assertIn('id', discussion_by_id)
-        self.assertEqual(discussion_by_id['id'], 1)
+        self.assertIn("view", discussion_by_id)
+        self.assertIn("participants", discussion_by_id)
+        self.assertIn("id", discussion_by_id)
+        self.assertEqual(discussion_by_id["id"], 1)
 
         discussion_topic = self.group.get_discussion_topics()[0]
         discussion_by_obj = self.group.get_full_discussion_topic(discussion_topic)
         self.assertIsInstance(discussion_by_obj, dict)
-        self.assertIn('view', discussion_by_obj)
-        self.assertIn('participants', discussion_by_obj)
-        self.assertIn('id', discussion_by_obj)
-        self.assertEqual(discussion_by_obj['id'], 1)
+        self.assertIn("view", discussion_by_obj)
+        self.assertIn("participants", discussion_by_obj)
+        self.assertIn("id", discussion_by_obj)
+        self.assertEqual(discussion_by_obj["id"], 1)
 
     # get_discussion_topics()
     def test_get_discussion_topics(self, m):
-        register_uris({'group': ['get_discussion_topics']}, m)
+        register_uris({"group": ["get_discussion_topics"]}, m)
 
         response = self.group.get_discussion_topics()
         discussion_list = [discussion for discussion in response]
         self.assertIsInstance(discussion_list[0], DiscussionTopic)
-        self.assertTrue(hasattr(discussion_list[0], 'group_id'))
+        self.assertTrue(hasattr(discussion_list[0], "group_id"))
         self.assertEqual(2, len(discussion_list))
 
     # create_discussion_topic()
     def test_create_discussion_topic(self, m):
-        register_uris({'group': ['create_discussion_topic']}, m)
+        register_uris({"group": ["create_discussion_topic"]}, m)
 
         title = "Topic 1"
         discussion = self.group.create_discussion_topic()
-        self.assertTrue(hasattr(discussion, 'group_id'))
+        self.assertTrue(hasattr(discussion, "group_id"))
         self.assertIsInstance(discussion, DiscussionTopic)
         self.assertEqual(discussion.title, title)
         self.assertEqual(discussion.group_id, 1)
@@ -360,8 +328,8 @@ class TestGroup(unittest.TestCase):
     def test_reorder_pinned_topics(self, m):
         # Custom matcher to test that params are set correctly
         def custom_matcher(request):
-            match_text = '1,2,3'
-            if request.text == 'order={}'.format(quote(match_text)):
+            match_text = "1,2,3"
+            if request.text == "order={}".format(quote(match_text)):
                 resp = requests.Response()
                 resp._content = b'{"reorder": true, "order": [1, 2, 3]}'
                 resp.status_code = 200
@@ -374,14 +342,14 @@ class TestGroup(unittest.TestCase):
         self.assertTrue(discussions)
 
     def test_reorder_pinned_topics_tuple(self, m):
-        register_uris({'group': ['reorder_pinned_topics']}, m)
+        register_uris({"group": ["reorder_pinned_topics"]}, m)
 
         order = (1, 2, 3)
         discussions = self.group.reorder_pinned_topics(order=order)
         self.assertTrue(discussions)
 
     def test_reorder_pinned_topics_comma_separated_string(self, m):
-        register_uris({'group': ['reorder_pinned_topics']}, m)
+        register_uris({"group": ["reorder_pinned_topics"]}, m)
 
         order = "1,2,3"
         discussions = self.group.reorder_pinned_topics(order=order)
@@ -394,13 +362,13 @@ class TestGroup(unittest.TestCase):
 
     # list_external_feeds()
     def test_list_external_feeds(self, m):
-        register_uris({'group': ['list_external_feeds']}, m)
+        register_uris({"group": ["list_external_feeds"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             feeds = self.group.list_external_feeds()
             feed_list = [feed for feed in feeds]
             self.assertEqual(len(feed_list), 2)
-            self.assertTrue(hasattr(feed_list[0], 'url'))
+            self.assertTrue(hasattr(feed_list[0], "url"))
             self.assertIsInstance(feed_list[0], ExternalFeed)
 
             self.assertEqual(len(warning_list), 1)
@@ -408,17 +376,17 @@ class TestGroup(unittest.TestCase):
 
     # get_external_feeds()
     def test_get_external_feeds(self, m):
-        register_uris({'group': ['list_external_feeds']}, m)
+        register_uris({"group": ["list_external_feeds"]}, m)
 
         feeds = self.group.get_external_feeds()
         feed_list = [feed for feed in feeds]
         self.assertEqual(len(feed_list), 2)
-        self.assertTrue(hasattr(feed_list[0], 'url'))
+        self.assertTrue(hasattr(feed_list[0], "url"))
         self.assertIsInstance(feed_list[0], ExternalFeed)
 
     # create_external_feed()
     def test_create_external_feed(self, m):
-        register_uris({'group': ['create_external_feed']}, m)
+        register_uris({"group": ["create_external_feed"]}, m)
 
         url_str = "https://example.com/myblog.rss"
         response = self.group.create_external_feed(url=url_str)
@@ -426,23 +394,23 @@ class TestGroup(unittest.TestCase):
 
     # delete_external_feed()
     def test_delete_external_feed(self, m):
-        register_uris({'group': ['delete_external_feed']}, m)
+        register_uris({"group": ["delete_external_feed"]}, m)
 
         deleted_ef_by_id = self.group.delete_external_feed(1)
 
         self.assertIsInstance(deleted_ef_by_id, ExternalFeed)
-        self.assertTrue(hasattr(deleted_ef_by_id, 'url'))
+        self.assertTrue(hasattr(deleted_ef_by_id, "url"))
         self.assertEqual(deleted_ef_by_id.display_name, "My Blog")
 
         deleted_ef_by_obj = self.group.delete_external_feed(deleted_ef_by_id)
 
         self.assertIsInstance(deleted_ef_by_obj, ExternalFeed)
-        self.assertTrue(hasattr(deleted_ef_by_obj, 'url'))
+        self.assertTrue(hasattr(deleted_ef_by_obj, "url"))
         self.assertEqual(deleted_ef_by_obj.display_name, "My Blog")
 
     # list_files()
     def test_list_files(self, m):
-        register_uris({'group': ['list_group_files', 'list_group_files2']}, m)
+        register_uris({"group": ["list_group_files", "list_group_files2"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             files = self.group.list_files()
@@ -455,7 +423,7 @@ class TestGroup(unittest.TestCase):
 
     # get_files()
     def test_get_files(self, m):
-        register_uris({'group': ['list_group_files', 'list_group_files2']}, m)
+        register_uris({"group": ["list_group_files", "list_group_files2"]}, m)
 
         files = self.group.get_files()
         file_list = [file for file in files]
@@ -464,7 +432,7 @@ class TestGroup(unittest.TestCase):
 
     # get_folder()
     def test_get_folder(self, m):
-        register_uris({'group': ['get_folder']}, m)
+        register_uris({"group": ["get_folder"]}, m)
 
         folder_by_id = self.group.get_folder(1)
         self.assertEqual(folder_by_id.name, "Folder 1")
@@ -476,7 +444,7 @@ class TestGroup(unittest.TestCase):
 
     # list_folders()
     def test_list_folders(self, m):
-        register_uris({'group': ['list_folders']}, m)
+        register_uris({"group": ["list_folders"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             folders = self.group.list_folders()
@@ -489,7 +457,7 @@ class TestGroup(unittest.TestCase):
 
     # get_folders()
     def test_get_folders(self, m):
-        register_uris({'group': ['list_folders']}, m)
+        register_uris({"group": ["list_folders"]}, m)
 
         folders = self.group.get_folders()
         folder_list = [folder for folder in folders]
@@ -498,7 +466,7 @@ class TestGroup(unittest.TestCase):
 
     # create_folder()
     def test_create_folder(self, m):
-        register_uris({'group': ['create_folder']}, m)
+        register_uris({"group": ["create_folder"]}, m)
 
         name_str = "Test String"
         response = self.group.create_folder(name=name_str)
@@ -506,7 +474,7 @@ class TestGroup(unittest.TestCase):
 
     # list_tabs()
     def test_list_tabs(self, m):
-        register_uris({'group': ['list_tabs']}, m)
+        register_uris({"group": ["list_tabs"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             tabs = self.group.list_tabs()
@@ -519,7 +487,7 @@ class TestGroup(unittest.TestCase):
 
     # get_tabs()
     def test_get_tabs(self, m):
-        register_uris({'group': ['list_tabs']}, m)
+        register_uris({"group": ["list_tabs"]}, m)
 
         tabs = self.group.get_tabs()
         tab_list = [tab for tab in tabs]
@@ -528,41 +496,42 @@ class TestGroup(unittest.TestCase):
 
     # create_content_migration
     def test_create_content_migration(self, m):
-        register_uris({'group': ['create_content_migration']}, m)
+        register_uris({"group": ["create_content_migration"]}, m)
 
-        content_migration = self.group.create_content_migration('dummy_importer')
+        content_migration = self.group.create_content_migration("dummy_importer")
 
         self.assertIsInstance(content_migration, ContentMigration)
-        self.assertTrue(hasattr(content_migration, 'migration_type'))
+        self.assertTrue(hasattr(content_migration, "migration_type"))
 
     def test_create_content_migration_migrator(self, m):
-        register_uris({'group': ['create_content_migration',
-                                 'get_migration_systems_multiple']}, m)
+        register_uris(
+            {"group": ["create_content_migration", "get_migration_systems_multiple"]}, m
+        )
 
         migrators = self.group.get_migration_systems()
         content_migration = self.group.create_content_migration(migrators[0])
 
         self.assertIsInstance(content_migration, ContentMigration)
-        self.assertTrue(hasattr(content_migration, 'migration_type'))
+        self.assertTrue(hasattr(content_migration, "migration_type"))
 
     def test_create_content_migration_bad_migration_type(self, m):
-        register_uris({'group': ['create_content_migration']}, m)
+        register_uris({"group": ["create_content_migration"]}, m)
 
         with self.assertRaises(TypeError):
             self.group.create_content_migration(1)
 
     # get_content_migration
     def test_get_content_migration(self, m):
-        register_uris({'group': ['get_content_migration_single']}, m)
+        register_uris({"group": ["get_content_migration_single"]}, m)
 
         content_migration = self.group.get_content_migration(1)
 
         self.assertIsInstance(content_migration, ContentMigration)
-        self.assertTrue(hasattr(content_migration, 'migration_type'))
+        self.assertTrue(hasattr(content_migration, "migration_type"))
 
     # get_content_migrations
     def test_get_content_migrations(self, m):
-        register_uris({'group': ['get_content_migration_multiple']}, m)
+        register_uris({"group": ["get_content_migration_multiple"]}, m)
 
         content_migrations = self.group.get_content_migrations()
 
@@ -577,7 +546,7 @@ class TestGroup(unittest.TestCase):
 
     # get_migration_systems
     def test_get_migration_systems(self, m):
-        register_uris({'group': ['get_migration_systems_multiple']}, m)
+        register_uris({"group": ["get_migration_systems_multiple"]}, m)
 
         migration_systems = self.group.get_migration_systems()
 
@@ -594,7 +563,7 @@ class TestGroup(unittest.TestCase):
 
     # get_assignment_override
     def test_get_assignment_override(self, m):
-        register_uris({'assignment': ['override_group_alias']}, m)
+        register_uris({"assignment": ["override_group_alias"]}, m)
 
         override = self.group.get_assignment_override(1)
 
@@ -604,12 +573,11 @@ class TestGroup(unittest.TestCase):
 
 @requests_mock.Mocker()
 class TestGroupMembership(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({'group': ['get_by_id', 'get_membership']}, m)
+            register_uris({"group": ["get_by_id", "get_membership"]}, m)
 
             self.group = self.canvas.get_group(1)
             self.membership = self.group.get_membership(1, "users")
@@ -621,18 +589,14 @@ class TestGroupMembership(unittest.TestCase):
 
     # update()
     def test_update(self, m):
-        register_uris({'group': ['update_membership_membership']}, m)
+        register_uris({"group": ["update_membership_membership"]}, m)
 
         response = self.membership.update(mem_id=1, moderator=False)
         self.assertIsInstance(response, GroupMembership)
 
     # remove_user()
     def test_remove_user(self, m):
-        register_uris(
-            {
-                'group': ['remove_user'],
-                'user': ['get_by_id']
-            }, m)
+        register_uris({"group": ["remove_user"], "user": ["get_by_id"]}, m)
 
         response_by_id = self.membership.remove_user(1)
         self.assertIsInstance(response_by_id, dict)
@@ -645,7 +609,7 @@ class TestGroupMembership(unittest.TestCase):
 
     # remove_self()
     def test_remove_self(self, m):
-        register_uris({'group': ['remove_self']}, m)
+        register_uris({"group": ["remove_self"]}, m)
 
         response = self.membership.remove_self()
 
@@ -655,11 +619,10 @@ class TestGroupMembership(unittest.TestCase):
 
 @requests_mock.Mocker()
 class TestGroupCategory(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
         with requests_mock.Mocker() as m:
-            register_uris({'course': ['get_by_id', 'create_group_category']}, m)
+            register_uris({"course": ["get_by_id", "create_group_category"]}, m)
 
             self.course = self.canvas.get_course(1)
             self.group_category = self.course.create_group_category("Test String")
@@ -671,17 +634,17 @@ class TestGroupCategory(unittest.TestCase):
 
     # create_group()
     def test_create_group(self, m):
-        register_uris({'group': ['category_create_group']}, m)
+        register_uris({"group": ["category_create_group"]}, m)
 
         test_str = "Test Create Group"
         response = self.group_category.create_group(name=test_str)
         self.assertIsInstance(response, Group)
-        self.assertTrue(hasattr(response, 'name'))
+        self.assertTrue(hasattr(response, "name"))
         self.assertEqual(response.name, test_str)
 
     # update()
     def test_update(self, m):
-        register_uris({'group': ['category_update']}, m)
+        register_uris({"group": ["category_update"]}, m)
 
         new_name = "Test Update Category"
         response = self.group_category.update(name=new_name)
@@ -689,7 +652,7 @@ class TestGroupCategory(unittest.TestCase):
 
     # delete_category()
     def test_delete_category(self, m):
-        register_uris({'group': ['category_delete_category']}, m)
+        register_uris({"group": ["category_delete_category"]}, m)
 
         response = self.group_category.delete()
 
@@ -698,40 +661,40 @@ class TestGroupCategory(unittest.TestCase):
 
     # list_groups()
     def test_list_groups(self, m):
-        register_uris({'group': ['category_list_groups']}, m)
+        register_uris({"group": ["category_list_groups"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             response = self.group_category.list_groups()
             group_list = [group for group in response]
             self.assertEqual(len(group_list), 2)
             self.assertIsInstance(group_list[0], Group)
-            self.assertTrue(hasattr(group_list[0], 'id'))
+            self.assertTrue(hasattr(group_list[0], "id"))
 
             self.assertEqual(len(warning_list), 1)
             self.assertEqual(warning_list[-1].category, DeprecationWarning)
 
     # get_groups()
     def test_get_groups(self, m):
-        register_uris({'group': ['category_list_groups']}, m)
+        register_uris({"group": ["category_list_groups"]}, m)
 
         response = self.group_category.get_groups()
         group_list = [group for group in response]
         self.assertEqual(len(group_list), 2)
         self.assertIsInstance(group_list[0], Group)
-        self.assertTrue(hasattr(group_list[0], 'id'))
+        self.assertTrue(hasattr(group_list[0], "id"))
 
     # list_users()
     def test_list_users(self, m):
         from canvasapi.user import User
 
-        register_uris({'group': ['category_list_users']}, m)
+        register_uris({"group": ["category_list_users"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             response = self.group_category.list_users()
             user_list = [user for user in response]
             self.assertEqual(len(user_list), 4)
             self.assertIsInstance(user_list[0], User)
-            self.assertTrue(hasattr(user_list[0], 'user_id'))
+            self.assertTrue(hasattr(user_list[0], "user_id"))
 
             self.assertEqual(len(warning_list), 1)
             self.assertEqual(warning_list[-1].category, DeprecationWarning)
@@ -740,13 +703,13 @@ class TestGroupCategory(unittest.TestCase):
     def test_get_users(self, m):
         from canvasapi.user import User
 
-        register_uris({'group': ['category_list_users']}, m)
+        register_uris({"group": ["category_list_users"]}, m)
 
         response = self.group_category.get_users()
         user_list = [user for user in response]
         self.assertEqual(len(user_list), 4)
         self.assertIsInstance(user_list[0], User)
-        self.assertTrue(hasattr(user_list[0], 'user_id'))
+        self.assertTrue(hasattr(user_list[0], "user_id"))
 
     # assign_members()
     def test_assign_members(self, m):
@@ -754,10 +717,7 @@ class TestGroupCategory(unittest.TestCase):
         from canvasapi.paginated_list import PaginatedList
 
         requires = {
-            'group': [
-                'category_assign_members_true',
-                'category_assign_members_false'
-            ]
+            "group": ["category_assign_members_true", "category_assign_members_false"]
         }
         register_uris(requires, m)
 

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -11,44 +11,38 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestLogin(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({
-                'account': ['get_by_id'],
-                'login': ['create_user_login']
-            }, m)
+            register_uris({"account": ["get_by_id"], "login": ["create_user_login"]}, m)
 
             self.account = self.canvas.get_account(1)
             self.login = self.account.create_user_login(
-                user={'id': 1},
-                login={'unique_id': 'belieber@example.com'}
+                user={"id": 1}, login={"unique_id": "belieber@example.com"}
             )
 
     # delete()
     def test_delete_user_login(self, m):
-        register_uris({'login': ['delete_user_login']}, m)
+        register_uris({"login": ["delete_user_login"]}, m)
 
         deleted_user_login = self.login.delete()
 
         self.assertIsInstance(deleted_user_login, Login)
-        self.assertTrue(hasattr(deleted_user_login, 'unique_id'))
-        self.assertEqual(deleted_user_login.unique_id, 'belieber@example.com')
+        self.assertTrue(hasattr(deleted_user_login, "unique_id"))
+        self.assertEqual(deleted_user_login.unique_id, "belieber@example.com")
 
     # edit()
     def test_edit_user_login(self, m):
-        register_uris({'login': ['edit_user_login']}, m)
+        register_uris({"login": ["edit_user_login"]}, m)
 
-        unique_id = 'newemail@example.com'
+        unique_id = "newemail@example.com"
         edited_user_login = self.login.edit(
-            user={'id': 1},
-            login={'unique_id': unique_id},
+            user={"id": 1}, login={"unique_id": unique_id}
         )
 
         self.assertIsInstance(edited_user_login, Login)
-        self.assertTrue(hasattr(edited_user_login, 'unique_id'))
+        self.assertTrue(hasattr(edited_user_login, "unique_id"))
         self.assertEqual(edited_user_login.unique_id, unique_id)
 
     # __str__()

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -13,52 +13,51 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestModule(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({'course': ['get_by_id', 'get_module_by_id']}, m)
+            register_uris({"course": ["get_by_id", "get_module_by_id"]}, m)
 
             self.course = self.canvas.get_course(1)
             self.module = self.course.get_module(1)
 
     # edit()
     def test_edit_module(self, m):
-        register_uris({'module': ['edit']}, m)
+        register_uris({"module": ["edit"]}, m)
 
-        name = 'New Name'
-        edited_module = self.module.edit(module={'name': name})
+        name = "New Name"
+        edited_module = self.module.edit(module={"name": name})
 
         self.assertIsInstance(edited_module, Module)
-        self.assertTrue(hasattr(edited_module, 'name'))
+        self.assertTrue(hasattr(edited_module, "name"))
         self.assertEqual(edited_module.name, name)
-        self.assertTrue(hasattr(edited_module, 'course_id'))
+        self.assertTrue(hasattr(edited_module, "course_id"))
         self.assertEqual(edited_module.course_id, self.course.id)
 
     # delete()
     def test_delete_module(self, m):
-        register_uris({'module': ['delete']}, m)
+        register_uris({"module": ["delete"]}, m)
 
         deleted_module = self.module.delete()
 
         self.assertIsInstance(deleted_module, Module)
-        self.assertTrue(hasattr(deleted_module, 'course_id'))
+        self.assertTrue(hasattr(deleted_module, "course_id"))
         self.assertEqual(deleted_module.course_id, self.course.id)
 
     # relock()
     def test_relock(self, m):
-        register_uris({'module': ['relock']}, m)
+        register_uris({"module": ["relock"]}, m)
 
         relocked_module = self.module.relock()
 
         self.assertIsInstance(relocked_module, Module)
-        self.assertTrue(hasattr(relocked_module, 'course_id'))
+        self.assertTrue(hasattr(relocked_module, "course_id"))
         self.assertEqual(relocked_module.course_id, self.course.id)
 
     # list_module_items()
     def test_list_module_items(self, m):
-        register_uris({'module': ['list_module_items', 'list_module_items2']}, m)
+        register_uris({"module": ["list_module_items", "list_module_items2"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             module_items = self.module.list_module_items()
@@ -66,7 +65,7 @@ class TestModule(unittest.TestCase):
 
             self.assertEqual(len(module_item_list), 4)
             self.assertIsInstance(module_item_list[0], ModuleItem)
-            self.assertTrue(hasattr(module_item_list[0], 'course_id'))
+            self.assertTrue(hasattr(module_item_list[0], "course_id"))
             self.assertEqual(module_item_list[0].course_id, self.course.id)
 
             self.assertEqual(len(warning_list), 1)
@@ -74,57 +73,50 @@ class TestModule(unittest.TestCase):
 
     # get_module_items()
     def test_get_module_items(self, m):
-        register_uris({'module': ['list_module_items', 'list_module_items2']}, m)
+        register_uris({"module": ["list_module_items", "list_module_items2"]}, m)
 
         module_items = self.module.get_module_items()
         module_item_list = [module_item for module_item in module_items]
 
         self.assertEqual(len(module_item_list), 4)
         self.assertIsInstance(module_item_list[0], ModuleItem)
-        self.assertTrue(hasattr(module_item_list[0], 'course_id'))
+        self.assertTrue(hasattr(module_item_list[0], "course_id"))
         self.assertEqual(module_item_list[0].course_id, self.course.id)
 
     # get_module_item()
     def test_get_module_item(self, m):
-        register_uris({'module': ['get_module_item_by_id']}, m)
+        register_uris({"module": ["get_module_item_by_id"]}, m)
 
         module_item_by_id = self.module.get_module_item(1)
 
         self.assertIsInstance(module_item_by_id, ModuleItem)
-        self.assertTrue(hasattr(module_item_by_id, 'course_id'))
+        self.assertTrue(hasattr(module_item_by_id, "course_id"))
         self.assertEqual(module_item_by_id.course_id, self.course.id)
 
         module_item_by_obj = self.module.get_module_item(module_item_by_id)
 
         self.assertIsInstance(module_item_by_obj, ModuleItem)
-        self.assertTrue(hasattr(module_item_by_obj, 'course_id'))
+        self.assertTrue(hasattr(module_item_by_obj, "course_id"))
         self.assertEqual(module_item_by_obj.course_id, self.course.id)
 
     # create_module_item()
     def test_create_module_item(self, m):
-        register_uris({'module': ['create_module_item']}, m)
+        register_uris({"module": ["create_module_item"]}, m)
 
         module_item = self.module.create_module_item(
-            module_item={
-                'type': 'Page',
-                'content_id': 1
-            }
+            module_item={"type": "Page", "content_id": 1}
         )
         self.assertIsInstance(module_item, ModuleItem)
-        self.assertTrue(hasattr(module_item, 'course_id'))
+        self.assertTrue(hasattr(module_item, "course_id"))
         self.assertEqual(module_item.course_id, self.course.id)
 
     def test_create_module_item_fail1(self, m):
         with self.assertRaises(RequiredFieldMissing):
-            self.module.create_module_item(
-                module_item={'content_id': 1}
-            )
+            self.module.create_module_item(module_item={"content_id": 1})
 
     def test_create_module_item_fail2(self, m):
         with self.assertRaises(RequiredFieldMissing):
-            self.module.create_module_item(
-                module_item={'type': 'Page'}
-            )
+            self.module.create_module_item(module_item={"type": "Page"})
 
     # __str__
     def test__str__(self, m):
@@ -134,14 +126,13 @@ class TestModule(unittest.TestCase):
 
 @requests_mock.Mocker()
 class TestModuleItem(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
             requires = {
-                'course': ['get_by_id', 'get_module_by_id'],
-                'module': ['get_module_item_by_id']
+                "course": ["get_by_id", "get_module_by_id"],
+                "module": ["get_module_item_by_id"],
             }
             register_uris(requires, m)
 
@@ -151,49 +142,47 @@ class TestModuleItem(unittest.TestCase):
 
     # edit()
     def test_edit_module_item(self, m):
-        register_uris({'module': ['edit_module_item']}, m)
+        register_uris({"module": ["edit_module_item"]}, m)
 
-        title = 'New Title'
-        edited_module_item = self.module_item.edit(
-            module_item={'title': title}
-        )
+        title = "New Title"
+        edited_module_item = self.module_item.edit(module_item={"title": title})
 
         self.assertIsInstance(edited_module_item, ModuleItem)
-        self.assertTrue(hasattr(edited_module_item, 'title'))
+        self.assertTrue(hasattr(edited_module_item, "title"))
         self.assertEqual(edited_module_item.title, title)
-        self.assertTrue(hasattr(edited_module_item, 'course_id'))
+        self.assertTrue(hasattr(edited_module_item, "course_id"))
         self.assertEqual(edited_module_item.course_id, self.course.id)
 
     # delete()
     def test_delete(self, m):
-        register_uris({'module': ['delete_module_item']}, m)
+        register_uris({"module": ["delete_module_item"]}, m)
 
         deleted_module_item = self.module_item.delete()
 
         self.assertIsInstance(deleted_module_item, ModuleItem)
-        self.assertTrue(hasattr(deleted_module_item, 'course_id'))
+        self.assertTrue(hasattr(deleted_module_item, "course_id"))
         self.assertEqual(deleted_module_item.course_id, self.course.id)
 
     # complete(course_id, True)
     def test_complete(self, m):
-        register_uris({'module': ['complete_module_item']}, m)
+        register_uris({"module": ["complete_module_item"]}, m)
 
         completed_module_item = self.module_item.complete()
 
         self.assertIsInstance(completed_module_item, ModuleItem)
-        self.assertTrue(hasattr(completed_module_item, 'completion_requirement'))
-        self.assertTrue(hasattr(completed_module_item, 'course_id'))
+        self.assertTrue(hasattr(completed_module_item, "completion_requirement"))
+        self.assertTrue(hasattr(completed_module_item, "course_id"))
         self.assertEqual(completed_module_item.course_id, self.course.id)
 
     # complete(course_id, False)
     def test_uncomplete(self, m):
-        register_uris({'module': ['uncomplete_module_item']}, m)
+        register_uris({"module": ["uncomplete_module_item"]}, m)
 
         completed_module_item = self.module_item.uncomplete()
 
         self.assertIsInstance(completed_module_item, ModuleItem)
-        self.assertTrue(hasattr(completed_module_item, 'completion_requirement'))
-        self.assertTrue(hasattr(completed_module_item, 'course_id'))
+        self.assertTrue(hasattr(completed_module_item, "completion_requirement"))
+        self.assertTrue(hasattr(completed_module_item, "course_id"))
         self.assertEqual(completed_module_item.course_id, self.course.id)
 
     def test__str__(self, m):

--- a/tests/test_notification_preference.py
+++ b/tests/test_notification_preference.py
@@ -10,20 +10,21 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestNotificationPreference(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
             register_uris(
                 {
-                    'user': ['get_by_id', 'list_comm_channels'],
-                    'communication_channel': ['get_preference']
-                }, m)
+                    "user": ["get_by_id", "list_comm_channels"],
+                    "communication_channel": ["get_preference"],
+                },
+                m,
+            )
 
             self.user = self.canvas.get_user(1)
             self.comm_chan = self.user.get_communication_channels()[0]
-            self.notif_pref = self.comm_chan.get_preference('new_announcement')
+            self.notif_pref = self.comm_chan.get_preference("new_announcement")
 
     # __str__()
     def test__str__(self, m):

--- a/tests/test_outcome.py
+++ b/tests/test_outcome.py
@@ -18,15 +18,16 @@ class TestOutcome(unittest.TestCase):
         with requests_mock.Mocker() as m:
             register_uris(
                 {
-                    'course': ['get_by_id'],
-                    'outcome': [
-                        'account_root_outcome_group',
-                        'canvas_root_outcome_group',
-                        'course_root_outcome_group',
-                        'course_outcome_links_in_context',
-                        'outcome_example'
-                    ]
-                }, m
+                    "course": ["get_by_id"],
+                    "outcome": [
+                        "account_root_outcome_group",
+                        "canvas_root_outcome_group",
+                        "course_root_outcome_group",
+                        "course_outcome_links_in_context",
+                        "outcome_example",
+                    ],
+                },
+                m,
             )
 
             self.course = self.canvas.get_course(1)
@@ -40,8 +41,8 @@ class TestOutcome(unittest.TestCase):
 
     # update()
     def test_update(self, m):
-        register_uris({'outcome': ['outcome_update']}, m)
-        self.assertEqual(self.example_outcome.title, 'Outcome Show Example')
+        register_uris({"outcome": ["outcome_update"]}, m)
+        self.assertEqual(self.example_outcome.title, "Outcome Show Example")
         result = self.example_outcome.update(title="new_title")
         self.assertTrue(result)
         self.assertIsInstance(self.example_outcome, Outcome)
@@ -56,13 +57,14 @@ class TestOutcomeLink(unittest.TestCase):
         with requests_mock.Mocker() as m:
             register_uris(
                 {
-                    'account': ['get_by_id'],
-                    'course': ['get_by_id'],
-                    'outcome': [
-                        'account_outcome_links_in_context',
-                        'course_outcome_links_in_context'
-                    ]
-                }, m
+                    "account": ["get_by_id"],
+                    "course": ["get_by_id"],
+                    "outcome": [
+                        "account_outcome_links_in_context",
+                        "course_outcome_links_in_context",
+                    ],
+                },
+                m,
             )
 
             self.account = self.canvas.get_account(1)
@@ -72,13 +74,15 @@ class TestOutcomeLink(unittest.TestCase):
 
     # __str__()
     def test__str__(self, m):
-        register_uris({'outcome': ['course_outcome_links_in_context']}, m)
+        register_uris({"outcome": ["course_outcome_links_in_context"]}, m)
         string = str(self.course_outcome_links[0])
         self.assertIsInstance(string, str)
 
     # get_outcome()
     def test_get_outcome(self, m):
-        register_uris({'outcome': ['outcome_example', 'course_outcome_links_in_context']}, m)
+        register_uris(
+            {"outcome": ["outcome_example", "course_outcome_links_in_context"]}, m
+        )
         result = self.course_outcome_links[0].get_outcome()
         self.assertIsInstance(result, Outcome)
 
@@ -86,14 +90,15 @@ class TestOutcomeLink(unittest.TestCase):
     def test_get_outcome_group(self, m):
         register_uris(
             {
-                'outcome': [
-                    'outcome_group_example_account',
-                    'account_outcome_links_in_context',
-                    'outcome_group_example_course',
-                    'course_outcome_links_in_context'
+                "outcome": [
+                    "outcome_group_example_account",
+                    "account_outcome_links_in_context",
+                    "outcome_group_example_course",
+                    "course_outcome_links_in_context",
                 ]
-                }, m
-            )
+            },
+            m,
+        )
         result = self.course_outcome_links[0].get_outcome_group()
         self.assertIsInstance(result, OutcomeGroup)
         result = self.account_outcome_links[0].get_outcome_group()
@@ -108,16 +113,17 @@ class TestOutcomeGroup(unittest.TestCase):
         with requests_mock.Mocker() as m:
             register_uris(
                 {
-                    'account': ['get_by_id'],
-                    'course': ['get_by_id'],
-                    'outcome': [
-                        'account_root_outcome_group',
-                        'canvas_root_outcome_group',
-                        'course_root_outcome_group',
-                        'course_outcome_links_in_context',
-                        'outcome_example'
-                    ]
-                }, m
+                    "account": ["get_by_id"],
+                    "course": ["get_by_id"],
+                    "outcome": [
+                        "account_root_outcome_group",
+                        "canvas_root_outcome_group",
+                        "course_root_outcome_group",
+                        "course_outcome_links_in_context",
+                        "outcome_example",
+                    ],
+                },
+                m,
             )
 
             self.canvas_outcome_group = self.canvas.get_root_outcome_group()
@@ -143,28 +149,30 @@ class TestOutcomeGroup(unittest.TestCase):
     def test_update(self, m):
         register_uris(
             {
-                'outcome': [
-                    'outcome_group_update_global',
-                    'outcome_group_update_account',
-                    'outcome_group_update_course'
+                "outcome": [
+                    "outcome_group_update_global",
+                    "outcome_group_update_account",
+                    "outcome_group_update_course",
                 ]
-            }, m)
+            },
+            m,
+        )
 
         new_title = "New Outcome Group Title"
 
-        self.assertEqual(self.account_outcome_group.title, 'ROOT')
+        self.assertEqual(self.account_outcome_group.title, "ROOT")
         result = self.account_outcome_group.update(title=new_title)
         self.assertTrue(result)
         self.assertIsInstance(self.account_outcome_group, OutcomeGroup)
         self.assertEqual(self.account_outcome_group.title, new_title)
 
-        self.assertEqual(self.canvas_outcome_group.title, 'ROOT')
+        self.assertEqual(self.canvas_outcome_group.title, "ROOT")
         result = self.canvas_outcome_group.update(title=new_title)
         self.assertTrue(result)
         self.assertIsInstance(self.canvas_outcome_group, OutcomeGroup)
         self.assertEqual(self.canvas_outcome_group.title, new_title)
 
-        self.assertEqual(self.course_outcome_group.title, 'ROOT')
+        self.assertEqual(self.course_outcome_group.title, "ROOT")
         result = self.course_outcome_group.update(title=new_title)
         self.assertTrue(result)
         self.assertIsInstance(self.course_outcome_group, OutcomeGroup)
@@ -174,22 +182,24 @@ class TestOutcomeGroup(unittest.TestCase):
     def test_delete(self, m):
         register_uris(
             {
-                'outcome': [
-                    'outcome_group_delete_global',
-                    'outcome_group_delete_account',
-                    'outcome_group_delete_course'
+                "outcome": [
+                    "outcome_group_delete_global",
+                    "outcome_group_delete_account",
+                    "outcome_group_delete_course",
                 ]
-            }, m)
+            },
+            m,
+        )
 
-        self.assertEqual(self.account_outcome_group.title, 'ROOT')
+        self.assertEqual(self.account_outcome_group.title, "ROOT")
         result = self.account_outcome_group.delete()
         self.assertTrue(result)
 
-        self.assertEqual(self.canvas_outcome_group.title, 'ROOT')
+        self.assertEqual(self.canvas_outcome_group.title, "ROOT")
         result = self.canvas_outcome_group.delete()
         self.assertTrue(result)
 
-        self.assertEqual(self.course_outcome_group.title, 'ROOT')
+        self.assertEqual(self.course_outcome_group.title, "ROOT")
         result = self.course_outcome_group.delete()
         self.assertTrue(result)
 
@@ -197,18 +207,22 @@ class TestOutcomeGroup(unittest.TestCase):
     def test_list_linked_outcomes(self, m):
         register_uris(
             {
-                'outcome': [
-                    'outcome_group_list_linked_outcomes_account',
-                    'outcome_group_list_linked_outcomes_global',
-                    'outcome_group_list_linked_outcomes_courses'
+                "outcome": [
+                    "outcome_group_list_linked_outcomes_account",
+                    "outcome_group_list_linked_outcomes_global",
+                    "outcome_group_list_linked_outcomes_courses",
                 ]
-            }, m)
+            },
+            m,
+        )
 
         with warnings.catch_warnings(record=True) as warning_list:
             result = self.account_outcome_group.list_linked_outcomes()
             self.assertIsInstance(result[0], OutcomeLink)
-            self.assertEqual(result[0].outcome_group['id'], 2)
-            self.assertEqual(result[0].outcome_group['title'], "Account Test Outcome Group")
+            self.assertEqual(result[0].outcome_group["id"], 2)
+            self.assertEqual(
+                result[0].outcome_group["title"], "Account Test Outcome Group"
+            )
 
             self.assertEqual(len(warning_list), 1)
             self.assertEqual(warning_list[-1].category, DeprecationWarning)
@@ -216,8 +230,10 @@ class TestOutcomeGroup(unittest.TestCase):
         with warnings.catch_warnings(record=True) as warning_list:
             result = self.canvas_outcome_group.list_linked_outcomes()
             self.assertIsInstance(result[0], OutcomeLink)
-            self.assertEqual(result[0].outcome_group['id'], 2)
-            self.assertEqual(result[0].outcome_group['title'], "Global Test Outcome Group")
+            self.assertEqual(result[0].outcome_group["id"], 2)
+            self.assertEqual(
+                result[0].outcome_group["title"], "Global Test Outcome Group"
+            )
 
             self.assertEqual(len(warning_list), 1)
             self.assertEqual(warning_list[-1].category, DeprecationWarning)
@@ -225,8 +241,10 @@ class TestOutcomeGroup(unittest.TestCase):
         with warnings.catch_warnings(record=True) as warning_list:
             result = self.course_outcome_group.list_linked_outcomes()
             self.assertIsInstance(result[0], OutcomeLink)
-            self.assertEqual(result[0].outcome_group['id'], 2)
-            self.assertEqual(result[0].outcome_group['title'], "Course Test Outcome Group")
+            self.assertEqual(result[0].outcome_group["id"], 2)
+            self.assertEqual(
+                result[0].outcome_group["title"], "Course Test Outcome Group"
+            )
 
             self.assertEqual(len(warning_list), 1)
             self.assertEqual(warning_list[-1].category, DeprecationWarning)
@@ -235,106 +253,114 @@ class TestOutcomeGroup(unittest.TestCase):
     def test_get_linked_outcomes(self, m):
         register_uris(
             {
-                'outcome': [
-                    'outcome_group_list_linked_outcomes_account',
-                    'outcome_group_list_linked_outcomes_global',
-                    'outcome_group_list_linked_outcomes_courses'
+                "outcome": [
+                    "outcome_group_list_linked_outcomes_account",
+                    "outcome_group_list_linked_outcomes_global",
+                    "outcome_group_list_linked_outcomes_courses",
                 ]
-            }, m)
+            },
+            m,
+        )
 
         result = self.account_outcome_group.get_linked_outcomes()
         self.assertIsInstance(result[0], OutcomeLink)
-        self.assertEqual(result[0].outcome_group['id'], 2)
-        self.assertEqual(result[0].outcome_group['title'], "Account Test Outcome Group")
+        self.assertEqual(result[0].outcome_group["id"], 2)
+        self.assertEqual(result[0].outcome_group["title"], "Account Test Outcome Group")
 
         result = self.canvas_outcome_group.get_linked_outcomes()
         self.assertIsInstance(result[0], OutcomeLink)
-        self.assertEqual(result[0].outcome_group['id'], 2)
-        self.assertEqual(result[0].outcome_group['title'], "Global Test Outcome Group")
+        self.assertEqual(result[0].outcome_group["id"], 2)
+        self.assertEqual(result[0].outcome_group["title"], "Global Test Outcome Group")
 
         result = self.course_outcome_group.get_linked_outcomes()
         self.assertIsInstance(result[0], OutcomeLink)
-        self.assertEqual(result[0].outcome_group['id'], 2)
-        self.assertEqual(result[0].outcome_group['title'], "Course Test Outcome Group")
+        self.assertEqual(result[0].outcome_group["id"], 2)
+        self.assertEqual(result[0].outcome_group["title"], "Course Test Outcome Group")
 
     # link_existing()
     def test_link_existing(self, m):
         register_uris(
             {
-                'outcome': [
-                    'outcome_example',
-                    'outcome_group_link_existing_global',
-                    'outcome_group_link_existing_account',
-                    'outcome_group_link_existing_course'
+                "outcome": [
+                    "outcome_example",
+                    "outcome_group_link_existing_global",
+                    "outcome_group_link_existing_account",
+                    "outcome_group_link_existing_course",
                 ]
-            }, m)
+            },
+            m,
+        )
 
         result = self.canvas_outcome_group.link_existing(self.example_outcome)
         self.assertIsInstance(result, OutcomeLink)
-        self.assertEqual(result.outcome_group['id'], 2)
+        self.assertEqual(result.outcome_group["id"], 2)
 
         result = self.account_outcome_group.link_existing(self.example_outcome)
         self.assertIsInstance(result, OutcomeLink)
-        self.assertEqual(result.outcome_group['id'], 2)
+        self.assertEqual(result.outcome_group["id"], 2)
 
         result = self.course_outcome_group.link_existing(self.example_outcome)
         self.assertIsInstance(result, OutcomeLink)
-        self.assertEqual(result.outcome_group['id'], 2)
+        self.assertEqual(result.outcome_group["id"], 2)
 
         result = self.canvas_outcome_group.link_existing(3)
         self.assertIsInstance(result, OutcomeLink)
-        self.assertEqual(result.outcome_group['id'], 2)
+        self.assertEqual(result.outcome_group["id"], 2)
 
         result = self.account_outcome_group.link_existing(3)
         self.assertIsInstance(result, OutcomeLink)
-        self.assertEqual(result.outcome_group['id'], 2)
+        self.assertEqual(result.outcome_group["id"], 2)
 
         result = self.course_outcome_group.link_existing(3)
         self.assertIsInstance(result, OutcomeLink)
-        self.assertEqual(result.outcome_group['id'], 2)
+        self.assertEqual(result.outcome_group["id"], 2)
 
     # link_new()
     def test_link_new(self, m):
         register_uris(
             {
-                'outcome': [
-                    'outcome_group_link_new_global',
-                    'outcome_group_link_new_account',
-                    'outcome_group_link_new_course'
+                "outcome": [
+                    "outcome_group_link_new_global",
+                    "outcome_group_link_new_account",
+                    "outcome_group_link_new_course",
                 ]
-            }, m)
+            },
+            m,
+        )
 
         new_title = "New Outcome"
 
         result = self.canvas_outcome_group.link_new(title=new_title)
         self.assertIsInstance(result, OutcomeLink)
-        self.assertEqual(result.outcome_group['id'], 1)
-        self.assertEqual(result.outcome['id'], 2)
-        self.assertEqual(result.outcome['context_type'], None)
+        self.assertEqual(result.outcome_group["id"], 1)
+        self.assertEqual(result.outcome["id"], 2)
+        self.assertEqual(result.outcome["context_type"], None)
 
         result = self.account_outcome_group.link_new(title=new_title)
         self.assertIsInstance(result, OutcomeLink)
-        self.assertEqual(result.outcome_group['id'], 1)
-        self.assertEqual(result.outcome['id'], 2)
-        self.assertEqual(result.outcome['context_type'], 'Account')
+        self.assertEqual(result.outcome_group["id"], 1)
+        self.assertEqual(result.outcome["id"], 2)
+        self.assertEqual(result.outcome["context_type"], "Account")
 
         result = self.course_outcome_group.link_new(title=new_title)
         self.assertIsInstance(result, OutcomeLink)
-        self.assertEqual(result.outcome_group['id'], 1)
-        self.assertEqual(result.outcome['id'], 2)
-        self.assertEqual(result.outcome['context_type'], 'Course')
+        self.assertEqual(result.outcome_group["id"], 1)
+        self.assertEqual(result.outcome["id"], 2)
+        self.assertEqual(result.outcome["context_type"], "Course")
 
     # unlink_outcome()
     def test_unlink_outcome(self, m):
         register_uris(
             {
-                'outcome': [
-                    'outcome_example',
-                    'outcome_group_unlink_outcome_global',
-                    'outcome_group_unlink_outcome_account',
-                    'outcome_group_unlink_outcome_course'
+                "outcome": [
+                    "outcome_example",
+                    "outcome_group_unlink_outcome_global",
+                    "outcome_group_unlink_outcome_account",
+                    "outcome_group_unlink_outcome_course",
                 ]
-            }, m)
+            },
+            m,
+        )
 
         result = self.canvas_outcome_group.unlink_outcome(self.example_outcome)
         self.assertTrue(result)
@@ -358,12 +384,14 @@ class TestOutcomeGroup(unittest.TestCase):
     def test_list_subgroups(self, m):
         register_uris(
             {
-                'outcome': [
-                    'outcome_group_list_subgroups_global',
-                    'outcome_group_list_subgroups_account',
-                    'outcome_group_list_subgroups_course'
+                "outcome": [
+                    "outcome_group_list_subgroups_global",
+                    "outcome_group_list_subgroups_account",
+                    "outcome_group_list_subgroups_course",
                 ]
-            }, m)
+            },
+            m,
+        )
 
         with warnings.catch_warnings(record=True) as warning_list:
             result = self.canvas_outcome_group.list_subgroups()
@@ -405,122 +433,148 @@ class TestOutcomeGroup(unittest.TestCase):
     def test_get_subgroups(self, m):
         register_uris(
             {
-                'outcome': [
-                    'outcome_group_list_subgroups_global',
-                    'outcome_group_list_subgroups_account',
-                    'outcome_group_list_subgroups_course'
+                "outcome": [
+                    "outcome_group_list_subgroups_global",
+                    "outcome_group_list_subgroups_account",
+                    "outcome_group_list_subgroups_course",
                 ]
-            }, m)
+            },
+            m,
+        )
 
         result = self.canvas_outcome_group.get_subgroups()
         self.assertIsInstance(result[0], OutcomeGroup)
         self.assertEqual(result[0].id, 2)
         self.assertEqual(result[0].title, "Global Listed Subgroup Title 1")
-        self.assertTrue(hasattr(result[0], 'context_type'))
+        self.assertTrue(hasattr(result[0], "context_type"))
         self.assertEqual(result[0].context_type, None)
-        self.assertTrue(hasattr(result[0], 'context_id'))
+        self.assertTrue(hasattr(result[0], "context_id"))
         self.assertEqual(result[0].context_id, None)
         self.assertIsInstance(result[1], OutcomeGroup)
         self.assertEqual(result[1].id, 3)
         self.assertEqual(result[1].title, "Global Listed Subgroup Title 2")
-        self.assertTrue(hasattr(result[0], 'context_type'))
+        self.assertTrue(hasattr(result[0], "context_type"))
         self.assertEqual(result[0].context_type, None)
-        self.assertTrue(hasattr(result[0], 'context_id'))
+        self.assertTrue(hasattr(result[0], "context_id"))
         self.assertEqual(result[0].context_id, None)
 
         result = self.account_outcome_group.get_subgroups()
         self.assertIsInstance(result[0], OutcomeGroup)
         self.assertEqual(result[0].id, 2)
         self.assertEqual(result[0].title, "Account Listed Subgroup Title 1")
-        self.assertTrue(hasattr(result[0], 'context_type'))
-        self.assertEqual(result[0].context_type, 'Account')
-        self.assertTrue(hasattr(result[0], 'context_id'))
+        self.assertTrue(hasattr(result[0], "context_type"))
+        self.assertEqual(result[0].context_type, "Account")
+        self.assertTrue(hasattr(result[0], "context_id"))
         self.assertEqual(result[0].context_id, self.account.id)
         self.assertIsInstance(result[1], OutcomeGroup)
         self.assertEqual(result[1].id, 3)
         self.assertEqual(result[1].title, "Account Listed Subgroup Title 2")
-        self.assertTrue(hasattr(result[0], 'context_type'))
-        self.assertEqual(result[0].context_type, 'Account')
-        self.assertTrue(hasattr(result[0], 'context_id'))
+        self.assertTrue(hasattr(result[0], "context_type"))
+        self.assertEqual(result[0].context_type, "Account")
+        self.assertTrue(hasattr(result[0], "context_id"))
         self.assertEqual(result[0].context_id, self.account.id)
 
         result = self.course_outcome_group.get_subgroups()
         self.assertIsInstance(result[0], OutcomeGroup)
         self.assertEqual(result[0].id, 2)
         self.assertEqual(result[0].title, "Course Listed Subgroup Title 1")
-        self.assertTrue(hasattr(result[0], 'context_type'))
-        self.assertEqual(result[0].context_type, 'Course')
-        self.assertTrue(hasattr(result[0], 'context_id'))
+        self.assertTrue(hasattr(result[0], "context_type"))
+        self.assertEqual(result[0].context_type, "Course")
+        self.assertTrue(hasattr(result[0], "context_id"))
         self.assertEqual(result[0].context_id, self.course.id)
         self.assertIsInstance(result[1], OutcomeGroup)
         self.assertEqual(result[1].id, 3)
         self.assertEqual(result[1].title, "Course Listed Subgroup Title 2")
-        self.assertTrue(hasattr(result[0], 'context_type'))
-        self.assertEqual(result[0].context_type, 'Course')
-        self.assertTrue(hasattr(result[0], 'context_id'))
+        self.assertTrue(hasattr(result[0], "context_type"))
+        self.assertEqual(result[0].context_type, "Course")
+        self.assertTrue(hasattr(result[0], "context_id"))
         self.assertEqual(result[0].context_id, self.course.id)
 
     # create_subgroup()
     def test_create_subgroup(self, m):
         register_uris(
             {
-                'outcome': [
-                    'outcome_group_create_subgroup_global',
-                    'outcome_group_create_subgroup_account',
-                    'outcome_group_create_subgroup_course'
+                "outcome": [
+                    "outcome_group_create_subgroup_global",
+                    "outcome_group_create_subgroup_account",
+                    "outcome_group_create_subgroup_course",
                 ]
-            }, m)
+            },
+            m,
+        )
 
         new_title = "New Subgroup Title"
 
         result = self.canvas_outcome_group.create_subgroup(new_title)
-        self.assertEqual(self.canvas_outcome_group.id, result.parent_outcome_group['id'])
-        self.assertEqual(result.parent_outcome_group['title'], "Parent of Subgroup")
+        self.assertEqual(
+            self.canvas_outcome_group.id, result.parent_outcome_group["id"]
+        )
+        self.assertEqual(result.parent_outcome_group["title"], "Parent of Subgroup")
         self.assertEqual(result.title, "New Subgroup Title")
 
         result = self.account_outcome_group.create_subgroup(new_title)
-        self.assertEqual(self.canvas_outcome_group.id, result.parent_outcome_group['id'])
-        self.assertEqual(result.parent_outcome_group['title'], "Parent of Subgroup")
+        self.assertEqual(
+            self.canvas_outcome_group.id, result.parent_outcome_group["id"]
+        )
+        self.assertEqual(result.parent_outcome_group["title"], "Parent of Subgroup")
         self.assertEqual(result.title, "New Subgroup Title")
 
         result = self.course_outcome_group.create_subgroup(new_title)
-        self.assertEqual(self.canvas_outcome_group.id, result.parent_outcome_group['id'])
-        self.assertEqual(result.parent_outcome_group['title'], "Parent of Subgroup")
+        self.assertEqual(
+            self.canvas_outcome_group.id, result.parent_outcome_group["id"]
+        )
+        self.assertEqual(result.parent_outcome_group["title"], "Parent of Subgroup")
         self.assertEqual(result.title, "New Subgroup Title")
 
     # import_outcome_group()
     def test_import_outcome_group(self, m):
         register_uris(
             {
-                'outcome': [
-                    'outcome_group_import_outcome_group_global',
-                    'outcome_group_import_outcome_group_account',
-                    'outcome_group_import_outcome_group_course'
+                "outcome": [
+                    "outcome_group_import_outcome_group_global",
+                    "outcome_group_import_outcome_group_account",
+                    "outcome_group_import_outcome_group_course",
                 ]
-            }, m)
+            },
+            m,
+        )
 
         result = self.canvas_outcome_group.import_outcome_group(3)
         self.assertEqual(result.id, 4)
         self.assertEqual(result.title, "Global Imported Subgroup Title")
-        self.assertEqual(result.parent_outcome_group['id'], self.canvas_outcome_group.id)
-        self.assertEqual(result.parent_outcome_group['title'], self.canvas_outcome_group.title)
+        self.assertEqual(
+            result.parent_outcome_group["id"], self.canvas_outcome_group.id
+        )
+        self.assertEqual(
+            result.parent_outcome_group["title"], self.canvas_outcome_group.title
+        )
 
         result = self.account_outcome_group.import_outcome_group(3)
         self.assertEqual(result.id, 4)
         self.assertEqual(result.title, "Account Imported Subgroup Title")
-        self.assertEqual(result.parent_outcome_group['id'], self.account_outcome_group.id)
-        self.assertEqual(result.parent_outcome_group['title'], self.account_outcome_group.title)
+        self.assertEqual(
+            result.parent_outcome_group["id"], self.account_outcome_group.id
+        )
+        self.assertEqual(
+            result.parent_outcome_group["title"], self.account_outcome_group.title
+        )
 
         result = self.course_outcome_group.import_outcome_group(3)
         self.assertEqual(result.id, 4)
         self.assertEqual(result.title, "Course Imported Subgroup Title")
-        self.assertEqual(result.parent_outcome_group['id'], self.course_outcome_group.id)
-        self.assertEqual(result.parent_outcome_group['title'], self.course_outcome_group.title)
+        self.assertEqual(
+            result.parent_outcome_group["id"], self.course_outcome_group.id
+        )
+        self.assertEqual(
+            result.parent_outcome_group["title"], self.course_outcome_group.title
+        )
 
         result_by_obj = self.course_outcome_group.import_outcome_group(result)
         self.assertEqual(result_by_obj.id, 4)
         self.assertEqual(result_by_obj.title, "Course Imported Subgroup Title")
-        self.assertEqual(result_by_obj.parent_outcome_group['id'], self.course_outcome_group.id)
         self.assertEqual(
-            result_by_obj.parent_outcome_group['title'], self.course_outcome_group.title
+            result_by_obj.parent_outcome_group["id"], self.course_outcome_group.id
+        )
+        self.assertEqual(
+            result_by_obj.parent_outcome_group["title"], self.course_outcome_group.title
         )

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -14,22 +14,21 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestPage(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
             requires = {
-                'course': ['get_by_id'],
-                'group': ['get_by_id', 'pages_get_page'],
-                'page': ['get_page']
+                "course": ["get_by_id"],
+                "group": ["get_by_id", "pages_get_page"],
+                "page": ["get_page"],
             }
             register_uris(requires, m)
 
             self.course = self.canvas.get_course(1)
             self.group = self.canvas.get_group(1)
-            self.page_course = self.course.get_page('my-url')
-            self.page_group = self.group.get_page('my-url')
+            self.page_course = self.course.get_page("my-url")
+            self.page_group = self.group.get_page("my-url")
 
     # __str__()
     def test__str__(self, m):
@@ -37,17 +36,17 @@ class TestPage(unittest.TestCase):
         self.assertIsInstance(string, str)
 
     def test_edit(self, m):
-        register_uris({'page': ['edit']}, m)
+        register_uris({"page": ["edit"]}, m)
 
         new_title = "New Page"
-        self.page_course.edit(page={'title': new_title})
+        self.page_course.edit(page={"title": new_title})
 
         self.assertIsInstance(self.page_course, Page)
-        self.assertTrue(hasattr(self.page_course, 'title'))
+        self.assertTrue(hasattr(self.page_course, "title"))
         self.assertEqual(self.page_course.title, new_title)
 
     def test_delete(self, m):
-        register_uris({'page': ['delete_page']}, m)
+        register_uris({"page": ["delete_page"]}, m)
 
         page = self.page_course
         deleted_page = page.delete()
@@ -56,7 +55,7 @@ class TestPage(unittest.TestCase):
 
     # list_revisions()
     def test_list_revisions(self, m):
-        register_uris({'page': ['list_revisions', 'list_revisions2']}, m)
+        register_uris({"page": ["list_revisions", "list_revisions2"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             revisions = self.page_course.list_revisions()
@@ -70,7 +69,7 @@ class TestPage(unittest.TestCase):
 
     # get_revisions()
     def test_get_revisions(self, m):
-        register_uris({'page': ['list_revisions', 'list_revisions2']}, m)
+        register_uris({"page": ["list_revisions", "list_revisions2"]}, m)
 
         revisions = self.page_course.get_revisions()
         rev_list = [rev for rev in revisions]
@@ -79,14 +78,14 @@ class TestPage(unittest.TestCase):
         self.assertIsInstance(rev_list[0], PageRevision)
 
     def test_show_latest_revision(self, m):
-        register_uris({'page': ['latest_revision']}, m)
+        register_uris({"page": ["latest_revision"]}, m)
 
         revision = self.page_course.show_latest_revision()
 
         self.assertIsInstance(revision, PageRevision)
 
     def test_get_revision_by_id_course(self, m):
-        register_uris({'page': ['get_latest_rev_by_id']}, m)
+        register_uris({"page": ["get_latest_rev_by_id"]}, m)
 
         revision_by_id = self.page_course.get_revision_by_id(2)
         self.assertIsInstance(revision_by_id, PageRevision)
@@ -95,7 +94,7 @@ class TestPage(unittest.TestCase):
         self.assertIsInstance(revision_by_obj, PageRevision)
 
     def test_get_revision_by_id_group(self, m):
-        register_uris({'page': ['get_latest_rev_by_id_group']}, m)
+        register_uris({"page": ["get_latest_rev_by_id_group"]}, m)
 
         revision_by_id = self.page_group.get_revision_by_id(2)
         self.assertIsInstance(revision_by_id, PageRevision)
@@ -104,14 +103,14 @@ class TestPage(unittest.TestCase):
         self.assertIsInstance(revision_by_obj, PageRevision)
 
     def test_revert_to_revision_course(self, m):
-        register_uris({'page': ['revert_to_revision']}, m)
+        register_uris({"page": ["revert_to_revision"]}, m)
 
         revision = self.page_course.revert_to_revision(3)
 
         self.assertIsInstance(revision, PageRevision)
 
     def test_revert_to_revision_group(self, m):
-        register_uris({'page': ['revert_to_revision_group']}, m)
+        register_uris({"page": ["revert_to_revision_group"]}, m)
 
         revision = self.page_group.revert_to_revision(3)
 
@@ -125,52 +124,51 @@ class TestPage(unittest.TestCase):
         self.assertEqual(self.page_group.parent_id, 1)
 
     def test_parent_id_no_id(self, m):
-        page = Page(self.canvas._Canvas__requester, {'url': 'my-url'})
+        page = Page(self.canvas._Canvas__requester, {"url": "my-url"})
         with self.assertRaises(ValueError):
             page.parent_id
 
     # parent_type
     def test_parent_type_course(self, m):
-        self.assertEqual(self.page_course.parent_type, 'course')
+        self.assertEqual(self.page_course.parent_type, "course")
 
     def test_parent_type_group(self, m):
-        self.assertEqual(self.page_group.parent_type, 'group')
+        self.assertEqual(self.page_group.parent_type, "group")
 
     def test_parent_type_no_id(self, m):
-        page = Page(self.canvas._Canvas__requester, {'url': 'my-url'})
+        page = Page(self.canvas._Canvas__requester, {"url": "my-url"})
         with self.assertRaises(ValueError):
             page.parent_type
 
     # get_parent()
     def test_get_parent_course(self, m):
-        register_uris({'course': ['get_by_id']}, m)
+        register_uris({"course": ["get_by_id"]}, m)
 
         self.assertIsInstance(self.page_course.get_parent(), Course)
 
     def test_get_parent_group(self, m):
-        register_uris({'group': ['get_by_id']}, m)
+        register_uris({"group": ["get_by_id"]}, m)
 
         self.assertIsInstance(self.page_group.get_parent(), Group)
 
 
 @requests_mock.Mocker()
 class TestPageRevision(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
             requires = {
-                'course': ['get_by_id', 'get_page'],
-                'group': ['get_by_id', 'pages_get_page'],
-                'page': ['get_latest_rev_by_id', 'get_latest_rev_by_id_group']
+                "course": ["get_by_id", "get_page"],
+                "group": ["get_by_id", "pages_get_page"],
+                "page": ["get_latest_rev_by_id", "get_latest_rev_by_id_group"],
             }
             register_uris(requires, m)
 
             self.course = self.canvas.get_course(1)
             self.group = self.canvas.get_group(1)
-            self.page_course = self.course.get_page('my-url')
-            self.page_group = self.group.get_page('my-url')
+            self.page_course = self.course.get_page("my-url")
+            self.page_group = self.group.get_page("my-url")
             self.revision = self.page_course.get_revision_by_id(2)
             self.group_revision = self.page_group.get_revision_by_id(2)
 
@@ -184,29 +182,29 @@ class TestPageRevision(unittest.TestCase):
         self.assertEqual(self.revision.parent_id, 1)
 
     def test_parent_id_no_id(self, m):
-        page = PageRevision(self.canvas._Canvas__requester, {'url': 'my-url'})
+        page = PageRevision(self.canvas._Canvas__requester, {"url": "my-url"})
         with self.assertRaises(ValueError):
             page.parent_id
 
     # parent_type
     def test_parent_type_course(self, m):
-        self.assertEqual(self.page_course.parent_type, 'course')
+        self.assertEqual(self.page_course.parent_type, "course")
 
     def test_parent_type_group(self, m):
-        self.assertEqual(self.page_group.parent_type, 'group')
+        self.assertEqual(self.page_group.parent_type, "group")
 
     def test_parent_type_no_id(self, m):
-        page = PageRevision(self.canvas._Canvas__requester, {'url': 'my-url'})
+        page = PageRevision(self.canvas._Canvas__requester, {"url": "my-url"})
         with self.assertRaises(ValueError):
             page.parent_type
 
     # get_parent()
     def test_get_parent_course(self, m):
-        register_uris({'course': ['get_by_id']}, m)
+        register_uris({"course": ["get_by_id"]}, m)
 
         self.assertIsInstance(self.revision.get_parent(), Course)
 
     def test_get_parent_group(self, m):
-        register_uris({'group': ['get_by_id']}, m)
+        register_uris({"group": ["get_by_id"]}, m)
 
         self.assertIsInstance(self.group_revision.get_parent(), Group)

--- a/tests/test_page_view.py
+++ b/tests/test_page_view.py
@@ -10,12 +10,11 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestPageView(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({'user': ['get_by_id', 'page_views', 'page_views_p2']}, m)
+            register_uris({"user": ["get_by_id", "page_views", "page_views_p2"]}, m)
 
             self.user = self.canvas.get_user(1)
             pageviews = self.user.get_page_views()

--- a/tests/test_paginated_list.py
+++ b/tests/test_paginated_list.py
@@ -13,255 +13,160 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestPaginatedList(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
         self.requester = self.canvas._Canvas__requester
 
     # various length lists
     def test_paginated_list_empty(self, m):
-        register_uris({'paginated_list': ['empty']}, m)
+        register_uris({"paginated_list": ["empty"]}, m)
 
-        pag_list = PaginatedList(
-            User,
-            self.requester,
-            'GET',
-            'empty_list'
-        )
+        pag_list = PaginatedList(User, self.requester, "GET", "empty_list")
         item_list = [item for item in pag_list]
         self.assertEqual(len(item_list), 0)
 
     def test_paginated_list_single(self, m):
-        register_uris({'paginated_list': ['single']}, m)
+        register_uris({"paginated_list": ["single"]}, m)
 
-        pag_list = PaginatedList(
-            User,
-            self.requester,
-            'GET',
-            'single_item'
-        )
+        pag_list = PaginatedList(User, self.requester, "GET", "single_item")
         item_list = [item for item in pag_list]
         self.assertEqual(len(item_list), 1)
         self.assertIsInstance(item_list[0], User)
 
     def test_paginated_list_two_one_page(self, m):
-        register_uris({'paginated_list': ['2_1_page']}, m)
+        register_uris({"paginated_list": ["2_1_page"]}, m)
 
-        pag_list = PaginatedList(
-            User,
-            self.requester,
-            'GET',
-            'two_objects_one_page'
-        )
+        pag_list = PaginatedList(User, self.requester, "GET", "two_objects_one_page")
         item_list = [item for item in pag_list]
         self.assertEqual(len(item_list), 2)
         self.assertIsInstance(item_list[0], User)
 
     def test_paginated_list_four_two_pages(self, m):
-        register_uris({'paginated_list': ['4_2_pages_p1', '4_2_pages_p2']}, m)
+        register_uris({"paginated_list": ["4_2_pages_p1", "4_2_pages_p2"]}, m)
 
-        pag_list = PaginatedList(
-            User,
-            self.requester,
-            'GET',
-            'four_objects_two_pages'
-        )
+        pag_list = PaginatedList(User, self.requester, "GET", "four_objects_two_pages")
         item_list = [item for item in pag_list]
         self.assertEqual(len(item_list), 4)
         self.assertIsInstance(item_list[0], User)
 
     def test_paginated_list_six_three_pages(self, m):
-        requires = {
-            'paginated_list': ['6_3_pages_p1', '6_3_pages_p2', '6_3_pages_p3']
-        }
+        requires = {"paginated_list": ["6_3_pages_p1", "6_3_pages_p2", "6_3_pages_p3"]}
         register_uris(requires, m)
 
-        pag_list = PaginatedList(
-            User,
-            self.requester,
-            'GET',
-            'six_objects_three_pages'
-        )
+        pag_list = PaginatedList(User, self.requester, "GET", "six_objects_three_pages")
         item_list = [item for item in pag_list]
         self.assertEqual(len(item_list), 6)
         self.assertIsInstance(item_list[0], User)
 
     # reusing iterator
     def test_iterator(self, m):
-        requires = {
-            'paginated_list': ['6_3_pages_p1', '6_3_pages_p2', '6_3_pages_p3']
-        }
+        requires = {"paginated_list": ["6_3_pages_p1", "6_3_pages_p2", "6_3_pages_p3"]}
         register_uris(requires, m)
 
-        pag_list = PaginatedList(
-            User,
-            self.requester,
-            'GET',
-            'six_objects_three_pages'
-        )
+        pag_list = PaginatedList(User, self.requester, "GET", "six_objects_three_pages")
         list_1 = [item for item in pag_list]
         list_2 = [item for item in pag_list]
         self.assertEqual(list_1, list_2)
 
     # get item
     def test_getitem_first(self, m):
-        requires = {
-            'paginated_list': ['6_3_pages_p1', '6_3_pages_p2', '6_3_pages_p3']
-        }
+        requires = {"paginated_list": ["6_3_pages_p1", "6_3_pages_p2", "6_3_pages_p3"]}
         register_uris(requires, m)
 
-        pag_list = PaginatedList(
-            User,
-            self.requester,
-            'GET',
-            'six_objects_three_pages'
-        )
+        pag_list = PaginatedList(User, self.requester, "GET", "six_objects_three_pages")
         first_item = pag_list[0]
         self.assertIsInstance(first_item, User)
 
     def test_getitem_second_page(self, m):
-        requires = {
-            'paginated_list': ['6_3_pages_p1', '6_3_pages_p2', '6_3_pages_p3']
-        }
+        requires = {"paginated_list": ["6_3_pages_p1", "6_3_pages_p2", "6_3_pages_p3"]}
         register_uris(requires, m)
 
-        pag_list = PaginatedList(
-            User,
-            self.requester,
-            'GET',
-            'six_objects_three_pages'
-        )
+        pag_list = PaginatedList(User, self.requester, "GET", "six_objects_three_pages")
         third_item = pag_list[2]
         self.assertIsInstance(third_item, User)
 
     # slicing
     def test_slice_beginning(self, m):
-        requires = {
-            'paginated_list': ['6_3_pages_p1', '6_3_pages_p2', '6_3_pages_p3']
-        }
+        requires = {"paginated_list": ["6_3_pages_p1", "6_3_pages_p2", "6_3_pages_p3"]}
         register_uris(requires, m)
 
-        pag_list = PaginatedList(
-            User,
-            self.requester,
-            'GET',
-            'six_objects_three_pages'
-        )
+        pag_list = PaginatedList(User, self.requester, "GET", "six_objects_three_pages")
         first_two_items = pag_list[:2]
         item_list = [item for item in first_two_items]
         self.assertEqual(len(item_list), 2)
         self.assertIsInstance(item_list[0], User)
-        self.assertTrue(hasattr(item_list[0], 'id'))
-        self.assertEqual(item_list[0].id, '1')
+        self.assertTrue(hasattr(item_list[0], "id"))
+        self.assertEqual(item_list[0].id, "1")
 
     def test_slice_middle(self, m):
-        requires = {
-            'paginated_list': ['6_3_pages_p1', '6_3_pages_p2', '6_3_pages_p3']
-        }
+        requires = {"paginated_list": ["6_3_pages_p1", "6_3_pages_p2", "6_3_pages_p3"]}
         register_uris(requires, m)
 
-        pag_list = PaginatedList(
-            User,
-            self.requester,
-            'GET',
-            'six_objects_three_pages'
-        )
+        pag_list = PaginatedList(User, self.requester, "GET", "six_objects_three_pages")
         middle_two_items = pag_list[2:4]
         item_list = [item for item in middle_two_items]
         self.assertEqual(len(item_list), 2)
         self.assertIsInstance(item_list[0], User)
-        self.assertTrue(hasattr(item_list[0], 'id'))
-        self.assertEqual(item_list[0].id, '3')
+        self.assertTrue(hasattr(item_list[0], "id"))
+        self.assertEqual(item_list[0].id, "3")
 
     def test_slice_end(self, m):
-        requires = {
-            'paginated_list': ['6_3_pages_p1', '6_3_pages_p2', '6_3_pages_p3']
-        }
+        requires = {"paginated_list": ["6_3_pages_p1", "6_3_pages_p2", "6_3_pages_p3"]}
         register_uris(requires, m)
 
-        pag_list = PaginatedList(
-            User,
-            self.requester,
-            'GET',
-            'six_objects_three_pages'
-        )
+        pag_list = PaginatedList(User, self.requester, "GET", "six_objects_three_pages")
         middle_two_items = pag_list[4:6]
         item_list = [item for item in middle_two_items]
         self.assertEqual(len(item_list), 2)
         self.assertIsInstance(item_list[0], User)
-        self.assertTrue(hasattr(item_list[0], 'id'))
-        self.assertEqual(item_list[0].id, '5')
+        self.assertTrue(hasattr(item_list[0], "id"))
+        self.assertEqual(item_list[0].id, "5")
 
     def test_slice_oversize(self, m):
-        requires = {
-            'paginated_list': ['4_2_pages_p1', '4_2_pages_p2']
-        }
+        requires = {"paginated_list": ["4_2_pages_p1", "4_2_pages_p2"]}
         register_uris(requires, m)
 
-        pag_list = PaginatedList(
-            User,
-            self.requester,
-            'GET',
-            'four_objects_two_pages'
-        )
+        pag_list = PaginatedList(User, self.requester, "GET", "four_objects_two_pages")
         oversized_slice = pag_list[0:10]
         item_list = [item for item in oversized_slice]
         self.assertEqual(len(item_list), 4)
 
     def test_slice_out_of_bounds(self, m):
-        requires = {
-            'paginated_list': ['4_2_pages_p1', '4_2_pages_p2']
-        }
+        requires = {"paginated_list": ["4_2_pages_p1", "4_2_pages_p2"]}
         register_uris(requires, m)
 
-        pag_list = PaginatedList(
-            User,
-            self.requester,
-            'GET',
-            'four_objects_two_pages'
-        )
+        pag_list = PaginatedList(User, self.requester, "GET", "four_objects_two_pages")
         out_of_bounds = pag_list[4:5]
         item_list = [item for item in out_of_bounds]
         self.assertEqual(len(item_list), 0)
 
     # __repr__()
     def test_repr(self, m):
-        requires = {
-            'paginated_list': ['6_3_pages_p1', '6_3_pages_p2', '6_3_pages_p3']
-        }
+        requires = {"paginated_list": ["6_3_pages_p1", "6_3_pages_p2", "6_3_pages_p3"]}
         register_uris(requires, m)
 
-        pag_list = PaginatedList(
-            User,
-            self.requester,
-            'GET',
-            'six_objects_three_pages'
-        )
-        self.assertEqual(pag_list.__repr__(), '<PaginatedList of type User>')
+        pag_list = PaginatedList(User, self.requester, "GET", "six_objects_three_pages")
+        self.assertEqual(pag_list.__repr__(), "<PaginatedList of type User>")
 
     def test_root_element_incorrect(self, m):
-        register_uris({'account': ['get_enrollment_terms']}, m)
+        register_uris({"account": ["get_enrollment_terms"]}, m)
 
         pag_list = PaginatedList(
-            EnrollmentTerm,
-            self.requester,
-            'GET',
-            'accounts/1/terms',
-            _root='wrong'
+            EnrollmentTerm, self.requester, "GET", "accounts/1/terms", _root="wrong"
         )
 
         with self.assertRaises(ValueError):
             pag_list[0]
 
     def test_root_element(self, m):
-        register_uris({'account': ['get_enrollment_terms']}, m)
+        register_uris({"account": ["get_enrollment_terms"]}, m)
 
         pag_list = PaginatedList(
             EnrollmentTerm,
             self.requester,
-            'GET',
-            'accounts/1/terms',
-            _root='enrollment_terms'
+            "GET",
+            "accounts/1/terms",
+            _root="enrollment_terms",
         )
 
         self.assertIsInstance(pag_list[0], EnrollmentTerm)

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -11,14 +11,13 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestProgress(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
             requires = {
-                'course': ['get_by_id', 'create_group_category'],
-                'group': ['category_assign_members_false']
+                "course": ["get_by_id", "create_group_category"],
+                "group": ["category_assign_members_false"],
             }
 
             register_uris(requires, m)
@@ -34,7 +33,7 @@ class TestProgress(unittest.TestCase):
 
     # query()
     def test_query(self, m):
-        register_uris({'progress': ['progress_query']}, m)
+        register_uris({"progress": ["progress_query"]}, m)
 
         response = self.progress.query()
         self.assertIsInstance(response, Progress)

--- a/tests/test_quiz.py
+++ b/tests/test_quiz.py
@@ -14,12 +14,11 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestQuiz(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({'course': ['get_by_id'], 'quiz': ['get_by_id']}, m)
+            register_uris({"course": ["get_by_id"], "quiz": ["get_by_id"]}, m)
 
             self.course = self.canvas.get_course(1)
             self.quiz = self.course.get_quiz(1)
@@ -29,35 +28,49 @@ class TestQuiz(unittest.TestCase):
         string = str(self.quiz)
         self.assertIsInstance(string, str)
 
+    # broadcast_message()
+    def test_broadcast_message(self, m):
+        register_uris({"quiz": ["broadcast_message"]}, m)
+
+        success = self.quiz.broadcast_message(
+            conversations={
+                "body": "please take the quiz",
+                "recipients": "submitted",
+                "subject": "ATTN: Quiz 101 Students",
+            }
+        )
+
+        self.assertEqual(success, True)
+
     # edit()
     def test_edit(self, m):
-        register_uris({'quiz': ['edit']}, m)
+        register_uris({"quiz": ["edit"]}, m)
 
-        title = 'New Title'
-        edited_quiz = self.quiz.edit(quiz={'title': title})
+        title = "New Title"
+        edited_quiz = self.quiz.edit(quiz={"title": title})
 
         self.assertIsInstance(edited_quiz, Quiz)
-        self.assertTrue(hasattr(edited_quiz, 'title'))
+        self.assertTrue(hasattr(edited_quiz, "title"))
         self.assertEqual(edited_quiz.title, title)
-        self.assertTrue(hasattr(edited_quiz, 'course_id'))
+        self.assertTrue(hasattr(edited_quiz, "course_id"))
         self.assertEqual(edited_quiz.course_id, self.course.id)
 
     # delete()
     def test_delete(self, m):
-        register_uris({'quiz': ['delete']}, m)
+        register_uris({"quiz": ["delete"]}, m)
 
         title = "Great Title"
-        deleted_quiz = self.quiz.delete(quiz={'title': title})
+        deleted_quiz = self.quiz.delete(quiz={"title": title})
 
         self.assertIsInstance(deleted_quiz, Quiz)
-        self.assertTrue(hasattr(deleted_quiz, 'title'))
+        self.assertTrue(hasattr(deleted_quiz, "title"))
         self.assertEqual(deleted_quiz.title, title)
-        self.assertTrue(hasattr(deleted_quiz, 'course_id'))
+        self.assertTrue(hasattr(deleted_quiz, "course_id"))
         self.assertEqual(deleted_quiz.course_id, self.course.id)
 
     # get_quiz_group()
     def test_get_quiz_group(self, m):
-        register_uris({'quiz': ['get_quiz_group']}, m)
+        register_uris({"quiz": ["get_quiz_group"]}, m)
 
         result = self.quiz.get_quiz_group(1)
         self.assertIsInstance(result, QuizGroup)
@@ -66,23 +79,31 @@ class TestQuiz(unittest.TestCase):
 
     # create_question_group()
     def test_create_question_group(self, m):
-        register_uris({'quiz': ['create_question_group']}, m)
+        register_uris({"quiz": ["create_question_group"]}, m)
 
-        quiz_group = [{'name': 'Test Group', 'pick_count': 1,
-                      'question_points': 2, 'assessment_question_bank_id': 3}]
+        quiz_group = [
+            {
+                "name": "Test Group",
+                "pick_count": 1,
+                "question_points": 2,
+                "assessment_question_bank_id": 3,
+            }
+        ]
         result = self.quiz.create_question_group(quiz_group)
 
         self.assertIsInstance(result, QuizGroup)
         self.assertEqual(result.id, 1)
         self.assertEqual(result.quiz_id, 1)
-        self.assertEqual(result.name, quiz_group[0].get('name'))
-        self.assertEqual(result.pick_count, quiz_group[0].get('pick_count'))
-        self.assertEqual(result.question_points, quiz_group[0].get('question_points'))
-        self.assertEqual(result.assessment_question_bank_id,
-                         quiz_group[0].get('assessment_question_bank_id'))
+        self.assertEqual(result.name, quiz_group[0].get("name"))
+        self.assertEqual(result.pick_count, quiz_group[0].get("pick_count"))
+        self.assertEqual(result.question_points, quiz_group[0].get("question_points"))
+        self.assertEqual(
+            result.assessment_question_bank_id,
+            quiz_group[0].get("assessment_question_bank_id"),
+        )
 
     def test_create_question_group_empty_list(self, m):
-        register_uris({'quiz': ['create_question_group']}, m)
+        register_uris({"quiz": ["create_question_group"]}, m)
 
         quiz_group = []
 
@@ -90,7 +111,7 @@ class TestQuiz(unittest.TestCase):
             self.quiz.create_question_group(quiz_group)
 
     def test_create_question_group_incorrect_param(self, m):
-        register_uris({'quiz': ['create_question_group']}, m)
+        register_uris({"quiz": ["create_question_group"]}, m)
 
         quiz_group = [1]
 
@@ -98,7 +119,7 @@ class TestQuiz(unittest.TestCase):
             self.quiz.create_question_group(quiz_group)
 
     def test_create_question_group_incorrect_dict(self, m):
-        register_uris({'quiz': ['create_question_group']}, m)
+        register_uris({"quiz": ["create_question_group"]}, m)
 
         quiz_group = [{}]
 
@@ -107,81 +128,74 @@ class TestQuiz(unittest.TestCase):
 
     # create_question()
     def test_create_question(self, m):
-        register_uris({'quiz': ['create_question']}, m)
+        register_uris({"quiz": ["create_question"]}, m)
 
         question_dict = {
-            'question_name': 'Pick Correct Answer',
-            'question_type': 'multiple_choice_question',
-            'question_text': 'What is the right answer?',
-            'points_possible': 10,
-            'correct_comments': 'That\'s correct!',
-            'incorrect_comments': 'That\'s wrong!',
+            "question_name": "Pick Correct Answer",
+            "question_type": "multiple_choice_question",
+            "question_text": "What is the right answer?",
+            "points_possible": 10,
+            "correct_comments": "That's correct!",
+            "incorrect_comments": "That's wrong!",
         }
         question = self.quiz.create_question(question=question_dict)
 
         self.assertIsInstance(question, QuizQuestion)
-        self.assertTrue(hasattr(question, 'question_name'))
-        self.assertEqual(question.question_name, question_dict['question_name'])
+        self.assertTrue(hasattr(question, "question_name"))
+        self.assertEqual(question.question_name, question_dict["question_name"])
 
     # get_question()
     def test_get_question(self, m):
-        register_uris({'quiz': ['get_question']}, m)
+        register_uris({"quiz": ["get_question"]}, m)
 
         question_id = 1
         question = self.quiz.get_question(question_id)
 
         self.assertIsInstance(question, QuizQuestion)
-        self.assertTrue(hasattr(question, 'id'))
+        self.assertTrue(hasattr(question, "id"))
         self.assertEqual(question.id, question_id)
-        self.assertTrue(hasattr(question, 'question_name'))
-        self.assertEqual(question.question_name, 'Pick Correct Answer')
+        self.assertTrue(hasattr(question, "question_name"))
+        self.assertEqual(question.question_name, "Pick Correct Answer")
 
     # get_questions()
     def test_get_questions(self, m):
-        register_uris({'quiz': ['get_questions']}, m)
+        register_uris({"quiz": ["get_questions"]}, m)
 
         questions = self.quiz.get_questions()
         question_list = [q for q in questions]
 
         self.assertEqual(len(question_list), 2)
         self.assertIsInstance(question_list[0], QuizQuestion)
-        self.assertTrue(hasattr(question_list[0], 'id'))
+        self.assertTrue(hasattr(question_list[0], "id"))
         self.assertEqual(question_list[0].id, 1)
         self.assertIsInstance(question_list[1], QuizQuestion)
-        self.assertTrue(hasattr(question_list[1], 'id'))
+        self.assertTrue(hasattr(question_list[1], "id"))
         self.assertEqual(question_list[1].id, 2)
 
     # set_extensions()
     def test_set_extensions(self, m):
-        register_uris({'quiz': ['set_extensions']}, m)
+        register_uris({"quiz": ["set_extensions"]}, m)
 
-        extension = self.quiz.set_extensions([
-            {
-                'user_id': 1,
-                'extra_time': 60
-            },
-            {
-                'user_id': 2,
-                'extra_attempts': 3
-            }
-        ])
+        extension = self.quiz.set_extensions(
+            [{"user_id": 1, "extra_time": 60}, {"user_id": 2, "extra_attempts": 3}]
+        )
 
         self.assertIsInstance(extension, list)
         self.assertEqual(len(extension), 2)
 
         self.assertIsInstance(extension[0], QuizExtension)
         self.assertEqual(extension[0].user_id, "1")
-        self.assertTrue(hasattr(extension[0], 'extra_time'))
+        self.assertTrue(hasattr(extension[0], "extra_time"))
         self.assertEqual(extension[0].extra_time, 60)
 
         self.assertIsInstance(extension[1], QuizExtension)
         self.assertEqual(extension[1].user_id, "2")
-        self.assertTrue(hasattr(extension[1], 'extra_attempts'))
+        self.assertTrue(hasattr(extension[1], "extra_attempts"))
         self.assertEqual(extension[1].extra_attempts, 3)
 
     def test_set_extensions_not_list(self, m):
         with self.assertRaises(ValueError):
-            self.quiz.set_extensions({'user_id': 1, 'extra_time': 60})
+            self.quiz.set_extensions({"user_id": 1, "extra_time": 60})
 
     def test_set_extensions_empty_list(self, m):
         with self.assertRaises(ValueError):
@@ -189,15 +203,15 @@ class TestQuiz(unittest.TestCase):
 
     def test_set_extensions_non_dicts(self, m):
         with self.assertRaises(ValueError):
-            self.quiz.set_extensions([('user_id', 1), ('extra_time', 60)])
+            self.quiz.set_extensions([("user_id", 1), ("extra_time", 60)])
 
     def test_set_extensions_missing_key(self, m):
         with self.assertRaises(RequiredFieldMissing):
-            self.quiz.set_extensions([{'extra_time': 60, 'extra_attempts': 3}])
+            self.quiz.set_extensions([{"extra_time": 60, "extra_attempts": 3}])
 
     # get_all_quiz_submissions()
     def test_get_all_quiz_submissions(self, m):
-        register_uris({'quiz': ['get_all_quiz_submissions']}, m)
+        register_uris({"quiz": ["get_all_quiz_submissions"]}, m)
         submission = self.quiz.get_all_quiz_submissions()
 
         self.assertIsInstance(submission, list)
@@ -205,36 +219,36 @@ class TestQuiz(unittest.TestCase):
 
         self.assertIsInstance(submission[0], QuizSubmission)
         self.assertEqual(submission[0].id, 1)
-        self.assertTrue(hasattr(submission[0], 'attempt'))
+        self.assertTrue(hasattr(submission[0], "attempt"))
         self.assertEqual(submission[0].attempt, 3)
 
         self.assertIsInstance(submission[1], QuizSubmission)
         self.assertEqual(submission[1].id, 2)
-        self.assertTrue(hasattr(submission[1], 'score'))
+        self.assertTrue(hasattr(submission[1], "score"))
         self.assertEqual(submission[1].score, 5)
 
     # get_quiz_submission
     def test_get_quiz_submission(self, m):
-        register_uris({'quiz': ['get_quiz_submission']}, m)
+        register_uris({"quiz": ["get_quiz_submission"]}, m)
 
         quiz_id = 1
         submission = self.quiz.get_quiz_submission(quiz_id)
 
         self.assertIsInstance(submission, QuizSubmission)
-        self.assertTrue(hasattr(submission, 'id'))
+        self.assertTrue(hasattr(submission, "id"))
         self.assertEqual(submission.quiz_id, quiz_id)
-        self.assertTrue(hasattr(submission, 'quiz_version'))
+        self.assertTrue(hasattr(submission, "quiz_version"))
         self.assertEqual(submission.quiz_version, 1)
-        self.assertTrue(hasattr(submission, 'user_id'))
+        self.assertTrue(hasattr(submission, "user_id"))
         self.assertEqual(submission.user_id, 1)
-        self.assertTrue(hasattr(submission, 'validation_token'))
-        self.assertEqual(submission.validation_token, 'this is a validation token')
-        self.assertTrue(hasattr(submission, 'score'))
+        self.assertTrue(hasattr(submission, "validation_token"))
+        self.assertEqual(submission.validation_token, "this is a validation token")
+        self.assertTrue(hasattr(submission, "score"))
         self.assertEqual(submission.score, 0)
 
     # create_submission
     def test_create_submission(self, m):
-        register_uris({'quiz': ['create_submission']}, m)
+        register_uris({"quiz": ["create_submission"]}, m)
 
         submission = self.quiz.create_submission()
 
@@ -249,16 +263,16 @@ class TestQuizSubmission(unittest.TestCase):
         self.submission = QuizSubmission(
             self.canvas._Canvas__requester,
             {
-                'id': 1,
-                'quiz_id': 1,
-                'user_id': 1,
-                'course_id': 1,
-                'submission_id': 1,
-                'attempt': 3,
-                'validation_token': 'this is a validation token',
-                'manually_unlocked': None,
-                'score': 7
-            }
+                "id": 1,
+                "quiz_id": 1,
+                "user_id": 1,
+                "course_id": 1,
+                "submission_id": 1,
+                "attempt": 3,
+                "validation_token": "this is a validation token",
+                "manually_unlocked": None,
+                "score": 7,
+            },
         )
 
     # __str__()
@@ -268,7 +282,7 @@ class TestQuizSubmission(unittest.TestCase):
 
     # complete
     def test_complete(self, m):
-        register_uris({'submission': ['complete']}, m)
+        register_uris({"submission": ["complete"]}, m)
 
         submission = self.submission.complete()
 
@@ -276,17 +290,19 @@ class TestQuizSubmission(unittest.TestCase):
             self.submission.complete(attempt=1)
 
         with self.assertRaises(ValueError):
-            self.submission.complete(validation_token='should not pass validation token here')
+            self.submission.complete(
+                validation_token="should not pass validation token here"
+            )
 
         self.assertIsInstance(submission, QuizSubmission)
-        self.assertTrue(hasattr(submission, 'id'))
-        self.assertTrue(hasattr(submission, 'quiz_id'))
-        self.assertTrue(hasattr(submission, 'attempt'))
-        self.assertTrue(hasattr(submission, 'validation_token'))
+        self.assertTrue(hasattr(submission, "id"))
+        self.assertTrue(hasattr(submission, "quiz_id"))
+        self.assertTrue(hasattr(submission, "attempt"))
+        self.assertTrue(hasattr(submission, "validation_token"))
 
     # get_times
     def test_get_times(self, m):
-        register_uris({'submission': ['get_times']}, m)
+        register_uris({"submission": ["get_times"]}, m)
 
         submission = self.submission.get_times()
 
@@ -294,47 +310,34 @@ class TestQuizSubmission(unittest.TestCase):
             self.submission.get_times(attempt=1)
 
         self.assertIsInstance(submission, dict)
-        self.assertIn('end_at', submission)
-        self.assertIn('time_left', submission)
-        self.assertIsInstance(submission['time_left'], int)
-        self.assertIsInstance(submission['end_at'], text_type)
+        self.assertIn("end_at", submission)
+        self.assertIn("time_left", submission)
+        self.assertIsInstance(submission["time_left"], int)
+        self.assertIsInstance(submission["end_at"], text_type)
 
     # update_score_and_comments
     def test_update_score_and_comments(self, m):
-        register_uris({'submission': ['update_score_and_comments']}, m)
+        register_uris({"submission": ["update_score_and_comments"]}, m)
 
         submission = self.submission.update_score_and_comments(
             quiz_submissions=[
                 {
                     "attempt": 1,
                     "fudge_points": 1,
-                    "questions":
-                        {
-                            "question id 1":
-                            {
-                                "score": 1,
-                                "comment": "question 1 comment"
-                            },
-                            "question id 2":
-                            {
-                                "score": 2,
-                                "comment": "question 2 comment"
-                            },
-                            "question id 3":
-                            {
-                                "score": 3,
-                                "comment": "question 3 comment"
-                            }
-                        }
+                    "questions": {
+                        "question id 1": {"score": 1, "comment": "question 1 comment"},
+                        "question id 2": {"score": 2, "comment": "question 2 comment"},
+                        "question id 3": {"score": 3, "comment": "question 3 comment"},
+                    },
                 }
             ]
         )
 
         self.assertIsInstance(submission, QuizSubmission)
-        self.assertTrue(hasattr(submission, 'id'))
-        self.assertTrue(hasattr(submission, 'attempt'))
-        self.assertTrue(hasattr(submission, 'quiz_id'))
-        self.assertTrue(hasattr(submission, 'validation_token'))
+        self.assertTrue(hasattr(submission, "id"))
+        self.assertTrue(hasattr(submission, "attempt"))
+        self.assertTrue(hasattr(submission, "quiz_id"))
+        self.assertTrue(hasattr(submission, "validation_token"))
         self.assertEqual(submission.score, 7)
 
 
@@ -343,14 +346,17 @@ class TestQuizExtension(unittest.TestCase):
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
-        self.extension = QuizExtension(self.canvas._Canvas__requester, {
-            'user_id': 1,
-            'quiz_id': 1,
-            'extra_time': 60,
-            'extra_attempts': 3,
-            'manually_unlocked': None,
-            'end_at': None
-        })
+        self.extension = QuizExtension(
+            self.canvas._Canvas__requester,
+            {
+                "user_id": 1,
+                "quiz_id": 1,
+                "extra_time": 60,
+                "extra_attempts": 3,
+                "manually_unlocked": None,
+                "end_at": None,
+            },
+        )
 
     # __str__()
     def test__str__(self, m):
@@ -360,15 +366,13 @@ class TestQuizExtension(unittest.TestCase):
 
 @requests_mock.Mocker()
 class TestQuizQuestion(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({
-                'course': ['get_by_id'],
-                'quiz': ['get_by_id', 'get_question']
-            }, m)
+            register_uris(
+                {"course": ["get_by_id"], "quiz": ["get_by_id", "get_question"]}, m
+            )
 
             self.course = self.canvas.get_course(1)
             self.quiz = self.course.get_quiz(1)
@@ -381,29 +385,29 @@ class TestQuizQuestion(unittest.TestCase):
 
     # delete()
     def test_delete(self, m):
-        register_uris({'quiz': ['delete_question']}, m)
+        register_uris({"quiz": ["delete_question"]}, m)
 
         response = self.question.delete()
         self.assertTrue(response)
 
     # edit()
     def test_edit(self, m):
-        register_uris({'quiz': ['edit_question']}, m)
+        register_uris({"quiz": ["edit_question"]}, m)
 
         question_dict = {
-            'question_name': 'Updated Question',
-            'question_type': 'multiple_choice_question',
-            'question_text': 'This question has been updated.',
-            'points_possible': 100,
-            'correct_comments': 'Updated correct!',
-            'incorrect_comments': 'Updated wrong!',
+            "question_name": "Updated Question",
+            "question_type": "multiple_choice_question",
+            "question_text": "This question has been updated.",
+            "points_possible": 100,
+            "correct_comments": "Updated correct!",
+            "incorrect_comments": "Updated wrong!",
         }
 
-        self.assertEqual(self.question.question_name, 'Pick Correct Answer')
+        self.assertEqual(self.question.question_name, "Pick Correct Answer")
 
         response = self.question.edit(question=question_dict)
 
         self.assertIsInstance(response, QuizQuestion)
         self.assertIsInstance(self.question, QuizQuestion)
-        self.assertEqual(response.question_name, question_dict['question_name'])
-        self.assertEqual(self.question.question_name, question_dict['question_name'])
+        self.assertEqual(response.question_name, question_dict["question_name"])
+        self.assertEqual(self.question.question_name, question_dict["question_name"])

--- a/tests/test_quiz_group.py
+++ b/tests/test_quiz_group.py
@@ -11,15 +11,13 @@ from canvasapi.exceptions import RequiredFieldMissing
 
 @requests_mock.Mocker()
 class TestQuizGroup(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({
-                'course': ['get_by_id'],
-                'quiz': ['get_by_id', 'get_quiz_group']
-            }, m)
+            register_uris(
+                {"course": ["get_by_id"], "quiz": ["get_by_id", "get_quiz_group"]}, m
+            )
 
             self.course = self.canvas.get_course(1)
             self.quiz_group = self.course.get_quiz(1).get_quiz_group(1)
@@ -31,9 +29,9 @@ class TestQuizGroup(unittest.TestCase):
 
     # update_question_group()
     def test_update(self, m):
-        register_uris({'quiz_group': ['update']}, m)
+        register_uris({"quiz_group": ["update"]}, m)
 
-        quiz_group = [{'name': 'Test Group', 'pick_count': 1, 'question_points': 2}]
+        quiz_group = [{"name": "Test Group", "pick_count": 1, "question_points": 2}]
         result = self.quiz_group.update(1, quiz_group)
 
         self.assertIsInstance(result, bool)
@@ -41,12 +39,14 @@ class TestQuizGroup(unittest.TestCase):
 
         self.assertEqual(self.quiz_group.id, 1)
         self.assertEqual(self.quiz_group.quiz_id, 1)
-        self.assertEqual(self.quiz_group.name, quiz_group[0].get('name'))
-        self.assertEqual(self.quiz_group.pick_count, quiz_group[0].get('pick_count'))
-        self.assertEqual(self.quiz_group.question_points, quiz_group[0].get('question_points'))
+        self.assertEqual(self.quiz_group.name, quiz_group[0].get("name"))
+        self.assertEqual(self.quiz_group.pick_count, quiz_group[0].get("pick_count"))
+        self.assertEqual(
+            self.quiz_group.question_points, quiz_group[0].get("question_points")
+        )
 
     def test_update_empty_list(self, m):
-        register_uris({'quiz_group': ['update']}, m)
+        register_uris({"quiz_group": ["update"]}, m)
 
         quiz_group = []
 
@@ -54,7 +54,7 @@ class TestQuizGroup(unittest.TestCase):
             self.quiz_group.update(1, quiz_group)
 
     def test_update_incorrect_param(self, m):
-        register_uris({'quiz_group': ['update']}, m)
+        register_uris({"quiz_group": ["update"]}, m)
 
         quiz_group = [1]
 
@@ -62,7 +62,7 @@ class TestQuizGroup(unittest.TestCase):
             self.quiz_group.update(1, quiz_group)
 
     def test_update_incorrect_dict(self, m):
-        register_uris({'quiz_group': ['update']}, m)
+        register_uris({"quiz_group": ["update"]}, m)
 
         quiz_group = [{}]
 
@@ -71,7 +71,7 @@ class TestQuizGroup(unittest.TestCase):
 
     # delete_question_group()
     def test_delete(self, m):
-        register_uris({'quiz_group': ['delete']}, m)
+        register_uris({"quiz_group": ["delete"]}, m)
 
         result = self.quiz_group.delete(1)
 
@@ -79,15 +79,15 @@ class TestQuizGroup(unittest.TestCase):
 
     # reorder_question_group()
     def test_reorder_question_group(self, m):
-        register_uris({'quiz_group': ['reorder_question_group']}, m)
+        register_uris({"quiz_group": ["reorder_question_group"]}, m)
 
-        newOrdering = [{'id': 2}, {'id': 1, 'type': 'question'}]
+        newOrdering = [{"id": 2}, {"id": 1, "type": "question"}]
         result = self.quiz_group.reorder_question_group(1, newOrdering)
 
         self.assertTrue(result)
 
     def test_reorderquestion_group_empty_list(self, m):
-        register_uris({'quiz_group': ['reorder_question_group']}, m)
+        register_uris({"quiz_group": ["reorder_question_group"]}, m)
 
         order = []
 
@@ -95,7 +95,7 @@ class TestQuizGroup(unittest.TestCase):
             self.quiz_group.reorder_question_group(1, order)
 
     def test_reorderquestion_group_incorrect_param(self, m):
-        register_uris({'quiz_group': ['reorder_question_group']}, m)
+        register_uris({"quiz_group": ["reorder_question_group"]}, m)
 
         order = [1]
 
@@ -103,7 +103,7 @@ class TestQuizGroup(unittest.TestCase):
             self.quiz_group.reorder_question_group(1, order)
 
     def test_reorderquestion_group_incorrect_dict(self, m):
-        register_uris({'quiz_group': ['reorder_question_group']}, m)
+        register_uris({"quiz_group": ["reorder_question_group"]}, m)
 
         order = [{"something": 2}]
 

--- a/tests/test_requester.py
+++ b/tests/test_requester.py
@@ -8,8 +8,12 @@ from six.moves.urllib.parse import quote
 
 from canvasapi import Canvas
 from canvasapi.exceptions import (
-    BadRequest, CanvasException, Conflict, InvalidAccessToken, ResourceDoesNotExist,
-    Unauthorized
+    BadRequest,
+    CanvasException,
+    Conflict,
+    InvalidAccessToken,
+    ResourceDoesNotExist,
+    Unauthorized,
 )
 from tests import settings
 from tests.util import register_uris
@@ -17,23 +21,22 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestRequester(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
         self.requester = self.canvas._Canvas__requester
 
     # request()
     def test_request_get(self, m):
-        register_uris({'requests': ['get']}, m)
+        register_uris({"requests": ["get"]}, m)
 
-        response = self.requester.request('GET', 'fake_get_request')
+        response = self.requester.request("GET", "fake_get_request")
         self.assertEqual(response.status_code, 200)
 
     def test_request_get_datetime(self, m):
         date = datetime.today()
 
         def custom_matcher(request):
-            match_query = 'date={}'.format(quote(date.isoformat()).lower())
+            match_query = "date={}".format(quote(date.isoformat()).lower())
             if request.query == match_query:
                 resp = requests.Response()
                 resp.status_code = 200
@@ -41,20 +44,20 @@ class TestRequester(unittest.TestCase):
 
         m.add_matcher(custom_matcher)
 
-        response = self.requester.request('GET', 'test', date=date)
+        response = self.requester.request("GET", "test", date=date)
         self.assertEqual(response.status_code, 200)
 
     def test_request_post(self, m):
-        register_uris({'requests': ['post']}, m)
+        register_uris({"requests": ["post"]}, m)
 
-        response = self.requester.request('POST', 'fake_post_request')
+        response = self.requester.request("POST", "fake_post_request")
         self.assertEqual(response.status_code, 200)
 
     def test_request_post_datetime(self, m):
         date = datetime.today()
 
         def custom_matcher(request):
-            match_text = 'date={}'.format(quote(date.isoformat()))
+            match_text = "date={}".format(quote(date.isoformat()))
             if request.text == match_text:
                 resp = requests.Response()
                 resp.status_code = 200
@@ -62,87 +65,82 @@ class TestRequester(unittest.TestCase):
 
         m.add_matcher(custom_matcher)
 
-        response = self.requester.request('POST', 'test', date=date)
+        response = self.requester.request("POST", "test", date=date)
         self.assertEqual(response.status_code, 200)
 
     def test_request_delete(self, m):
-        register_uris({'requests': ['delete']}, m)
+        register_uris({"requests": ["delete"]}, m)
 
-        response = self.requester.request('DELETE', 'fake_delete_request')
+        response = self.requester.request("DELETE", "fake_delete_request")
         self.assertEqual(response.status_code, 200)
 
     def test_request_put(self, m):
-        register_uris({'requests': ['put']}, m)
+        register_uris({"requests": ["put"]}, m)
 
-        response = self.requester.request('PUT', 'fake_put_request')
+        response = self.requester.request("PUT", "fake_put_request")
         self.assertEqual(response.status_code, 200)
 
     def test_request_cache(self, m):
-        register_uris({'requests': ['get']}, m)
+        register_uris({"requests": ["get"]}, m)
 
-        response = self.requester.request('GET', 'fake_get_request')
+        response = self.requester.request("GET", "fake_get_request")
         self.assertEqual(response, self.requester._cache[0])
 
     def test_request_cache_clear_after_5(self, m):
-        register_uris({'requests': ['get', 'post']}, m)
+        register_uris({"requests": ["get", "post"]}, m)
 
         for i in range(5):
-            self.requester.request('GET', 'fake_get_request')
+            self.requester.request("GET", "fake_get_request")
 
-        response = self.requester.request('POST', 'fake_post_request')
+        response = self.requester.request("POST", "fake_post_request")
 
         self.assertLessEqual(len(self.requester._cache), 5)
         self.assertEqual(response, self.requester._cache[0])
 
     def test_request_lowercase_boolean(self, m):
         def custom_matcher(request):
-            if 'test=true' in request.text and 'test2=false' in request.text:
+            if "test=true" in request.text and "test2=false" in request.text:
                 resp = requests.Response()
                 resp.status_code = 200
                 return resp
 
         m.add_matcher(custom_matcher)
 
-        response = self.requester.request(
-            'POST',
-            'test',
-            test=True,
-            test2=False
-        )
+        response = self.requester.request("POST", "test", test=True, test2=False)
         self.assertEqual(response.status_code, 200)
 
     def test_request_400(self, m):
-        register_uris({'requests': ['400']}, m)
+        register_uris({"requests": ["400"]}, m)
 
         with self.assertRaises(BadRequest):
-            self.requester.request('GET', '400')
+            self.requester.request("GET", "400")
 
     def test_request_401_InvalidAccessToken(self, m):
-        register_uris({'requests': ['401_invalid_access_token']}, m)
+        register_uris({"requests": ["401_invalid_access_token"]}, m)
 
         with self.assertRaises(InvalidAccessToken):
-            self.requester.request('GET', '401_invalid_access_token')
+            self.requester.request("GET", "401_invalid_access_token")
 
     def test_request_401_Unauthorized(self, m):
-        register_uris({'requests': ['401_unauthorized']}, m)
+        register_uris({"requests": ["401_unauthorized"]}, m)
 
         with self.assertRaises(Unauthorized):
-            self.requester.request('GET', '401_unauthorized')
+            self.requester.request("GET", "401_unauthorized")
 
     def test_request_404(self, m):
-        register_uris({'requests': ['404']}, m)
+        register_uris({"requests": ["404"]}, m)
 
         with self.assertRaises(ResourceDoesNotExist):
-            self.requester.request('GET', '404')
+            self.requester.request("GET", "404")
 
     def test_request_409(self, m):
-        register_uris({'requests': ['409']}, m)
+        register_uris({"requests": ["409"]}, m)
 
         with self.assertRaises(Conflict):
-            self.requester.request('GET', '409')
+            self.requester.request("GET", "409")
 
     def test_request_500(self, m):
-        register_uris({'requests': ['500']}, m)
+        register_uris({"requests": ["500"]}, m)
 
         with self.assertRaises(CanvasException):
-            self.requester.request('GET', '500')
+            self.requester.request("GET", "500")

--- a/tests/test_rubric.py
+++ b/tests/test_rubric.py
@@ -10,14 +10,11 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestGradingStandard(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({
-                'course': ['get_by_id', 'get_rubric_single']
-            }, m)
+            register_uris({"course": ["get_by_id", "get_rubric_single"]}, m)
 
             self.course = self.canvas.get_course(1)
             self.rubric = self.course.get_rubric(1)

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -18,12 +18,11 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestSection(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({'section': ['get_by_id']}, m)
+            register_uris({"section": ["get_by_id"]}, m)
 
             self.section = self.canvas.get_section(1)
 
@@ -34,7 +33,7 @@ class TestSection(unittest.TestCase):
 
     # get_assignment_override
     def test_get_assignment_override(self, m):
-        register_uris({'assignment': ['override_section_alias']}, m)
+        register_uris({"assignment": ["override_section_alias"]}, m)
 
         override = self.section.get_assignment_override(1)
 
@@ -43,7 +42,7 @@ class TestSection(unittest.TestCase):
 
     # get_enrollments()
     def test_get_enrollments(self, m):
-        register_uris({'section': ['list_enrollments', 'list_enrollments_2']}, m)
+        register_uris({"section": ["list_enrollments", "list_enrollments_2"]}, m)
 
         enrollments = self.section.get_enrollments()
         enrollment_list = [enrollment for enrollment in enrollments]
@@ -52,11 +51,7 @@ class TestSection(unittest.TestCase):
         self.assertIsInstance(enrollment_list[0], Enrollment)
 
     def test_cross_list_section(self, m):
-        register_uris(
-            {
-                'course': ['get_by_id_2'],
-                'section': ['crosslist_section']
-            }, m)
+        register_uris({"course": ["get_by_id_2"], "section": ["crosslist_section"]}, m)
 
         section_by_id = self.section.cross_list_section(2)
         self.assertIsInstance(section_by_id, Section)
@@ -66,21 +61,21 @@ class TestSection(unittest.TestCase):
         self.assertIsInstance(section_by_obj, Section)
 
     def test_decross_list_section(self, m):
-        register_uris({'section': ['decross_section']}, m)
+        register_uris({"section": ["decross_section"]}, m)
 
         section = self.section.decross_list_section()
 
         self.assertIsInstance(section, Section)
 
     def test_edit(self, m):
-        register_uris({'section': ['edit']}, m)
+        register_uris({"section": ["edit"]}, m)
 
         edit = self.section.edit()
 
         self.assertIsInstance(edit, Section)
 
     def test_delete(self, m):
-        register_uris({'section': ['delete']}, m)
+        register_uris({"section": ["delete"]}, m)
 
         deleted_section = self.section.delete()
 
@@ -90,19 +85,21 @@ class TestSection(unittest.TestCase):
     def test_submit_assignment(self, m):
         register_uris(
             {
-                'assignment': ['submit'],
-                'submission': ['get_by_id_section'],
-                'user': ['get_by_id', 'get_user_assignments']
-            }, m)
+                "assignment": ["submit"],
+                "submission": ["get_by_id_section"],
+                "user": ["get_by_id", "get_user_assignments"],
+            },
+            m,
+        )
 
         assignment_id = 1
         sub_type = "online_upload"
-        sub_dict = {'submission_type': sub_type}
+        sub_dict = {"submission_type": sub_type}
         with warnings.catch_warnings(record=True) as warning_list:
             assignment_by_id = self.section.submit_assignment(assignment_id, sub_dict)
 
             self.assertIsInstance(assignment_by_id, Submission)
-            self.assertTrue(hasattr(assignment_by_id, 'submission_type'))
+            self.assertTrue(hasattr(assignment_by_id, "submission_type"))
             self.assertEqual(assignment_by_id.submission_type, sub_type)
 
             self.assertEqual(len(warning_list), 1)
@@ -111,12 +108,14 @@ class TestSection(unittest.TestCase):
         user_obj = self.canvas.get_user(1)
         assignments_obj = user_obj.get_assignments(1)
         sub_type = "online_upload"
-        sub_dict = {'submission_type': sub_type}
+        sub_dict = {"submission_type": sub_type}
         with warnings.catch_warnings(record=True) as warning_list:
-            assignment_by_obj = self.section.submit_assignment(assignments_obj[0], sub_dict)
+            assignment_by_obj = self.section.submit_assignment(
+                assignments_obj[0], sub_dict
+            )
 
             self.assertIsInstance(assignment_by_obj, Submission)
-            self.assertTrue(hasattr(assignment_by_obj, 'submission_type'))
+            self.assertTrue(hasattr(assignment_by_obj, "submission_type"))
             self.assertEqual(assignment_by_obj.submission_type, sub_type)
 
             self.assertEqual(len(warning_list), 1)
@@ -133,9 +132,11 @@ class TestSection(unittest.TestCase):
     def test_list_submissions(self, m):
         register_uris(
             {
-                'submission': ['list_submissions'],
-                'user': ['get_by_id', 'get_user_assignments']
-            }, m)
+                "submission": ["list_submissions"],
+                "user": ["get_by_id", "get_user_assignments"],
+            },
+            m,
+        )
 
         assignment_id = 1
         with warnings.catch_warnings(record=True) as warning_list:
@@ -162,7 +163,7 @@ class TestSection(unittest.TestCase):
 
     # list_multiple_submission()
     def test_list_multiple_submissions(self, m):
-        register_uris({'section': ['list_multiple_submissions']}, m)
+        register_uris({"section": ["list_multiple_submissions"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             submissions = self.section.list_multiple_submissions()
@@ -176,7 +177,7 @@ class TestSection(unittest.TestCase):
 
     # get_multiple_submission()
     def test_get_multiple_submissions(self, m):
-        register_uris({'section': ['list_multiple_submissions']}, m)
+        register_uris({"section": ["list_multiple_submissions"]}, m)
 
         submissions = self.section.get_multiple_submissions()
         submission_list = [submission for submission in submissions]
@@ -185,10 +186,10 @@ class TestSection(unittest.TestCase):
         self.assertIsInstance(submission_list[0], Submission)
 
     def test_get_multiple_submissions_grouped_param(self, m):
-        register_uris({'section': ['list_multiple_submissions']}, m)
+        register_uris({"section": ["list_multiple_submissions"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
-            warnings.simplefilter('always')
+            warnings.simplefilter("always")
             submissions = self.section.get_multiple_submissions(grouped=True)
             submission_list = [submission for submission in submissions]
 
@@ -197,7 +198,7 @@ class TestSection(unittest.TestCase):
             self.assertEqual(warning_list[-1].category, UserWarning)
             self.assertEqual(
                 text_type(warning_list[-1].message),
-                'The `grouped` parameter must be empty. Removing kwarg `grouped`.'
+                "The `grouped` parameter must be empty. Removing kwarg `grouped`.",
             )
 
             self.assertEqual(len(submission_list), 2)
@@ -207,9 +208,11 @@ class TestSection(unittest.TestCase):
     def test_get_submission(self, m):
         register_uris(
             {
-                'submission': ['get_by_id_course'],
-                'user': ['get_by_id', 'get_user_assignments']
-            }, m)
+                "submission": ["get_by_id_course"],
+                "user": ["get_by_id", "get_user_assignments"],
+            },
+            m,
+        )
 
         assignment_id = 1
         user_id = 1
@@ -217,7 +220,7 @@ class TestSection(unittest.TestCase):
             submission_by_id = self.section.get_submission(assignment_id, user_id)
 
             self.assertIsInstance(submission_by_id, Submission)
-            self.assertTrue(hasattr(submission_by_id, 'submission_type'))
+            self.assertTrue(hasattr(submission_by_id, "submission_type"))
 
             self.assertEqual(len(warning_list), 1)
             self.assertEqual(warning_list[-1].category, DeprecationWarning)
@@ -225,10 +228,12 @@ class TestSection(unittest.TestCase):
         user_obj = self.canvas.get_user(1)
         assignments_obj = user_obj.get_assignments(1)
         with warnings.catch_warnings(record=True) as warning_list:
-            submission_by_obj = self.section.get_submission(assignments_obj[0], user_obj)
+            submission_by_obj = self.section.get_submission(
+                assignments_obj[0], user_obj
+            )
 
             self.assertIsInstance(submission_by_obj, Submission)
-            self.assertTrue(hasattr(submission_by_obj, 'submission_type'))
+            self.assertTrue(hasattr(submission_by_obj, "submission_type"))
 
             self.assertEqual(len(warning_list), 1)
             self.assertEqual(warning_list[-1].category, DeprecationWarning)
@@ -237,21 +242,21 @@ class TestSection(unittest.TestCase):
     def test_update_submission(self, m):
         register_uris(
             {
-                'submission': ['get_by_id_section', 'edit'],
-                'user': ['get_by_id', 'get_user_assignments']
-            }, m)
+                "submission": ["get_by_id_section", "edit"],
+                "user": ["get_by_id", "get_user_assignments"],
+            },
+            m,
+        )
 
         assignment_id = 1
         user_id = 1
         with warnings.catch_warnings(record=True) as warning_list:
             submission_by_id = self.section.update_submission(
-                assignment_id,
-                user_id,
-                submission={'excuse': True}
+                assignment_id, user_id, submission={"excuse": True}
             )
 
             self.assertIsInstance(submission_by_id, Submission)
-            self.assertTrue(hasattr(submission_by_id, 'excused'))
+            self.assertTrue(hasattr(submission_by_id, "excused"))
 
             self.assertEqual(len(warning_list), 1)
             self.assertEqual(warning_list[-1].category, DeprecationWarning)
@@ -261,13 +266,11 @@ class TestSection(unittest.TestCase):
 
         with warnings.catch_warnings(record=True) as warning_list:
             submission_by_obj = self.section.update_submission(
-                assignments_obj[0],
-                user_obj,
-                submission={'excuse': True}
+                assignments_obj[0], user_obj, submission={"excuse": True}
             )
 
             self.assertIsInstance(submission_by_obj, Submission)
-            self.assertTrue(hasattr(submission_by_obj, 'excused'))
+            self.assertTrue(hasattr(submission_by_obj, "excused"))
 
             self.assertEqual(len(warning_list), 1)
             self.assertEqual(warning_list[-1].category, DeprecationWarning)
@@ -276,15 +279,19 @@ class TestSection(unittest.TestCase):
     def test_mark_submission_as_read(self, m):
         register_uris(
             {
-                'course': ['mark_submission_as_read'],
-                'submission': ['get_by_id_section'],
-                'user': ['get_by_id', 'get_user_assignments']
-            }, m)
+                "course": ["mark_submission_as_read"],
+                "submission": ["get_by_id_section"],
+                "user": ["get_by_id", "get_user_assignments"],
+            },
+            m,
+        )
 
         submission_id = 1
         user_id = 1
         with warnings.catch_warnings(record=True) as warning_list:
-            submission_by_id = self.section.mark_submission_as_read(submission_id, user_id)
+            submission_by_id = self.section.mark_submission_as_read(
+                submission_id, user_id
+            )
 
             self.assertTrue(submission_by_id)
 
@@ -294,7 +301,9 @@ class TestSection(unittest.TestCase):
         user_obj = self.canvas.get_user(1)
         with warnings.catch_warnings(record=True) as warning_list:
             assignments_obj = user_obj.get_assignments(1)
-            submission_by_obj = self.section.mark_submission_as_read(assignments_obj[0], user_obj)
+            submission_by_obj = self.section.mark_submission_as_read(
+                assignments_obj[0], user_obj
+            )
 
             self.assertTrue(submission_by_obj)
 
@@ -305,15 +314,19 @@ class TestSection(unittest.TestCase):
     def test_mark_submission_as_unread(self, m):
         register_uris(
             {
-                'course': ['mark_submission_as_unread'],
-                'submission': ['get_by_id_section'],
-                'user': ['get_by_id', 'get_user_assignments']
-            }, m)
+                "course": ["mark_submission_as_unread"],
+                "submission": ["get_by_id_section"],
+                "user": ["get_by_id", "get_user_assignments"],
+            },
+            m,
+        )
 
         user_id = 1
         assignment_id = 1
         with warnings.catch_warnings(record=True) as warning_list:
-            submission_by_id = self.section.mark_submission_as_unread(assignment_id, user_id)
+            submission_by_id = self.section.mark_submission_as_unread(
+                assignment_id, user_id
+            )
             self.assertTrue(submission_by_id)
 
             self.assertEqual(len(warning_list), 1)
@@ -323,8 +336,7 @@ class TestSection(unittest.TestCase):
         assignments_obj = user_obj.get_assignments(1)
         with warnings.catch_warnings(record=True) as warning_list:
             submission_by_obj = self.section.mark_submission_as_unread(
-                assignments_obj[0],
-                user_obj
+                assignments_obj[0], user_obj
             )
             self.assertTrue(submission_by_obj)
 
@@ -332,18 +344,11 @@ class TestSection(unittest.TestCase):
             self.assertEqual(warning_list[-1].category, DeprecationWarning)
 
     def test_submissions_bulk_update(self, m):
-        register_uris({'section': ['update_submissions']}, m)
-        register_uris({'progress': ['course_progress']}, m)
-        progress = self.section.submissions_bulk_update(grade_data={
-            '1': {
-                '1': {
-                    'posted_grade': 97
-                },
-                '2': {
-                    'posted_grade': 98
-                }
-            }
-        })
+        register_uris({"section": ["update_submissions"]}, m)
+        register_uris({"progress": ["course_progress"]}, m)
+        progress = self.section.submissions_bulk_update(
+            grade_data={"1": {"1": {"posted_grade": 97}, "2": {"posted_grade": 98}}}
+        )
         self.assertIsInstance(progress, Progress)
         self.assertTrue(progress.context_type == "Course")
         progress = progress.query()

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -13,16 +13,18 @@ from tests.util import cleanup_file, register_uris
 
 @requests_mock.Mocker()
 class TestSubmission(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({
-                'course': ['get_by_id', 'get_assignment_by_id'],
-                'section': ['get_by_id'],
-                'submission': ['get_by_id_course', 'get_by_id_section']
-            }, m)
+            register_uris(
+                {
+                    "course": ["get_by_id", "get_assignment_by_id"],
+                    "section": ["get_by_id"],
+                    "submission": ["get_by_id_course", "get_by_id_section"],
+                },
+                m,
+            )
 
             with warnings.catch_warnings(record=True) as warning_list:
                 self.course = self.canvas.get_course(1)
@@ -42,53 +44,47 @@ class TestSubmission(unittest.TestCase):
 
     # edit()
     def test_edit(self, m):
-        register_uris({
-            'submission': ['edit']
-        }, m)
+        register_uris({"submission": ["edit"]}, m)
 
-        self.assertFalse(hasattr(self.submission_course, 'excused'))
+        self.assertFalse(hasattr(self.submission_course, "excused"))
 
-        self.submission_course.edit(submission={'excuse': True})
+        self.submission_course.edit(submission={"excuse": True})
 
         self.assertIsInstance(self.submission_course, Submission)
-        self.assertTrue(hasattr(self.submission_course, 'excused'))
+        self.assertTrue(hasattr(self.submission_course, "excused"))
         self.assertTrue(self.submission_course.excused)
 
     # upload_comment()
     def test_upload_comment(self, m):
-        register_uris({'submission': [
-            'upload_comment',
-            'upload_comment_final',
-            'edit',
-        ]}, m)
+        register_uris(
+            {"submission": ["upload_comment", "upload_comment_final", "edit"]}, m
+        )
 
-        filename = 'testfile_submission_{}'.format(uuid.uuid4().hex)
+        filename = "testfile_submission_{}".format(uuid.uuid4().hex)
 
         try:
-            with open(filename, 'w+') as file:
+            with open(filename, "w+") as file:
                 response = self.submission_course.upload_comment(file)
 
             self.assertTrue(response[0])
             self.assertIsInstance(response[1], dict)
-            self.assertIn('url', response[1])
+            self.assertIn("url", response[1])
         finally:
             cleanup_file(filename)
 
     def test_upload_comment_section(self, m):
-        register_uris({'submission': [
-            'upload_comment',
-            'upload_comment_final',
-            'edit',
-        ]}, m)
+        register_uris(
+            {"submission": ["upload_comment", "upload_comment_final", "edit"]}, m
+        )
 
-        filename = 'testfile_submission_{}'.format(uuid.uuid4().hex)
+        filename = "testfile_submission_{}".format(uuid.uuid4().hex)
 
         try:
-            with open(filename, 'w+') as file:
+            with open(filename, "w+") as file:
                 response = self.submission_section.upload_comment(file)
 
             self.assertTrue(response[0])
             self.assertIsInstance(response[1], dict)
-            self.assertIn('url', response[1])
+            self.assertIn("url", response[1])
         finally:
             cleanup_file(filename)

--- a/tests/test_tab.py
+++ b/tests/test_tab.py
@@ -11,15 +11,17 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestTab(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({
-                'course': ['get_by_id', 'list_tabs'],
-                'group': ['get_by_id', 'list_tabs']
-            }, m)
+            register_uris(
+                {
+                    "course": ["get_by_id", "list_tabs"],
+                    "group": ["get_by_id", "list_tabs"],
+                },
+                m,
+            )
 
             self.course = self.canvas.get_course(1)
 
@@ -37,7 +39,7 @@ class TestTab(unittest.TestCase):
 
     # update()
     def test_update_course(self, m):
-        register_uris({'course': ['update_tab']}, m)
+        register_uris({"course": ["update_tab"]}, m)
 
         new_position = 3
         self.tab.update(position=new_position)

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -12,13 +12,12 @@ from tests.util import cleanup_file, register_uris
 
 @requests_mock.Mocker()
 class TestUploader(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
         self.requester = self.canvas._Canvas__requester
 
-        self.filename = 'testfile_uploader_{}'.format(uuid.uuid4().hex)
-        self.file = open(self.filename, 'w+')
+        self.filename = "testfile_uploader_{}".format(uuid.uuid4().hex)
+        self.file = open(self.filename, "w+")
 
     def tearDown(self):
         self.file.close()
@@ -26,57 +25,55 @@ class TestUploader(unittest.TestCase):
 
     # start()
     def test_start(self, m):
-        requires = {
-            'uploader': ['upload_response', 'upload_response_upload_url']
-        }
+        requires = {"uploader": ["upload_response", "upload_response_upload_url"]}
         register_uris(requires, m)
 
-        uploader = Uploader(self.requester, 'upload_response', self.file)
+        uploader = Uploader(self.requester, "upload_response", self.file)
         result = uploader.start()
 
         self.assertTrue(result[0])
         self.assertIsInstance(result[1], dict)
-        self.assertIn('url', result[1])
+        self.assertIn("url", result[1])
 
     def test_start_path(self, m):
-        requires = {
-            'uploader': ['upload_response', 'upload_response_upload_url']
-        }
+        requires = {"uploader": ["upload_response", "upload_response_upload_url"]}
         register_uris(requires, m)
 
-        uploader = Uploader(self.requester, 'upload_response', self.filename)
+        uploader = Uploader(self.requester, "upload_response", self.filename)
         result = uploader.start()
 
         self.assertTrue(result[0])
         self.assertIsInstance(result[1], dict)
-        self.assertIn('url', result[1])
+        self.assertIn("url", result[1])
 
     def test_start_file_does_not_exist(self, m):
         with self.assertRaises(IOError):
-            Uploader(self.requester, 'upload_response', 'test_file_not_real.xyz')
+            Uploader(self.requester, "upload_response", "test_file_not_real.xyz")
 
     # upload()
     def test_upload_no_upload_url(self, m):
-        register_uris({'uploader': ['upload_response_no_upload_url']}, m)
+        register_uris({"uploader": ["upload_response_no_upload_url"]}, m)
 
         with self.assertRaises(ValueError):
-            Uploader(self.requester, 'upload_response_no_upload_url', self.filename).start()
+            Uploader(
+                self.requester, "upload_response_no_upload_url", self.filename
+            ).start()
 
     def test_upload_no_upload_params(self, m):
-        register_uris({'uploader': ['upload_response_no_upload_params']}, m)
+        register_uris({"uploader": ["upload_response_no_upload_params"]}, m)
 
         with self.assertRaises(ValueError):
-            Uploader(self.requester, 'upload_response_no_upload_params', self.filename).start()
+            Uploader(
+                self.requester, "upload_response_no_upload_params", self.filename
+            ).start()
 
     def test_upload_fail(self, m):
-        requires = {
-            'uploader': ['upload_fail', 'upload_response_fail']
-        }
+        requires = {"uploader": ["upload_fail", "upload_response_fail"]}
         register_uris(requires, m)
 
-        uploader = Uploader(self.requester, 'upload_response_fail', self.file)
+        uploader = Uploader(self.requester, "upload_response_fail", self.file)
         result = uploader.start()
 
         self.assertFalse(result[0])
         self.assertIsInstance(result[1], dict)
-        self.assertNotIn('url', result[1])
+        self.assertNotIn("url", result[1])

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -24,12 +24,11 @@ from tests.util import cleanup_file, register_uris
 
 @requests_mock.Mocker()
 class TestUser(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({'user': ['get_by_id']}, m)
+            register_uris({"user": ["get_by_id"]}, m)
 
             self.user = self.canvas.get_user(1)
 
@@ -40,16 +39,16 @@ class TestUser(unittest.TestCase):
 
     # get_profile()
     def test_get_profile(self, m):
-        register_uris({'user': ['profile']}, m)
+        register_uris({"user": ["profile"]}, m)
 
         profile = self.user.get_profile()
 
         self.assertIsInstance(profile, dict)
-        self.assertIn('name', profile)
+        self.assertIn("name", profile)
 
     # get_page_views()
     def test_get_page_views(self, m):
-        register_uris({'user': ['page_views', 'page_views_p2']}, m)
+        register_uris({"user": ["page_views", "page_views_p2"]}, m)
 
         page_views = self.user.get_page_views()
         page_view_list = [view for view in page_views]
@@ -59,7 +58,7 @@ class TestUser(unittest.TestCase):
 
     # get_courses()
     def test_get_courses(self, m):
-        register_uris({'user': ['courses', 'courses_p2']}, m)
+        register_uris({"user": ["courses", "courses_p2"]}, m)
 
         courses = self.user.get_courses()
         course_list = [course for course in courses]
@@ -69,7 +68,7 @@ class TestUser(unittest.TestCase):
 
     # get_missing_submissions()
     def test_get_missing_submissions(self, m):
-        register_uris({'user': ['missing_sub', 'missing_sub_p2']}, m)
+        register_uris({"user": ["missing_sub", "missing_sub_p2"]}, m)
 
         missing_assigments = self.user.get_missing_submissions()
         assignment_list = [assignment for assignment in missing_assigments]
@@ -79,89 +78,89 @@ class TestUser(unittest.TestCase):
 
     # update_settings()
     def test_update_settings(self, m):
-        register_uris({'user': ['update_settings']}, m)
+        register_uris({"user": ["update_settings"]}, m)
 
         settings = self.user.update_settings(manual_mark_as_read=True)
 
         self.assertIsInstance(settings, dict)
-        self.assertIn('manual_mark_as_read', settings)
-        self.assertTrue(settings['manual_mark_as_read'])
+        self.assertIn("manual_mark_as_read", settings)
+        self.assertTrue(settings["manual_mark_as_read"])
 
     # get_color()
     def test_get_color(self, m):
-        register_uris({'user': ['color']}, m)
+        register_uris({"user": ["color"]}, m)
 
         color = self.user.get_color("course_1")
 
         self.assertIsInstance(color, dict)
-        self.assertIn('hexcode', color)
-        self.assertEqual(color['hexcode'], "#abc123")
+        self.assertIn("hexcode", color)
+        self.assertEqual(color["hexcode"], "#abc123")
 
     # get_colors()
     def test_get_colors(self, m):
-        register_uris({'user': ['colors']}, m)
+        register_uris({"user": ["colors"]}, m)
 
         colors = self.user.get_colors()
 
         self.assertIsInstance(colors, dict)
-        self.assertIn('custom_colors', colors)
-        self.assertIsInstance(colors['custom_colors'], dict)
+        self.assertIn("custom_colors", colors)
+        self.assertIsInstance(colors["custom_colors"], dict)
 
     # update_color()
     def test_update_color(self, m):
-        register_uris({'user': ['color_update']}, m)
+        register_uris({"user": ["color_update"]}, m)
 
         new_hexcode = "#f00f00"
         color = self.user.update_color("course_1", new_hexcode)
 
         self.assertIsInstance(color, dict)
-        self.assertIn('hexcode', color)
-        self.assertEqual(color['hexcode'], new_hexcode)
+        self.assertIn("hexcode", color)
+        self.assertEqual(color["hexcode"], new_hexcode)
 
     def test_update_color_no_hashtag(self, m):
-        register_uris({'user': ['color_update']}, m)
+        register_uris({"user": ["color_update"]}, m)
 
         new_hexcode = "f00f00"
         color = self.user.update_color("course_1", new_hexcode)
 
         self.assertIsInstance(color, dict)
-        self.assertIn('hexcode', color)
-        self.assertEqual(color['hexcode'], "#" + new_hexcode)
+        self.assertIn("hexcode", color)
+        self.assertEqual(color["hexcode"], "#" + new_hexcode)
 
     # edit()
     def test_edit(self, m):
-        register_uris({'user': ['edit']}, m)
+        register_uris({"user": ["edit"]}, m)
 
         new_name = "New User Name"
-        self.user.edit(user={'name': new_name})
+        self.user.edit(user={"name": new_name})
 
         self.assertIsInstance(self.user, User)
-        self.assertTrue(hasattr(self.user, 'name'))
+        self.assertTrue(hasattr(self.user, "name"))
         self.assertEqual(self.user.name, new_name)
 
     # merge_into()
     def test_merge_into_id(self, m):
-        register_uris({'user': ['merge']}, m)
+        register_uris({"user": ["merge"]}, m)
 
         self.user.merge_into(2)
 
         self.assertIsInstance(self.user, User)
-        self.assertTrue(hasattr(self.user, 'name'))
-        self.assertEqual(self.user.name, 'John Smith')
+        self.assertTrue(hasattr(self.user, "name"))
+        self.assertEqual(self.user.name, "John Smith")
 
     def test_merge_into_user(self, m):
-        register_uris({'user': ['get_by_id_2', 'merge']}, m)
+        register_uris({"user": ["get_by_id_2", "merge"]}, m)
 
         other_user = self.canvas.get_user(2)
         self.user.merge_into(other_user)
 
         self.assertIsInstance(self.user, User)
-        self.assertTrue(hasattr(self.user, 'name'))
-        self.assertEqual(self.user.name, 'John Smith')
+        self.assertTrue(hasattr(self.user, "name"))
+        self.assertEqual(self.user.name, "John Smith")
 
     # get_avatars()
     def test_get_avatars(self, m):
-        register_uris({'user': ['avatars', 'avatars_p2']}, m)
+        register_uris({"user": ["avatars", "avatars_p2"]}, m)
 
         avatars = self.user.get_avatars()
         avatar_list = [avatar for avatar in avatars]
@@ -173,9 +172,11 @@ class TestUser(unittest.TestCase):
     def test_user_get_assignments(self, m):
         register_uris(
             {
-                'course': ['get_by_id'],
-                'user': ['get_user_assignments', 'get_user_assignments2']
-            }, m)
+                "course": ["get_by_id"],
+                "user": ["get_user_assignments", "get_user_assignments2"],
+            },
+            m,
+        )
 
         assignments_by_id = self.user.get_assignments(1)
         assignment_list = [assignment for assignment in assignments_by_id]
@@ -190,7 +191,7 @@ class TestUser(unittest.TestCase):
 
     # get_enrollments()
     def test_get_enrollments(self, m):
-        register_uris({'user': ['list_enrollments', 'list_enrollments_2']}, m)
+        register_uris({"user": ["list_enrollments", "list_enrollments_2"]}, m)
 
         enrollments = self.user.get_enrollments()
         enrollment_list = [enrollment for enrollment in enrollments]
@@ -200,23 +201,23 @@ class TestUser(unittest.TestCase):
 
     # upload()
     def test_upload(self, m):
-        register_uris({'user': ['upload', 'upload_final']}, m)
+        register_uris({"user": ["upload", "upload_final"]}, m)
 
-        filename = 'testfile_user_{}'.format(uuid.uuid4().hex)
+        filename = "testfile_user_{}".format(uuid.uuid4().hex)
 
         try:
-            with open(filename, 'w+') as file:
+            with open(filename, "w+") as file:
                 response = self.user.upload(file)
 
             self.assertTrue(response[0])
             self.assertIsInstance(response[1], dict)
-            self.assertIn('url', response[1])
+            self.assertIn("url", response[1])
         finally:
             cleanup_file(filename)
 
     # list_calendar_events_for_user()
     def test_list_calendar_events_for_user(self, m):
-        register_uris({'user': ['list_calendar_events_for_user']}, m)
+        register_uris({"user": ["list_calendar_events_for_user"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             cal_events = self.user.list_calendar_events_for_user()
@@ -229,7 +230,7 @@ class TestUser(unittest.TestCase):
 
     # get_calendar_events_for_user()
     def test_get_calendar_events_for_user(self, m):
-        register_uris({'user': ['list_calendar_events_for_user']}, m)
+        register_uris({"user": ["list_calendar_events_for_user"]}, m)
 
         cal_events = self.user.get_calendar_events_for_user()
         cal_event_list = [cal_event for cal_event in cal_events]
@@ -238,7 +239,7 @@ class TestUser(unittest.TestCase):
 
     # list_communication_channels()
     def test_list_communication_channels(self, m):
-        register_uris({'user': ['list_comm_channels', 'list_comm_channels2']}, m)
+        register_uris({"user": ["list_comm_channels", "list_comm_channels2"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             comm_channels = self.user.list_communication_channels()
@@ -251,7 +252,7 @@ class TestUser(unittest.TestCase):
 
     # get_communication_channels()
     def test_get_communication_channels(self, m):
-        register_uris({'user': ['list_comm_channels', 'list_comm_channels2']}, m)
+        register_uris({"user": ["list_comm_channels", "list_comm_channels2"]}, m)
 
         comm_channels = self.user.get_communication_channels()
         channel_list = [channel for channel in comm_channels]
@@ -260,7 +261,7 @@ class TestUser(unittest.TestCase):
 
     # list_files()
     def test_list_files(self, m):
-        register_uris({'user': ['get_user_files', 'get_user_files2']}, m)
+        register_uris({"user": ["get_user_files", "get_user_files2"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             files = self.user.list_files()
@@ -273,7 +274,7 @@ class TestUser(unittest.TestCase):
 
     # get_files()
     def test_get_files(self, m):
-        register_uris({'user': ['get_user_files', 'get_user_files2']}, m)
+        register_uris({"user": ["get_user_files", "get_user_files2"]}, m)
 
         files = self.user.get_files()
         file_list = [file for file in files]
@@ -282,21 +283,21 @@ class TestUser(unittest.TestCase):
 
     # get_file()
     def test_get_file(self, m):
-        register_uris({'user': ['get_file']}, m)
+        register_uris({"user": ["get_file"]}, m)
 
         file_by_id = self.user.get_file(1)
         self.assertIsInstance(file_by_id, File)
-        self.assertEqual(file_by_id.display_name, 'User_File.docx')
+        self.assertEqual(file_by_id.display_name, "User_File.docx")
         self.assertEqual(file_by_id.size, 1024)
 
         file_by_obj = self.user.get_file(file_by_id)
         self.assertIsInstance(file_by_obj, File)
-        self.assertEqual(file_by_obj.display_name, 'User_File.docx')
+        self.assertEqual(file_by_obj.display_name, "User_File.docx")
         self.assertEqual(file_by_obj.size, 1024)
 
     # get_folder()
     def test_get_folder(self, m):
-        register_uris({'user': ['get_folder']}, m)
+        register_uris({"user": ["get_folder"]}, m)
 
         folder_by_id = self.user.get_folder(1)
         self.assertEqual(folder_by_id.name, "Folder 1")
@@ -308,7 +309,7 @@ class TestUser(unittest.TestCase):
 
     # list_folders()
     def test_list_folders(self, m):
-        register_uris({'user': ['list_folders']}, m)
+        register_uris({"user": ["list_folders"]}, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
             folders = self.user.list_folders()
@@ -321,7 +322,7 @@ class TestUser(unittest.TestCase):
 
     # get_folders()
     def test_get_folders(self, m):
-        register_uris({'user': ['list_folders']}, m)
+        register_uris({"user": ["list_folders"]}, m)
 
         folders = self.user.get_folders()
         folder_list = [folder for folder in folders]
@@ -330,7 +331,7 @@ class TestUser(unittest.TestCase):
 
     # create_folder()
     def test_create_folder(self, m):
-        register_uris({'user': ['create_folder']}, m)
+        register_uris({"user": ["create_folder"]}, m)
 
         name_str = "Test String"
         response = self.user.create_folder(name=name_str)
@@ -338,7 +339,7 @@ class TestUser(unittest.TestCase):
 
     # list_user_logins()
     def test_list_user_logins(self, m):
-        requires = {'user': ['list_user_logins', 'list_user_logins_2']}
+        requires = {"user": ["list_user_logins", "list_user_logins_2"]}
         register_uris(requires, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
@@ -353,7 +354,7 @@ class TestUser(unittest.TestCase):
 
     # get_user_logins()
     def test_get_user_logins(self, m):
-        requires = {'user': ['list_user_logins', 'list_user_logins_2']}
+        requires = {"user": ["list_user_logins", "list_user_logins_2"]}
         register_uris(requires, m)
 
         response = self.user.get_user_logins()
@@ -364,7 +365,7 @@ class TestUser(unittest.TestCase):
 
     # list_observees()
     def test_list_observees(self, m):
-        requires = {'user': ['list_observees', 'list_observees_2']}
+        requires = {"user": ["list_observees", "list_observees_2"]}
         register_uris(requires, m)
 
         with warnings.catch_warnings(record=True) as warning_list:
@@ -379,7 +380,7 @@ class TestUser(unittest.TestCase):
 
     # get_observees()
     def test_get_observees(self, m):
-        requires = {'user': ['list_observees', 'list_observees_2']}
+        requires = {"user": ["list_observees", "list_observees_2"]}
         register_uris(requires, m)
 
         response = self.user.get_observees()
@@ -390,7 +391,7 @@ class TestUser(unittest.TestCase):
 
     # add_observee_with_credentials()
     def test_add_observee_with_credentials(self, m):
-        register_uris({'user': ['add_observee_with_credentials']}, m)
+        register_uris({"user": ["add_observee_with_credentials"]}, m)
 
         response = self.user.add_observee_with_credentials()
 
@@ -398,7 +399,7 @@ class TestUser(unittest.TestCase):
 
     # show_observee()
     def test_show_observee(self, m):
-        register_uris({'user': ['show_observee']}, m)
+        register_uris({"user": ["show_observee"]}, m)
 
         response = self.user.show_observee(6)
 
@@ -406,7 +407,7 @@ class TestUser(unittest.TestCase):
 
     # add_observee()
     def test_add_observee(self, m):
-        register_uris({'user': ['add_observee']}, m)
+        register_uris({"user": ["add_observee"]}, m)
 
         response = self.user.add_observee(7)
 
@@ -414,7 +415,7 @@ class TestUser(unittest.TestCase):
 
     # remove_observee()
     def test_remove_observee(self, m):
-        register_uris({'user': ['remove_observee']}, m)
+        register_uris({"user": ["remove_observee"]}, m)
 
         response = self.user.remove_observee(8)
 
@@ -422,41 +423,42 @@ class TestUser(unittest.TestCase):
 
     # create_content_migration
     def test_create_content_migration(self, m):
-        register_uris({'user': ['create_content_migration']}, m)
+        register_uris({"user": ["create_content_migration"]}, m)
 
-        content_migration = self.user.create_content_migration('dummy_importer')
+        content_migration = self.user.create_content_migration("dummy_importer")
 
         self.assertIsInstance(content_migration, ContentMigration)
-        self.assertTrue(hasattr(content_migration, 'migration_type'))
+        self.assertTrue(hasattr(content_migration, "migration_type"))
 
     def test_create_content_migration_migrator(self, m):
-        register_uris({'user': ['create_content_migration',
-                                'get_migration_systems_multiple']}, m)
+        register_uris(
+            {"user": ["create_content_migration", "get_migration_systems_multiple"]}, m
+        )
 
         migrators = self.user.get_migration_systems()
         content_migration = self.user.create_content_migration(migrators[0])
 
         self.assertIsInstance(content_migration, ContentMigration)
-        self.assertTrue(hasattr(content_migration, 'migration_type'))
+        self.assertTrue(hasattr(content_migration, "migration_type"))
 
     def test_create_content_migration_bad_migration_type(self, m):
-        register_uris({'user': ['create_content_migration']}, m)
+        register_uris({"user": ["create_content_migration"]}, m)
 
         with self.assertRaises(TypeError):
             self.user.create_content_migration(1)
 
     # get_content_migration
     def test_get_content_migration(self, m):
-        register_uris({'user': ['get_content_migration_single']}, m)
+        register_uris({"user": ["get_content_migration_single"]}, m)
 
         content_migration = self.user.get_content_migration(1)
 
         self.assertIsInstance(content_migration, ContentMigration)
-        self.assertTrue(hasattr(content_migration, 'migration_type'))
+        self.assertTrue(hasattr(content_migration, "migration_type"))
 
     # get_content_migrations
     def test_get_content_migrations(self, m):
-        register_uris({'user': ['get_content_migration_multiple']}, m)
+        register_uris({"user": ["get_content_migration_multiple"]}, m)
 
         content_migrations = self.user.get_content_migrations()
 
@@ -471,7 +473,7 @@ class TestUser(unittest.TestCase):
 
     # get_migration_systems
     def test_get_migration_systems(self, m):
-        register_uris({'user': ['get_migration_systems_multiple']}, m)
+        register_uris({"user": ["get_migration_systems_multiple"]}, m)
 
         migration_systems = self.user.get_migration_systems()
 
@@ -489,14 +491,20 @@ class TestUser(unittest.TestCase):
 
 @requests_mock.Mocker()
 class TestUserDisplay(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
         with requests_mock.Mocker() as m:
-            register_uris({
-                'course': ['get_by_id', 'get_assignment_by_id', 'list_gradeable_students']
-            }, m)
+            register_uris(
+                {
+                    "course": [
+                        "get_by_id",
+                        "get_assignment_by_id",
+                        "list_gradeable_students",
+                    ]
+                },
+                m,
+            )
 
             self.course = self.canvas.get_course(1)
             self.assignment = self.course.get_assignment(1)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -7,7 +7,10 @@ from canvasapi import Canvas
 from canvasapi.course import CourseNickname
 from canvasapi.user import User
 from canvasapi.util import (
-    combine_kwargs, get_institution_url, is_multivalued, obj_or_id
+    combine_kwargs,
+    get_institution_url,
+    is_multivalued,
+    obj_or_id,
 )
 from itertools import chain
 from six import integer_types, iterkeys, itervalues, iteritems, text_type
@@ -18,7 +21,6 @@ from tests.util import register_uris
 
 @requests_mock.Mocker()
 class TestUtil(unittest.TestCase):
-
     def setUp(self):
         self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
 
@@ -31,53 +33,54 @@ class TestUtil(unittest.TestCase):
             self.assertFalse(is_multivalued(type(1)))
 
     def test_is_multivalued_str(self, m):
-        self.assertFalse(is_multivalued('string'))
+        self.assertFalse(is_multivalued("string"))
 
     def test_is_multivalued_unicode(self, m):
-        self.assertFalse(is_multivalued(u'unicode'))
+        self.assertFalse(is_multivalued("unicode"))
 
     def test_is_multivalued_bytes(self, m):
-        self.assertFalse(is_multivalued(b'bytes'))
+        self.assertFalse(is_multivalued(b"bytes"))
 
     def test_is_multivalued_list(self, m):
-        self.assertTrue(is_multivalued(['item']))
+        self.assertTrue(is_multivalued(["item"]))
 
     def test_is_multivalued_list_iter(self, m):
-        self.assertTrue(is_multivalued(iter(['item'])))
+        self.assertTrue(is_multivalued(iter(["item"])))
 
     def test_is_multivalued_tuple(self, m):
-        self.assertTrue(is_multivalued(('item',)))
+        self.assertTrue(is_multivalued(("item",)))
 
     def test_is_multivalued_tuple_iter(self, m):
-        self.assertTrue(is_multivalued(iter(('item',))))
+        self.assertTrue(is_multivalued(iter(("item",))))
 
     def test_is_multivalued_set(self, m):
-        self.assertTrue(is_multivalued({'element'}))
+        self.assertTrue(is_multivalued({"element"}))
 
     def test_is_multivalued_set_iter(self, m):
-        self.assertTrue(is_multivalued(iter({'element'})))
+        self.assertTrue(is_multivalued(iter({"element"})))
 
     def test_is_multivalued_dict(self, m):
-        self.assertTrue(is_multivalued({'key': 'value'}))
+        self.assertTrue(is_multivalued({"key": "value"}))
 
     def test_is_multivalued_dict_iter(self, m):
-        self.assertTrue(is_multivalued(iter({'key': 'value'})))
+        self.assertTrue(is_multivalued(iter({"key": "value"})))
 
     def test_is_multivalued_dict_keys(self, m):
-        self.assertTrue(is_multivalued(iterkeys({'key': 'value'})))
+        self.assertTrue(is_multivalued(iterkeys({"key": "value"})))
 
     def test_is_multivalued_dict_values(self, m):
-        self.assertTrue(is_multivalued(itervalues({'key': 'value'})))
+        self.assertTrue(is_multivalued(itervalues({"key": "value"})))
 
     def test_is_multivalued_dict_items(self, m):
-        self.assertTrue(is_multivalued(iteritems({'key': 'value'})))
+        self.assertTrue(is_multivalued(iteritems({"key": "value"})))
 
     def test_is_multivalued_generator_expr(self, m):
-        self.assertTrue(is_multivalued(item for item in ('item',)))
+        self.assertTrue(is_multivalued(item for item in ("item",)))
 
     def test_is_multivalued_generator_call(self, m):
         def yielder():
-            yield 'item'
+            yield "item"
+
         self.assertTrue(is_multivalued(yielder()))
 
     def test_is_multivalued_chain(self, m):
@@ -94,16 +97,16 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(len(result), 0)
 
     def test_combine_kwargs_single(self, m):
-        result = combine_kwargs(var='test')
+        result = combine_kwargs(var="test")
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 1)
-        self.assertIn(('var', 'test'), result)
+        self.assertIn(("var", "test"), result)
 
     def test_combine_kwargs_single_dict(self, m):
-        result = combine_kwargs(var={'foo': 'bar'})
+        result = combine_kwargs(var={"foo": "bar"})
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 1)
-        self.assertIn(('var[foo]', 'bar'), result)
+        self.assertIn(("var[foo]", "bar"), result)
 
     def test_combine_kwargs_single_list_empty(self, m):
         result = combine_kwargs(var=[])
@@ -111,27 +114,27 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(len(result), 0)
 
     def test_combine_kwargs_single_list_single_item(self, m):
-        result = combine_kwargs(var=['test'])
+        result = combine_kwargs(var=["test"])
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 1)
-        self.assertIn(('var[]', 'test'), result)
+        self.assertIn(("var[]", "test"), result)
 
     def test_combine_kwargs_single_list_multiple_items(self, m):
-        result = combine_kwargs(foo=['bar1', 'bar2', 'bar3', 'bar4'])
+        result = combine_kwargs(foo=["bar1", "bar2", "bar3", "bar4"])
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 4)
 
-        self.assertIn(('foo[]', 'bar1'), result)
-        self.assertIn(('foo[]', 'bar2'), result)
-        self.assertIn(('foo[]', 'bar3'), result)
-        self.assertIn(('foo[]', 'bar4'), result)
+        self.assertIn(("foo[]", "bar1"), result)
+        self.assertIn(("foo[]", "bar2"), result)
+        self.assertIn(("foo[]", "bar3"), result)
+        self.assertIn(("foo[]", "bar4"), result)
 
         # Ensure kwargs are in correct order
         self.assertTrue(
-            result.index(('foo[]', 'bar1'))
-            < result.index(('foo[]', 'bar2'))
-            < result.index(('foo[]', 'bar3'))
-            < result.index(('foo[]', 'bar4'))
+            result.index(("foo[]", "bar1"))
+            < result.index(("foo[]", "bar2"))
+            < result.index(("foo[]", "bar3"))
+            < result.index(("foo[]", "bar4"))
         )
 
     def test_combine_kwargs_single_generator_empty(self, m):
@@ -140,329 +143,291 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(len(result), 0)
 
     def test_combine_kwargs_single_generator_single_item(self, m):
-        result = combine_kwargs(var=(value for value in ('test',)))
+        result = combine_kwargs(var=(value for value in ("test",)))
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 1)
-        self.assertIn(('var[]', 'test'), result)
+        self.assertIn(("var[]", "test"), result)
 
     def test_combine_kwargs_single_generator_multiple_items(self, m):
-        result = combine_kwargs(foo=(value for value in ('bar1', 'bar2', 'bar3', 'bar4')))
+        result = combine_kwargs(
+            foo=(value for value in ("bar1", "bar2", "bar3", "bar4"))
+        )
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 4)
 
-        self.assertIn(('foo[]', 'bar1'), result)
-        self.assertIn(('foo[]', 'bar2'), result)
-        self.assertIn(('foo[]', 'bar3'), result)
-        self.assertIn(('foo[]', 'bar4'), result)
+        self.assertIn(("foo[]", "bar1"), result)
+        self.assertIn(("foo[]", "bar2"), result)
+        self.assertIn(("foo[]", "bar3"), result)
+        self.assertIn(("foo[]", "bar4"), result)
 
         # Ensure kwargs are in correct order
         self.assertTrue(
-            result.index(('foo[]', 'bar1'))
-            < result.index(('foo[]', 'bar2'))
-            < result.index(('foo[]', 'bar3'))
-            < result.index(('foo[]', 'bar4'))
+            result.index(("foo[]", "bar1"))
+            < result.index(("foo[]", "bar2"))
+            < result.index(("foo[]", "bar3"))
+            < result.index(("foo[]", "bar4"))
         )
 
     def test_combine_kwargs_multiple_dicts(self, m):
-        result = combine_kwargs(
-            var1={'foo': 'bar'},
-            var2={'fizz': 'buzz'}
-        )
+        result = combine_kwargs(var1={"foo": "bar"}, var2={"fizz": "buzz"})
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 2)
 
-        self.assertIn(('var1[foo]', 'bar'), result)
-        self.assertIn(('var2[fizz]', 'buzz'), result)
+        self.assertIn(("var1[foo]", "bar"), result)
+        self.assertIn(("var2[fizz]", "buzz"), result)
 
     def test_combine_kwargs_multiple_mixed(self, m):
         result = combine_kwargs(
             var1=True,
-            var2={'fizz': 'buzz'},
-            var3='foo',
+            var2={"fizz": "buzz"},
+            var3="foo",
             var4=42,
-            var5=['test1', 'test2', 'test3']
+            var5=["test1", "test2", "test3"],
         )
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 7)
 
-        self.assertIn(('var1', True), result)
-        self.assertIn(('var2[fizz]', 'buzz'), result)
-        self.assertIn(('var3', 'foo'), result)
-        self.assertIn(('var4', 42), result)
-        self.assertIn(('var5[]', 'test1'), result)
-        self.assertIn(('var5[]', 'test2'), result)
-        self.assertIn(('var5[]', 'test3'), result)
+        self.assertIn(("var1", True), result)
+        self.assertIn(("var2[fizz]", "buzz"), result)
+        self.assertIn(("var3", "foo"), result)
+        self.assertIn(("var4", 42), result)
+        self.assertIn(("var5[]", "test1"), result)
+        self.assertIn(("var5[]", "test2"), result)
+        self.assertIn(("var5[]", "test3"), result)
 
         # Ensure list kwargs are in correct order
         self.assertTrue(
-            result.index(('var5[]', 'test1'))
-            < result.index(('var5[]', 'test2'))
-            < result.index(('var5[]', 'test3'))
+            result.index(("var5[]", "test1"))
+            < result.index(("var5[]", "test2"))
+            < result.index(("var5[]", "test3"))
         )
 
     def test_combine_kwargs_nested_dict(self, m):
-        result = combine_kwargs(dict={
-            'key': {'subkey': 'value'}
-        })
+        result = combine_kwargs(dict={"key": {"subkey": "value"}})
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 1)
 
-        self.assertIn(('dict[key][subkey]', 'value'), result)
+        self.assertIn(("dict[key][subkey]", "value"), result)
 
     def test_combine_kwargs_multiple_nested_dicts(self, m):
         result = combine_kwargs(
             dict1={
-                'key1': {
-                    'subkey1-1': 'value1-1',
-                    'subkey1-2': 'value1-2'
-                },
-                'key2': {
-                    'subkey2-1': 'value2-1',
-                    'subkey2-2': 'value2-2'
-                }
+                "key1": {"subkey1-1": "value1-1", "subkey1-2": "value1-2"},
+                "key2": {"subkey2-1": "value2-1", "subkey2-2": "value2-2"},
             },
             dict2={
-                'key1': {
-                    'subkey1-1': 'value1-1',
-                    'subkey1-2': 'value1-2'
-                },
-                'key2': {
-                    'subkey2-1': 'value2-1',
-                    'subkey2-2': 'value2-2'
-                }
-            }
+                "key1": {"subkey1-1": "value1-1", "subkey1-2": "value1-2"},
+                "key2": {"subkey2-1": "value2-1", "subkey2-2": "value2-2"},
+            },
         )
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 8)
 
-        self.assertIn(('dict1[key1][subkey1-1]', 'value1-1'), result)
-        self.assertIn(('dict1[key1][subkey1-2]', 'value1-2'), result)
-        self.assertIn(('dict1[key2][subkey2-1]', 'value2-1'), result)
-        self.assertIn(('dict1[key2][subkey2-2]', 'value2-2'), result)
-        self.assertIn(('dict2[key1][subkey1-1]', 'value1-1'), result)
-        self.assertIn(('dict2[key1][subkey1-2]', 'value1-2'), result)
-        self.assertIn(('dict2[key2][subkey2-1]', 'value2-1'), result)
-        self.assertIn(('dict2[key2][subkey2-2]', 'value2-2'), result)
+        self.assertIn(("dict1[key1][subkey1-1]", "value1-1"), result)
+        self.assertIn(("dict1[key1][subkey1-2]", "value1-2"), result)
+        self.assertIn(("dict1[key2][subkey2-1]", "value2-1"), result)
+        self.assertIn(("dict1[key2][subkey2-2]", "value2-2"), result)
+        self.assertIn(("dict2[key1][subkey1-1]", "value1-1"), result)
+        self.assertIn(("dict2[key1][subkey1-2]", "value1-2"), result)
+        self.assertIn(("dict2[key2][subkey2-1]", "value2-1"), result)
+        self.assertIn(("dict2[key2][subkey2-2]", "value2-2"), result)
 
     def test_combine_kwargs_super_nested_dict(self, m):
         result = combine_kwargs(
-            big_dict={'a': {'b': {'c': {'d': {'e': 'We need to go deeper'}}}}}
+            big_dict={"a": {"b": {"c": {"d": {"e": "We need to go deeper"}}}}}
         )
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 1)
-        self.assertIn(('big_dict[a][b][c][d][e]', 'We need to go deeper'), result)
+        self.assertIn(("big_dict[a][b][c][d][e]", "We need to go deeper"), result)
 
     def test_combine_kwargs_the_gauntlet(self, m):
         result = combine_kwargs(
-            foo='bar',
-            fb={
-                3: 'fizz',
-                5: 'buzz',
-                15: 'fizzbuzz'
-            },
+            foo="bar",
+            fb={3: "fizz", 5: "buzz", 15: "fizzbuzz"},
             true=False,
             life=42,
-            basic_list=['foo', 'bar'],
+            basic_list=["foo", "bar"],
             days_of_xmas={
-                'first': {
-                    1: 'partridge in a pear tree'
+                "first": {1: "partridge in a pear tree"},
+                "second": {1: "partridge in a pear tree", "2": "turtle doves"},
+                "third": {
+                    1: "partridge in a pear tree",
+                    "2": "turtle doves",
+                    3: "french hens",
                 },
-                'second': {
-                    1: 'partridge in a pear tree',
-                    '2': 'turtle doves',
+                "fourth": {
+                    1: "partridge in a pear tree",
+                    "2": "turtle doves",
+                    3: "french hens",
+                    "4": "mocking birds",
                 },
-                'third': {
-                    1: 'partridge in a pear tree',
-                    '2': 'turtle doves',
-                    3: 'french hens'
+                "fifth": {
+                    1: "partridge in a pear tree",
+                    "2": "turtle doves",
+                    3: "french hens",
+                    "4": "mocking birds",
+                    "5": "GOLDEN RINGS",
                 },
-                'fourth': {
-                    1: 'partridge in a pear tree',
-                    '2': 'turtle doves',
-                    3: 'french hens',
-                    '4': 'mocking birds',
-                },
-                'fifth': {
-                    1: 'partridge in a pear tree',
-                    '2': 'turtle doves',
-                    3: 'french hens',
-                    '4': 'mocking birds',
-                    '5': 'GOLDEN RINGS'
-                }
             },
-            super_nest={'1': {'2': {'3': {'4': {'5': {'6': 'tada'}}}}}},
+            super_nest={"1": {"2": {"3": {"4": {"5": {"6": "tada"}}}}}},
             list_dicts=[
-                {
-                    'l_d1a': 'val1a',
-                    'l_d1b': 'val1b'
-                },
-                {
-                    'l_d2a': 'val2a',
-                    'l_d2b': 'val2b'
-                }
+                {"l_d1a": "val1a", "l_d1b": "val1b"},
+                {"l_d2a": "val2a", "l_d2b": "val2b"},
             ],
-            nest_list=[
-                ['1a', '1b'],
-                ['2a', '2b'],
-                ['3a', '3b']
-            ],
-            generator=(v for v in ('g1', 'g2', 'g3')),
-            dict_list={
-                'key': ['item1', 'item2']
-            },
+            nest_list=[["1a", "1b"], ["2a", "2b"], ["3a", "3b"]],
+            generator=(v for v in ("g1", "g2", "g3")),
+            dict_list={"key": ["item1", "item2"]},
         )
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 39)
 
         # Check that all keys were generated correctly
-        self.assertIn(('foo', 'bar'), result)
-        self.assertIn(('fb[3]', 'fizz'), result)
-        self.assertIn(('fb[5]', 'buzz'), result)
-        self.assertIn(('fb[15]', 'fizzbuzz'), result)
-        self.assertIn(('true', False), result)
-        self.assertIn(('life', 42), result)
-        self.assertIn(('basic_list[]', 'foo'), result)
-        self.assertIn(('basic_list[]', 'bar'), result)
-        self.assertIn(('days_of_xmas[first][1]', 'partridge in a pear tree'), result)
-        self.assertIn(('days_of_xmas[second][1]', 'partridge in a pear tree'), result)
-        self.assertIn(('days_of_xmas[second][2]', 'turtle doves'), result)
-        self.assertIn(('days_of_xmas[third][1]', 'partridge in a pear tree'), result)
-        self.assertIn(('days_of_xmas[third][2]', 'turtle doves'), result)
-        self.assertIn(('days_of_xmas[third][3]', 'french hens'), result)
-        self.assertIn(('days_of_xmas[fourth][1]', 'partridge in a pear tree'), result)
-        self.assertIn(('days_of_xmas[fourth][2]', 'turtle doves'), result)
-        self.assertIn(('days_of_xmas[fourth][3]', 'french hens'), result)
-        self.assertIn(('days_of_xmas[fourth][4]', 'mocking birds'), result)
-        self.assertIn(('days_of_xmas[fifth][1]', 'partridge in a pear tree'), result)
-        self.assertIn(('days_of_xmas[fifth][2]', 'turtle doves'), result)
-        self.assertIn(('days_of_xmas[fifth][3]', 'french hens'), result)
-        self.assertIn(('days_of_xmas[fifth][4]', 'mocking birds'), result)
-        self.assertIn(('days_of_xmas[fifth][5]', 'GOLDEN RINGS'), result)
-        self.assertIn(('super_nest[1][2][3][4][5][6]', 'tada'), result)
-        self.assertIn(('list_dicts[][l_d1b]', 'val1b'), result)
-        self.assertIn(('list_dicts[][l_d1a]', 'val1a'), result)
-        self.assertIn(('list_dicts[][l_d2b]', 'val2b'), result)
-        self.assertIn(('list_dicts[][l_d2a]', 'val2a'), result)
-        self.assertIn(('nest_list[][]', '1a'), result)
-        self.assertIn(('nest_list[][]', '1b'), result)
-        self.assertIn(('nest_list[][]', '2a'), result)
-        self.assertIn(('nest_list[][]', '2b'), result)
-        self.assertIn(('nest_list[][]', '3a'), result)
-        self.assertIn(('nest_list[][]', '3b'), result)
-        self.assertIn(('generator[]', 'g1'), result)
-        self.assertIn(('generator[]', 'g2'), result)
-        self.assertIn(('generator[]', 'g3'), result)
-        self.assertIn(('dict_list[key][]', 'item1'), result)
-        self.assertIn(('dict_list[key][]', 'item2'), result)
+        self.assertIn(("foo", "bar"), result)
+        self.assertIn(("fb[3]", "fizz"), result)
+        self.assertIn(("fb[5]", "buzz"), result)
+        self.assertIn(("fb[15]", "fizzbuzz"), result)
+        self.assertIn(("true", False), result)
+        self.assertIn(("life", 42), result)
+        self.assertIn(("basic_list[]", "foo"), result)
+        self.assertIn(("basic_list[]", "bar"), result)
+        self.assertIn(("days_of_xmas[first][1]", "partridge in a pear tree"), result)
+        self.assertIn(("days_of_xmas[second][1]", "partridge in a pear tree"), result)
+        self.assertIn(("days_of_xmas[second][2]", "turtle doves"), result)
+        self.assertIn(("days_of_xmas[third][1]", "partridge in a pear tree"), result)
+        self.assertIn(("days_of_xmas[third][2]", "turtle doves"), result)
+        self.assertIn(("days_of_xmas[third][3]", "french hens"), result)
+        self.assertIn(("days_of_xmas[fourth][1]", "partridge in a pear tree"), result)
+        self.assertIn(("days_of_xmas[fourth][2]", "turtle doves"), result)
+        self.assertIn(("days_of_xmas[fourth][3]", "french hens"), result)
+        self.assertIn(("days_of_xmas[fourth][4]", "mocking birds"), result)
+        self.assertIn(("days_of_xmas[fifth][1]", "partridge in a pear tree"), result)
+        self.assertIn(("days_of_xmas[fifth][2]", "turtle doves"), result)
+        self.assertIn(("days_of_xmas[fifth][3]", "french hens"), result)
+        self.assertIn(("days_of_xmas[fifth][4]", "mocking birds"), result)
+        self.assertIn(("days_of_xmas[fifth][5]", "GOLDEN RINGS"), result)
+        self.assertIn(("super_nest[1][2][3][4][5][6]", "tada"), result)
+        self.assertIn(("list_dicts[][l_d1b]", "val1b"), result)
+        self.assertIn(("list_dicts[][l_d1a]", "val1a"), result)
+        self.assertIn(("list_dicts[][l_d2b]", "val2b"), result)
+        self.assertIn(("list_dicts[][l_d2a]", "val2a"), result)
+        self.assertIn(("nest_list[][]", "1a"), result)
+        self.assertIn(("nest_list[][]", "1b"), result)
+        self.assertIn(("nest_list[][]", "2a"), result)
+        self.assertIn(("nest_list[][]", "2b"), result)
+        self.assertIn(("nest_list[][]", "3a"), result)
+        self.assertIn(("nest_list[][]", "3b"), result)
+        self.assertIn(("generator[]", "g1"), result)
+        self.assertIn(("generator[]", "g2"), result)
+        self.assertIn(("generator[]", "g3"), result)
+        self.assertIn(("dict_list[key][]", "item1"), result)
+        self.assertIn(("dict_list[key][]", "item2"), result)
 
         # Ensure list kwargs are in correct order
         self.assertTrue(
-            result.index(('basic_list[]', 'foo'))
-            < result.index(('basic_list[]', 'bar'))
+            result.index(("basic_list[]", "foo"))
+            < result.index(("basic_list[]", "bar"))
         )
         self.assertTrue(
-            result.index(('list_dicts[][l_d1a]', 'val1a'))
-            < result.index(('list_dicts[][l_d2a]', 'val2a'))
+            result.index(("list_dicts[][l_d1a]", "val1a"))
+            < result.index(("list_dicts[][l_d2a]", "val2a"))
         )
         self.assertTrue(
-            result.index(('list_dicts[][l_d1b]', 'val1b'))
-            < result.index(('list_dicts[][l_d2b]', 'val2b'))
+            result.index(("list_dicts[][l_d1b]", "val1b"))
+            < result.index(("list_dicts[][l_d2b]", "val2b"))
         )
         self.assertTrue(
-            result.index(('nest_list[][]', '1a'))
-            < result.index(('nest_list[][]', '1b'))
-            < result.index(('nest_list[][]', '2a'))
-            < result.index(('nest_list[][]', '2b'))
-            < result.index(('nest_list[][]', '3a'))
-            < result.index(('nest_list[][]', '3b'))
+            result.index(("nest_list[][]", "1a"))
+            < result.index(("nest_list[][]", "1b"))
+            < result.index(("nest_list[][]", "2a"))
+            < result.index(("nest_list[][]", "2b"))
+            < result.index(("nest_list[][]", "3a"))
+            < result.index(("nest_list[][]", "3b"))
         )
         self.assertTrue(
-            result.index(('generator[]', 'g1'))
-            < result.index(('generator[]', 'g2'))
-            < result.index(('generator[]', 'g3'))
+            result.index(("generator[]", "g1"))
+            < result.index(("generator[]", "g2"))
+            < result.index(("generator[]", "g3"))
         )
         self.assertTrue(
-            result.index(('dict_list[key][]', 'item1'))
-            < result.index(('dict_list[key][]', 'item2'))
+            result.index(("dict_list[key][]", "item1"))
+            < result.index(("dict_list[key][]", "item2"))
         )
 
     # obj_or_id()
     def test_obj_or_id_int(self, m):
-        user_id = obj_or_id(1, 'user_id', (User,))
+        user_id = obj_or_id(1, "user_id", (User,))
 
         self.assertIsInstance(user_id, int)
         self.assertEqual(user_id, 1)
 
     def test_obj_or_id_str_valid(self, m):
-        user_id = obj_or_id("1", 'user_id', (User,))
+        user_id = obj_or_id("1", "user_id", (User,))
 
         self.assertIsInstance(user_id, int)
         self.assertEqual(user_id, 1)
 
     def test_obj_or_id_str_invalid(self, m):
         with self.assertRaises(TypeError):
-            obj_or_id("1a", 'user_id', (User,))
+            obj_or_id("1a", "user_id", (User,))
 
     def test_obj_or_id_obj(self, m):
-        register_uris({'user': ['get_by_id']}, m)
+        register_uris({"user": ["get_by_id"]}, m)
 
         user = self.canvas.get_user(1)
 
-        user_id = obj_or_id(user, 'user_id', (User,))
+        user_id = obj_or_id(user, "user_id", (User,))
 
         self.assertIsInstance(user_id, int)
         self.assertEqual(user_id, 1)
 
     def test_obj_or_id_obj_no_id(self, m):
-        register_uris({'user': ['course_nickname']}, m)
+        register_uris({"user": ["course_nickname"]}, m)
 
         nick = self.canvas.get_course_nickname(1)
 
         with self.assertRaises(TypeError):
-            obj_or_id(nick, 'nickname_id', (CourseNickname,))
+            obj_or_id(nick, "nickname_id", (CourseNickname,))
 
     def test_obj_or_id_multiple_objs(self, m):
-        register_uris({'user': ['get_by_id']}, m)
+        register_uris({"user": ["get_by_id"]}, m)
 
         user = self.canvas.get_user(1)
 
-        user_id = obj_or_id(user, 'user_id', (CourseNickname, User))
+        user_id = obj_or_id(user, "user_id", (CourseNickname, User))
 
         self.assertIsInstance(user_id, int)
         self.assertEqual(user_id, 1)
 
     def test_obj_or_id_user_self(self, m):
-        user_id = obj_or_id('self', 'user_id', (User,))
+        user_id = obj_or_id("self", "user_id", (User,))
 
         self.assertIsInstance(user_id, text_type)
-        self.assertEqual(user_id, 'self')
+        self.assertEqual(user_id, "self")
 
     def test_obj_or_id_nonuser_self(self, m):
         with self.assertRaises(TypeError):
-            obj_or_id('self', 'user_id', (CourseNickname,))
+            obj_or_id("self", "user_id", (CourseNickname,))
 
     # get_institution_url()
     def test_get_institution_url(self, m):
-        correct_url = 'https://my.canvas.edu'
+        correct_url = "https://my.canvas.edu"
 
+        self.assertEqual(get_institution_url("https://my.canvas.edu/"), correct_url)
         self.assertEqual(
-            get_institution_url('https://my.canvas.edu/'), correct_url
+            get_institution_url("https://my.canvas.edu/api/v1"), correct_url
         )
         self.assertEqual(
-            get_institution_url('https://my.canvas.edu/api/v1'), correct_url
+            get_institution_url("https://my.canvas.edu/api/v1/"), correct_url
         )
         self.assertEqual(
-            get_institution_url('https://my.canvas.edu/api/v1/'), correct_url
+            get_institution_url("https://my.canvas.edu/test/2/"),
+            correct_url + "/test/2",
         )
         self.assertEqual(
-            get_institution_url('https://my.canvas.edu/test/2/'),
-            correct_url + '/test/2'
+            get_institution_url("https://my.canvas.edu/test/2/api/v1"),
+            correct_url + "/test/2",
         )
         self.assertEqual(
-            get_institution_url('https://my.canvas.edu/test/2/api/v1'),
-            correct_url + '/test/2'
-        )
-        self.assertEqual(
-            get_institution_url('https://my.canvas.edu/test/2/api/v1/'),
-            correct_url + '/test/2'
+            get_institution_url("https://my.canvas.edu/test/2/api/v1/"),
+            correct_url + "/test/2",
         )

--- a/tests/test_validate_docstrings.py
+++ b/tests/test_validate_docstrings.py
@@ -17,12 +17,12 @@ import requests_mock
 @requests_mock.Mocker()
 class TestValidateDocstrings(unittest.TestCase):
     def test_validate_method_verb_mismatch(self, m):
-        url = 'https://canvas.instructure.com/doc/api/files.html#method.files.destroy>'
+        url = "https://canvas.instructure.com/doc/api/files.html#method.files.destroy>"
         register_doc_uri(url, m)
         self.assertFalse(validate_method(ExampleMethods.verb_mismatch, True))
 
     def test_validate_method_invalid_verb(self, m):
-        url = 'https://canvas.instructure.com/doc/api/files.html#method.files.destroy'
+        url = "https://canvas.instructure.com/doc/api/files.html#method.files.destroy"
         register_doc_uri(url, m)
         self.assertFalse(validate_method(ExampleMethods.invalid_verb, True))
 
@@ -30,61 +30,63 @@ class TestValidateDocstrings(unittest.TestCase):
         self.assertTrue(validate_method(ExampleMethods.no_api_call, True))
 
     def test_validate_method_good_docstring(self, m):
-        url = 'https://canvas.instructure.com/doc/api/files.html#method.files.destroy'
+        url = "https://canvas.instructure.com/doc/api/files.html#method.files.destroy"
         register_doc_uri(url, m)
         self.assertTrue(validate_method(ExampleMethods.good_docstring, True))
 
     def test_validate_method_multiple_endpoints(self, m):
-        url = 'https://canvas.instructure.com/doc/api/files.html#method.folders.show'
+        url = "https://canvas.instructure.com/doc/api/files.html#method.folders.show"
         register_doc_uri(url, m)
         self.assertTrue(validate_method(ExampleMethods.multiple_endpoints, True))
 
     def test_validate_method_multiline_URL(self, m):
         url = (
-            'https://canvas.instructure.com/doc/api/notification_preferences.html'
-            '#method.notification_preferences.index'
+            "https://canvas.instructure.com/doc/api/notification_preferences.html"
+            "#method.notification_preferences.index"
         )
         register_doc_uri(url, m)
         self.assertTrue(validate_method(ExampleMethods.multiline_URL, True))
 
     def test_validate_method_invalid_URL(self, m):
-        url = 'https://canvas.instructure.com/doc/api/404.html'
+        url = "https://canvas.instructure.com/doc/api/404.html"
         register_doc_uri(url, m, code=404)
         self.assertFalse(validate_method(ExampleMethods.invalid_URL, True))
 
     def test_validate_method_missing_endpoint_URL(self, m):
-        url = 'https://canvas.instructure.com/doc/api/files.html'
+        url = "https://canvas.instructure.com/doc/api/files.html"
         register_doc_uri(url, m)
         self.assertFalse(validate_method(ExampleMethods.missing_endpoint_URL, True))
 
     def test_validate_method_endpoint_URL_invalid(self, m):
-        url = 'https://canvas.instructure.com/doc/api/files.html#invalid'
+        url = "https://canvas.instructure.com/doc/api/files.html#invalid"
         register_doc_uri(url, m)
         self.assertFalse(validate_method(ExampleMethods.endpoint_invalid, True))
 
     def test_validate_method_not_an_endpoint(self, m):
         url = (
-            'https://canvas.instructure.com/doc/api/notification_preferences.html'
-            '#NotificationPreference'
+            "https://canvas.instructure.com/doc/api/notification_preferences.html"
+            "#NotificationPreference"
         )
         register_doc_uri(url, m)
         self.assertFalse(validate_method(ExampleMethods.not_an_endpoint, True))
 
 
 def register_doc_uri(url, m, code=200):
-    url_groups = re.search(r'(.*\/)([^\/]*)\.html', url)
+    url_groups = re.search(r"(.*\/)([^\/]*)\.html", url)
     if not url_groups:
         return
     file_name = url_groups.group(2)
 
-    with io.open('tests/fixtures/{}.html'.format(file_name), 'r', encoding='utf-8') as file:
+    with io.open(
+        "tests/fixtures/{}.html".format(file_name), "r", encoding="utf-8"
+    ) as file:
         data = file.read()
 
     m.register_uri(
-        'GET',
-        url_groups.group(1) + url_groups.group(2) + '.html',
+        "GET",
+        url_groups.group(1) + url_groups.group(2) + ".html",
         text=data,
-        status_code=code
+        status_code=code,
     )
 
 
@@ -96,10 +98,7 @@ class ExampleMethods(CanvasObject):
 
         :rtype: :class:`canvasapi.file.File`
         """
-        response = self._requester.request(
-            'DELETE',
-            'files/{}'.format(self.id)
-        )
+        response = self._requester.request("DELETE", "files/{}".format(self.id))
         return ExampleMethods(self._requester, response.json())
 
     def invalid_verb(self):
@@ -111,10 +110,7 @@ class ExampleMethods(CanvasObject):
 
         :rtype: :class:`canvasapi.file.File`
         """
-        response = self._requester.request(
-            'DELETE',
-            'files/{}'.format(self.id)
-        )
+        response = self._requester.request("DELETE", "files/{}".format(self.id))
         return ExampleMethods(self._requester, response.json())
 
     def no_api_call(self):
@@ -132,10 +128,7 @@ class ExampleMethods(CanvasObject):
 
         :rtype: :class:`canvasapi.file.File`
         """
-        response = self._requester.request(
-            'DELETE',
-            'files/{}'.format(self.id)
-        )
+        response = self._requester.request("DELETE", "files/{}".format(self.id))
         return ExampleMethods(self._requester, response.json())
 
     def multiple_endpoints(self, folder):
@@ -152,10 +145,7 @@ class ExampleMethods(CanvasObject):
         """
         folder_id = obj_or_id(folder, "folder", (Folder,))
 
-        response = self.__requester.request(
-            'GET',
-            'folders/{}'.format(folder_id)
-        )
+        response = self.__requester.request("GET", "folders/{}".format(folder_id))
         return Folder(self.__requester, response.json())
 
     def multiline_URL(self, **kwargs):
@@ -170,15 +160,14 @@ class ExampleMethods(CanvasObject):
         :rtype: `list`
         """
         response = self._requester.request(
-            'GET',
-            'users/{}/communication_channels/{}/notification_preferences'.format(
-                self.user_id,
-                self.id
+            "GET",
+            "users/{}/communication_channels/{}/notification_preferences".format(
+                self.user_id, self.id
             ),
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
 
-        return response.json()['notification_preferences']
+        return response.json()["notification_preferences"]
 
     def non_api_call(self):
         """
@@ -201,10 +190,7 @@ class ExampleMethods(CanvasObject):
 
         :rtype: :class:`canvasapi.file.File`
         """
-        response = self._requester.request(
-            'DELETE',
-            'files/{}'.format(self.id)
-        )
+        response = self._requester.request("DELETE", "files/{}".format(self.id))
         return ExampleMethods(self._requester, response.json())
 
     def missing_endpoint_URL(self, folder):
@@ -221,10 +207,7 @@ class ExampleMethods(CanvasObject):
         """
         folder_id = obj_or_id(folder, "folder", (Folder,))
 
-        response = self.__requester.request(
-            'GET',
-            'folders/{}'.format(folder_id)
-        )
+        response = self.__requester.request("GET", "folders/{}".format(folder_id))
         return Folder(self.__requester, response.json())
 
     def endpoint_invalid(self, folder):
@@ -241,10 +224,7 @@ class ExampleMethods(CanvasObject):
         """
         folder_id = obj_or_id(folder, "folder", (Folder,))
 
-        response = self.__requester.request(
-            'GET',
-            'folders/{}'.format(folder_id)
-        )
+        response = self.__requester.request("GET", "folders/{}".format(folder_id))
         return Folder(self.__requester, response.json())
 
     def not_an_endpoint(self, **kwargs):
@@ -259,12 +239,11 @@ class ExampleMethods(CanvasObject):
         :rtype: `list`
         """
         response = self._requester.request(
-            'GET',
-            'users/{}/communication_channels/{}/notification_preferences'.format(
-                self.user_id,
-                self.id
+            "GET",
+            "users/{}/communication_channels/{}/notification_preferences".format(
+                self.user_id, self.id
             ),
-            _kwargs=combine_kwargs(**kwargs)
+            _kwargs=combine_kwargs(**kwargs),
         )
 
-        return response.json()['notification_preferences']
+        return response.json()["notification_preferences"]

--- a/tests/util.py
+++ b/tests/util.py
@@ -19,36 +19,39 @@ def register_uris(requirements, requests_mocker):
     """
     for fixture, objects in requirements.items():
         try:
-            with open('tests/fixtures/{}.json'.format(fixture)) as file:
+            with open("tests/fixtures/{}.json".format(fixture)) as file:
                 data = json.loads(file.read())
         except IOError:
-            raise ValueError('Fixture {}.json contains invalid JSON.'.format(fixture))
+            raise ValueError("Fixture {}.json contains invalid JSON.".format(fixture))
 
         if not isinstance(objects, list):
-            raise TypeError('{} is not a list.'.format(objects))
+            raise TypeError("{} is not a list.".format(objects))
 
         for obj_name in objects:
             obj = data.get(obj_name)
 
             if obj is None:
-                raise ValueError('{} does not exist in {}.json'.format(
-                    obj_name.__repr__(),
-                    fixture
-                ))
+                raise ValueError(
+                    "{} does not exist in {}.json".format(obj_name.__repr__(), fixture)
+                )
 
-            method = requests_mock.ANY if obj['method'] == 'ANY' else obj['method']
-            if obj['endpoint'] == 'ANY':
+            method = requests_mock.ANY if obj["method"] == "ANY" else obj["method"]
+            if obj["endpoint"] == "ANY":
                 url = requests_mock.ANY
             else:
-                url = get_institution_url(settings.BASE_URL) + '/api/v1/' + obj['endpoint']
+                url = (
+                    get_institution_url(settings.BASE_URL)
+                    + "/api/v1/"
+                    + obj["endpoint"]
+                )
 
             try:
                 requests_mocker.register_uri(
                     method,
                     url,
-                    json=obj.get('data'),
-                    status_code=obj.get('status_code', 200),
-                    headers=obj.get('headers', {})
+                    json=obj.get("data"),
+                    status_code=obj.get("status_code", 200),
+                    headers=obj.get("headers", {}),
                 )
             except Exception as e:
                 print(e)


### PR DESCRIPTION
Added the "Send a message to unsubmitted or submitted users for the quiz" endpoint with tests. This endpoint allows you to send a message to users in a quiz by passing in a conversation object of class QuizUserConversation, which can be referenced in the link below. 

[https://canvas.instructure.com/doc/api/quiz_submission_user_list.html#method.quizzes/quiz_submission_users.message](url)
