### PR TITLE
adding coverage for resolve_path

### DIFF
--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -2658,6 +2658,28 @@ class Course(CanvasObject):
         )
         return Course(self._requester, response.json())
 
+    def resolve_path(self, full_path, **kwargs):
+        """
+        Returns the paginated list of all of the folders in the given
+        path starting at the course root folder.
+
+        :calls: `GET /api/v1/courses/:course_id/folders/by_path/*full_path \
+        <https://canvas.instructure.com/doc/api/files.html#method.folders.resolve_path>`_
+
+        :param full_path: Full path to resolve, relative to course root
+        :type full_path: string
+
+        :rtype: :class:`canvasapi.paginated_list.PaginatedList` of
+            :class:`canvasapi.folder.Folder`
+        """
+        return PaginatedList(
+            Folder,
+            self._requester,
+            "GET",
+            "courses/{0}/folders/by_path/{1}".format(self.id, full_path),
+            _kwargs=combine_kwargs(**kwargs),
+        )
+
     def set_quiz_extensions(self, quiz_extensions, **kwargs):
         """
         Set extensions for student all quiz submissions in a course.

--- a/tests/fixtures/course.json
+++ b/tests/fixtures/course.json
@@ -2149,5 +2149,41 @@
 			}
 		],
 		"status_code": 200
+	},
+    "resolve_path": {
+		"method": "GET",
+		"endpoint": "courses/1/folders/by_path/Folder_Level_1/Folder_Level_2/Folder_Level_3",
+		"data": [
+            {
+				"id": 2,
+				"files_count": 0,
+				"folders_count": 1,
+				"name": "course_files",
+				"full_name": "course_files"
+			},
+
+			{
+				"id": 3,
+				"files_count": 0,
+				"folders_count": 1,
+				"name": "Folder_Level_1",
+				"full_name": "course_files"
+			},
+			{
+				"id": 4,
+				"files_count": 0,
+				"folders_count": 1,
+				"name": "Folder_Level_2",
+				"full_name": "course_files/Folder_Level_1/Folder_Level_2"
+			},
+			{
+				"id": 5,
+				"files_count": 0,
+				"folders_count": 0,
+				"name": "Folder_Level_3",
+				"full_name": "course_files/Folder_Level_1/Folder_Level_2/Folder_Level_3"
+			}
+		],
+		"status_code": 200
 	}
 }

--- a/tests/test_course.py
+++ b/tests/test_course.py
@@ -2000,6 +2000,20 @@ class TestCourse(unittest.TestCase):
 
         self.assertEqual(2, len(licenses))
 
+    # resolve_path()
+    def test_resolve_path(self, m):
+        register_uris({"course": ["resolve_path"]}, m)
+
+        full_path = "Folder_Level_1/Folder_Level_2/Folder_Level_3"
+        folders = self.course.resolve_path(full_path)
+        folder_list = [folder for folder in folders]
+        self.assertEqual(len(folder_list), 4)
+        self.assertIsInstance(folder_list[0], Folder)
+        for folder_name, folder in zip(
+            ("course_files/" + full_path).split("/"), folders
+        ):
+            self.assertEqual(folder_name, folder.name)
+
 
 @requests_mock.Mocker()
 class TestCourseNickname(unittest.TestCase):


### PR DESCRIPTION
# Proposed Changes

This provides coverage for the courses/:course_id/folders/by_path/*full_path endpoint along with a basic unit test.

Fixes #375  
