### PR TITLE
GroupedSubmission submissions key:value deleted

### DIFF
--- a/canvasapi/submission.py
+++ b/canvasapi/submission.py
@@ -179,16 +179,15 @@ class Submission(CanvasObject):
 @python_2_unicode_compatible
 class GroupedSubmission(CanvasObject):
     def __init__(self, requester, attributes):
+        super(GroupedSubmission, self).__init__(requester, attributes)
+
         try:
             self.submissions = [
                 Submission(requester, submission)
                 for submission in attributes["submissions"]
             ]
-            del attributes["submissions"]
         except KeyError:
             self.submissions = list()
-
-        super(GroupedSubmission, self).__init__(requester, attributes)
 
     def __str__(self):
         return "{} submission(s) for User #{}".format(

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -154,6 +154,29 @@ class TestGroupedSubmission(unittest.TestCase):
         self.assertIsInstance(grouped_submission.submissions, list)
         self.assertEqual(len(grouped_submission.submissions), 0)
 
+    def test__init__issue_303_regression(self):
+        """
+        Regression test for issue #303
+        https://github.com/ucfopen/canvasapi/issues/303
+        """
+        grouped_submission = GroupedSubmission(
+            self.canvas._Canvas__requester,
+            {
+                "user_id": 1,
+                "submissions": [
+                    {
+                        "id": 1,
+                        "assignments_id": 1,
+                        "user_id": 1,
+                        "html_url": "https://example.com/courses/1/assignments/1/submissions/1",
+                        "submission_type": "online_upload",
+                    }
+                ],
+            },
+        )
+        self.assertTrue(hasattr(grouped_submission, "submissions"))
+        self.assertIn("submissions", grouped_submission.attributes)
+
     # __str__()
     def test__str__(self):
         string = str(self.grouped_submission)


### PR DESCRIPTION
# Proposed Changes

* Fixes an issue where `submissions` weren't in `attributes` of GroupedSubmission.

Fixes #303.
