### PR TITLE
Issue/206 print account report

### DIFF
--- a/canvasapi/account.py
+++ b/canvasapi/account.py
@@ -1925,7 +1925,11 @@ class AccountNotification(CanvasObject):
 @python_2_unicode_compatible
 class AccountReport(CanvasObject):
     def __str__(self):
-        return "{} ({})".format(self.report, self.id)
+        try:
+            return "{} ({})".format(self.report, self.id)
+        except AttributeError:
+            # Print params if not a report instance
+            return "{} ({})".format(self.report, self.parameters)
 
     def delete_report(self, **kwargs):
         """

--- a/tests/fixtures/account.json
+++ b/tests/fixtures/account.json
@@ -578,10 +578,12 @@
 		"endpoint": "accounts/1/reports",
 		"data": [
 			{
-				"id": 1
+				"id": 1,
+				"report": "sis_export_csv"
 			},
 			{
-				"id": 2
+				"id": 2,
+				"report": "grade_export_csv"
 			}
 		],
 		"headers": {

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -286,6 +286,7 @@ class TestAccount(unittest.TestCase):
         self.assertIsInstance(report, AccountReport)
         self.assertTrue(hasattr(report, "title"))
         self.assertEqual(report.title, "Zero Activity")
+        self.assertIsInstance(str(report), str)
 
     # get_index_of_reports()
     def test_get_index_of_reports(self, m):
@@ -310,6 +311,7 @@ class TestAccount(unittest.TestCase):
         self.assertEqual(len(reports_list), 4)
         self.assertIsInstance(reports_list[0], AccountReport)
         self.assertTrue(hasattr(reports_list[0], "id"))
+        self.assertIsInstance(str(reports_list[0]), str)
 
     # get_subaccounts()
     def test_get_subaccounts(self, m):


### PR DESCRIPTION
# Proposed Changes

* Printing AccountReport will output params instead of ID if the object is a report type (returned from `Account.get_reports()` and not a report instance (returned from `Account.get_report()).`

Fixes #206
