### PR TITLE
Add additional keyword arguments for get_user call

### DIFF
--- a/canvasapi/canvas.py
+++ b/canvasapi/canvas.py
@@ -1125,7 +1125,7 @@ class Canvas(object):
         response = self.__requester.request("GET", "users/self/upcoming_events")
         return response.json()
 
-    def get_user(self, user, id_type=None):
+    def get_user(self, user, id_type=None, **kwargs):
         """
         Retrieve a user by their ID. `id_type` denotes which endpoint to try as there are
         several different IDs that can pull the same user record from Canvas.
@@ -1152,7 +1152,9 @@ class Canvas(object):
             user_id = obj_or_id(user, "user", (User,))
             uri = "users/{}".format(user_id)
 
-        response = self.__requester.request("GET", uri)
+        response = self.__requester.request(
+            "GET", uri, _kwargs=combine_kwargs(**kwargs)
+        )
         return User(self.__requester, response.json())
 
     def get_user_participants(self, appointment_group, **kwargs):

--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -1971,7 +1971,7 @@ class Course(CanvasObject):
             kwargs=combine_kwargs(**kwargs),
         )
 
-    def get_user(self, user, user_id_type=None):
+    def get_user(self, user, user_id_type=None, **kwargs):
         """
         Retrieve a user by their ID. `user_id_type` denotes which endpoint to try as there are
         several different ids that can pull the same user record from Canvas.
@@ -1994,7 +1994,7 @@ class Course(CanvasObject):
             user_id = obj_or_id(user, "user", (User,))
             uri = "courses/{}/users/{}".format(self.id, user_id)
 
-        response = self._requester.request("GET", uri)
+        response = self._requester.request("GET", uri, _kwargs=combine_kwargs(**kwargs))
         return User(self._requester, response.json())
 
     def get_user_in_a_course_level_assignment_data(self, user):


### PR DESCRIPTION
# Proposed Changes

In general, calls on Canvas to URLs that return users accept additional optional arguments such as include. This PR adds additional keyword arguments for those calls.