### PR TITLE
changing all instances of l to lic in relevant tests to appease flake8

### DIFF
--- a/tests/test_course.py
+++ b/tests/test_course.py
@@ -1992,11 +1992,11 @@ class TestCourse(unittest.TestCase):
         self.assertIsInstance(licenses, PaginatedList)
         licenses = list(licenses)
 
-        for l in licenses:
-            self.assertIsInstance(l, License)
-            self.assertTrue(hasattr(l, "id"))
-            self.assertTrue(hasattr(l, "name"))
-            self.assertTrue(hasattr(l, "url"))
+        for lic in licenses:
+            self.assertIsInstance(lic, License)
+            self.assertTrue(hasattr(lic, "id"))
+            self.assertTrue(hasattr(lic, "name"))
+            self.assertTrue(hasattr(lic, "url"))
 
         self.assertEqual(2, len(licenses))
 

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -656,11 +656,11 @@ class TestGroup(unittest.TestCase):
         self.assertIsInstance(licenses, PaginatedList)
         licenses = list(licenses)
 
-        for l in licenses:
-            self.assertIsInstance(l, License)
-            self.assertTrue(hasattr(l, "id"))
-            self.assertTrue(hasattr(l, "name"))
-            self.assertTrue(hasattr(l, "url"))
+        for lic in licenses:
+            self.assertIsInstance(lic, License)
+            self.assertTrue(hasattr(lic, "id"))
+            self.assertTrue(hasattr(lic, "name"))
+            self.assertTrue(hasattr(lic, "url"))
 
         self.assertEqual(2, len(licenses))
 

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -617,11 +617,11 @@ class TestUser(unittest.TestCase):
         self.assertIsInstance(licenses, PaginatedList)
         licenses = list(licenses)
 
-        for l in licenses:
-            self.assertIsInstance(l, License)
-            self.assertTrue(hasattr(l, "id"))
-            self.assertTrue(hasattr(l, "name"))
-            self.assertTrue(hasattr(l, "url"))
+        for lic in licenses:
+            self.assertIsInstance(lic, License)
+            self.assertTrue(hasattr(lic, "id"))
+            self.assertTrue(hasattr(lic, "name"))
+            self.assertTrue(hasattr(lic, "url"))
 
         self.assertEqual(2, len(licenses))
 


### PR DESCRIPTION
# Proposed Changes

Fixing all instances of var `l` (which flake8 hates) to `lic` in 3 tests.

Resolves #373