### PR TITLE
Issue #384 Remove Python 2 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 matrix:
   include:
-    - python: 3.5
-      dist: xenial
     - python: 3.6
       dist: xenial
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 language: python
 matrix:
   include:
-    - python: 2.7
-      dist: xenial
-    - python: 3.4
-      dist: xenial
     - python: 3.5
       dist: xenial
     - python: 3.6
       dist: xenial
     - python: 3.7
+      dist: xenial
+      sudo: true
+    - python: 3.8
       dist: xenial
       sudo: true
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### General
+
+- Added support for Python 3.8
+- Dropped support for Python 3.4, 3.5, and 2.7
+
 ## [0.16.0] - 2020-06-26
 
 ### New Endpoint Coverage

--- a/canvasapi/__init__.py
+++ b/canvasapi/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from canvasapi.canvas import Canvas
 
 __all__ = ["Canvas"]

--- a/canvasapi/account.py
+++ b/canvasapi/account.py
@@ -1,8 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import warnings
-
-from six import python_2_unicode_compatible, string_types
 
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.exceptions import CanvasException, RequiredFieldMissing
@@ -16,7 +12,6 @@ from canvasapi.sis_import import SisImport
 from canvasapi.util import combine_kwargs, file_or_path, obj_or_id, obj_or_str
 
 
-@python_2_unicode_compatible
 class Account(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.name, self.id)
@@ -199,7 +194,7 @@ class Account(CanvasObject):
 
         if isinstance(migration_type, Migrator):
             kwargs["migration_type"] = migration_type.type
-        elif isinstance(migration_type, string_types):
+        elif isinstance(migration_type, str):
             kwargs["migration_type"] = migration_type
         else:
             raise TypeError("Parameter migration_type must be of type Migrator or str")
@@ -1902,7 +1897,6 @@ class Account(CanvasObject):
         return Role(self._requester, response.json())
 
 
-@python_2_unicode_compatible
 class AccountNotification(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.subject, self.id)
@@ -1943,7 +1937,6 @@ class AccountNotification(CanvasObject):
         return AccountNotification(self._requester, response.json())
 
 
-@python_2_unicode_compatible
 class AccountReport(CanvasObject):
     def __str__(self):
         try:
@@ -1970,19 +1963,16 @@ class AccountReport(CanvasObject):
         return AccountReport(self._requester, response.json())
 
 
-@python_2_unicode_compatible
 class Role(CanvasObject):
     def __str__(self):  # pragma: no cover
         return "{} ({})".format(self.label, self.base_role_type)
 
 
-@python_2_unicode_compatible
 class SSOSettings(CanvasObject):
     def __str__(self):  # pragma: no cover
         return "{} ({})".format(self.login_handle_name, self.change_password_url)
 
 
-@python_2_unicode_compatible
 class Admin(CanvasObject):
     def __str__(self):  # pragma: no cover
         return "{} {} ({})".format(self.user["name"], self.user["id"], self.id)

--- a/canvasapi/appointment_group.py
+++ b/canvasapi/appointment_group.py
@@ -1,13 +1,8 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.exceptions import RequiredFieldMissing
 from canvasapi.util import combine_kwargs
 
 
-@python_2_unicode_compatible
 class AppointmentGroup(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.title, self.id)

--- a/canvasapi/assignment.py
+++ b/canvasapi/assignment.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.exceptions import CanvasException, RequiredFieldMissing
 from canvasapi.paginated_list import PaginatedList
@@ -14,7 +10,6 @@ from canvasapi.user import UserDisplay
 from canvasapi.util import combine_kwargs, obj_or_id
 
 
-@python_2_unicode_compatible
 class Assignment(CanvasObject):
     def __init__(self, requester, attributes):
         super(Assignment, self).__init__(requester, attributes)
@@ -354,13 +349,11 @@ class Assignment(CanvasObject):
         ).start()
 
 
-@python_2_unicode_compatible
 class AssignmentExtension(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.assignment_id, self.user_id)
 
 
-@python_2_unicode_compatible
 class AssignmentGroup(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.name, self.id)
@@ -402,7 +395,6 @@ class AssignmentGroup(CanvasObject):
         return AssignmentGroup(self._requester, response.json())
 
 
-@python_2_unicode_compatible
 class AssignmentOverride(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.title, self.id)

--- a/canvasapi/authentication_event.py
+++ b/canvasapi/authentication_event.py
@@ -1,11 +1,6 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 
 
-@python_2_unicode_compatible
 class AuthenticationEvent(CanvasObject):
     def __str__(self):
         return "{} {} ({})".format(self.created_at, self.event_type, self.pseudonym_id)

--- a/canvasapi/authentication_provider.py
+++ b/canvasapi/authentication_provider.py
@@ -1,12 +1,7 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 
 
-@python_2_unicode_compatible
 class AuthenticationProvider(CanvasObject):
     def __str__(self):  # pragma: no cover
         return "{} ({})".format(self.auth_type, self.position)

--- a/canvasapi/avatar.py
+++ b/canvasapi/avatar.py
@@ -1,11 +1,6 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 
 
-@python_2_unicode_compatible
 class Avatar(CanvasObject):
     def __str__(self):  # pragma: no cover
         return "{}".format(self.display_name)

--- a/canvasapi/blueprint.py
+++ b/canvasapi/blueprint.py
@@ -1,13 +1,8 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.paginated_list import PaginatedList
 from canvasapi.util import combine_kwargs, obj_or_id
 
 
-@python_2_unicode_compatible
 class BlueprintTemplate(CanvasObject):
     def __str__(self):
         return "{}".format(self.id)
@@ -182,7 +177,6 @@ class BlueprintTemplate(CanvasObject):
         return response.json().get("success", False)
 
 
-@python_2_unicode_compatible
 class BlueprintMigration(CanvasObject):
     def __str__(self):
         return "{} {}".format(self.id, self.template_id)
@@ -234,13 +228,11 @@ class BlueprintMigration(CanvasObject):
         )
 
 
-@python_2_unicode_compatible
 class ChangeRecord(CanvasObject):
     def __str__(self):
         return "{} {}".format(self.asset_id, self.asset_name)
 
 
-@python_2_unicode_compatible
 class BlueprintSubscription(CanvasObject):
     def __str__(self):
         return "{} {}".format(self.id, self.template_id)

--- a/canvasapi/bookmark.py
+++ b/canvasapi/bookmark.py
@@ -1,12 +1,7 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 
 
-@python_2_unicode_compatible
 class Bookmark(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.name, self.id)

--- a/canvasapi/calendar_event.py
+++ b/canvasapi/calendar_event.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 

--- a/canvasapi/canvas.py
+++ b/canvasapi/canvas.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import warnings
 
 from canvasapi.account import Account
@@ -326,13 +324,12 @@ class Canvas(object):
         :rtype: :class:`canvasapi.planner.PlannerOverride`
         """
         from canvasapi.planner import PlannerOverride
-        from six import text_type, integer_types
 
-        if isinstance(plannable_type, text_type):
+        if isinstance(plannable_type, str):
             kwargs["plannable_type"] = plannable_type
         else:
             raise RequiredFieldMissing("plannable_type is required as a str.")
-        if isinstance(plannable_id, integer_types):
+        if isinstance(plannable_id, int):
             kwargs["plannable_id"] = plannable_id
         else:
             raise RequiredFieldMissing("plannable_id is required as an int.")

--- a/canvasapi/canvas_object.py
+++ b/canvasapi/canvas_object.py
@@ -1,12 +1,8 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from datetime import datetime
 import json
 import pytz
 import re
 import warnings
-
-from six import text_type
 
 DATE_PATTERN = re.compile("[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z")
 
@@ -78,7 +74,7 @@ class CanvasObject(object):
             self.__setattr__(attribute, value)
 
             # datetime field
-            if DATE_PATTERN.match(text_type(value)):
+            if DATE_PATTERN.match(str(value)):
                 naive = datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
                 aware = naive.replace(tzinfo=pytz.utc)
                 self.__setattr__(attribute + "_date", aware)

--- a/canvasapi/collaboration.py
+++ b/canvasapi/collaboration.py
@@ -1,13 +1,8 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.paginated_list import PaginatedList
 from canvasapi.util import combine_kwargs
 
 
-@python_2_unicode_compatible
 class Collaboration(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.document_id, self.id)
@@ -31,7 +26,6 @@ class Collaboration(CanvasObject):
         )
 
 
-@python_2_unicode_compatible
 class Collaborator(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.name, self.id)

--- a/canvasapi/comm_message.py
+++ b/canvasapi/comm_message.py
@@ -1,11 +1,6 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 
 
-@python_2_unicode_compatible
 class CommMessage(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.subject, self.id)

--- a/canvasapi/communication_channel.py
+++ b/canvasapi/communication_channel.py
@@ -1,15 +1,10 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import warnings
-
-from six import python_2_unicode_compatible
 
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.notification_preference import NotificationPreference
 from canvasapi.util import combine_kwargs
 
 
-@python_2_unicode_compatible
 class CommunicationChannel(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.address, self.id)

--- a/canvasapi/content_export.py
+++ b/canvasapi/content_export.py
@@ -1,11 +1,6 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 
 
-@python_2_unicode_compatible
 class ContentExport(CanvasObject):
     def __str__(self):
         return "{} {} ({})".format(self.export_type, self.user_id, self.id)

--- a/canvasapi/content_migration.py
+++ b/canvasapi/content_migration.py
@@ -1,13 +1,8 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.paginated_list import PaginatedList
 from canvasapi.util import combine_kwargs, obj_or_id
 
 
-@python_2_unicode_compatible
 class ContentMigration(CanvasObject):
     def __str__(self):
         return "{} {}".format(self.migration_type_title, self.id)
@@ -225,7 +220,6 @@ class ContentMigration(CanvasObject):
             return False
 
 
-@python_2_unicode_compatible
 class MigrationIssue(CanvasObject):
     def __str__(self):
         return "{}: {}".format(self.id, self.description)
@@ -265,7 +259,6 @@ class MigrationIssue(CanvasObject):
             return False
 
 
-@python_2_unicode_compatible
 class Migrator(CanvasObject):
     def __str__(self):
         return "{}".format(self.type)

--- a/canvasapi/conversation.py
+++ b/canvasapi/conversation.py
@@ -1,12 +1,7 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 
 
-@python_2_unicode_compatible
 class Conversation(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.subject, self.id)

--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -1,8 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import warnings
-
-from six import python_2_unicode_compatible, text_type, string_types
 
 from canvasapi.assignment import Assignment, AssignmentGroup
 from canvasapi.blueprint import BlueprintSubscription
@@ -42,7 +38,6 @@ from canvasapi.util import (
 )
 
 
-@python_2_unicode_compatible
 class Course(CanvasObject):
     def __str__(self):
         return "{} {} ({})".format(self.course_code, self.name, self.id)
@@ -187,7 +182,7 @@ class Course(CanvasObject):
 
         if isinstance(migration_type, Migrator):
             kwargs["migration_type"] = migration_type.type
-        elif isinstance(migration_type, string_types):
+        elif isinstance(migration_type, str):
             kwargs["migration_type"] = migration_type
         else:
             raise TypeError("Parameter migration_type must be of type Migrator or str")
@@ -2631,10 +2626,10 @@ class Course(CanvasObject):
         """
         # Convert iterable sequence to comma-separated string
         if is_multivalued(order):
-            order = ",".join([text_type(topic_id) for topic_id in order])
+            order = ",".join([str(topic_id) for topic_id in order])
 
         # Check if is a string with commas
-        if not isinstance(order, text_type) or "," not in order:
+        if not isinstance(order, str) or "," not in order:
             raise ValueError("Param `order` must be a list, tuple, or string.")
 
         response = self._requester.request(
@@ -2962,7 +2957,6 @@ class Course(CanvasObject):
         ).start()
 
 
-@python_2_unicode_compatible
 class CourseNickname(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.nickname, self.course_id)
@@ -2983,7 +2977,6 @@ class CourseNickname(CanvasObject):
         return CourseNickname(self._requester, response.json())
 
 
-@python_2_unicode_compatible
 class LatePolicy(CanvasObject):
     def __str__(self):
         return "Late Policy {}".format(self.id)

--- a/canvasapi/course_epub_export.py
+++ b/canvasapi/course_epub_export.py
@@ -1,11 +1,6 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 
 
-@python_2_unicode_compatible
 class CourseEpubExport(CanvasObject):
     def __str__(self):
         return "{} course_id:({}) epub_id:({}) {} ".format(

--- a/canvasapi/current_user.py
+++ b/canvasapi/current_user.py
@@ -1,8 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import warnings
-
-from six import python_2_unicode_compatible
 
 from canvasapi.bookmark import Bookmark
 from canvasapi.course import Course
@@ -13,7 +9,6 @@ from canvasapi.user import User
 from canvasapi.util import combine_kwargs, obj_or_id
 
 
-@python_2_unicode_compatible
 class CurrentUser(User):
     def __init__(self, _requester):
         self._requester = _requester

--- a/canvasapi/discussion_topic.py
+++ b/canvasapi/discussion_topic.py
@@ -1,15 +1,10 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import warnings
-
-from six import python_2_unicode_compatible
 
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.paginated_list import PaginatedList
 from canvasapi.util import combine_kwargs, obj_or_id
 
 
-@python_2_unicode_compatible
 class DiscussionTopic(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.title, self.id)
@@ -369,7 +364,6 @@ class DiscussionTopic(CanvasObject):
         return DiscussionTopic(self._requester, response.json())
 
 
-@python_2_unicode_compatible
 class DiscussionEntry(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.message, self.id)

--- a/canvasapi/enrollment.py
+++ b/canvasapi/enrollment.py
@@ -1,11 +1,6 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 
 
-@python_2_unicode_compatible
 class Enrollment(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.type, self.id)

--- a/canvasapi/enrollment_term.py
+++ b/canvasapi/enrollment_term.py
@@ -1,12 +1,7 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 
 
-@python_2_unicode_compatible
 class EnrollmentTerm(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.name, self.id)

--- a/canvasapi/exceptions.py
+++ b/canvasapi/exceptions.py
@@ -1,9 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible, text_type
-
-
-@python_2_unicode_compatible
 class CanvasException(Exception):  # pragma: no cover
     """
     Base class for all errors returned by the Canvas API.
@@ -22,7 +16,7 @@ class CanvasException(Exception):  # pragma: no cover
             self.message = message
 
     def __str__(self):
-        return text_type(self.message)
+        return str(self.message)
 
 
 class BadRequest(CanvasException):

--- a/canvasapi/external_feed.py
+++ b/canvasapi/external_feed.py
@@ -1,11 +1,6 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 
 
-@python_2_unicode_compatible
 class ExternalFeed(CanvasObject):
     def __str__(self):
         return "{}".format(self.display_name)

--- a/canvasapi/external_tool.py
+++ b/canvasapi/external_tool.py
@@ -1,13 +1,8 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.exceptions import CanvasException
 from canvasapi.util import combine_kwargs
 
 
-@python_2_unicode_compatible
 class ExternalTool(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.name, self.id)

--- a/canvasapi/favorite.py
+++ b/canvasapi/favorite.py
@@ -1,12 +1,7 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 
 
-@python_2_unicode_compatible
 class Favorite(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.context_type, self.context_id)

--- a/canvasapi/feature.py
+++ b/canvasapi/feature.py
@@ -1,12 +1,7 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs, obj_or_str
 
 
-@python_2_unicode_compatible
 class Feature(CanvasObject):
     def __str__(self):
         return "{} {}".format(self.display_name, self.applies_to)
@@ -49,7 +44,6 @@ class Feature(CanvasObject):
             )
 
 
-@python_2_unicode_compatible
 class FeatureFlag(CanvasObject):
     def __str__(self):
         return "{} {} {} {}".format(

--- a/canvasapi/file.py
+++ b/canvasapi/file.py
@@ -1,11 +1,6 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 
 
-@python_2_unicode_compatible
 class File(CanvasObject):
     def __str__(self):
         return "{}".format(self.display_name)

--- a/canvasapi/folder.py
+++ b/canvasapi/folder.py
@@ -1,8 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import warnings
-
-from six import python_2_unicode_compatible
 
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.paginated_list import PaginatedList
@@ -10,7 +6,6 @@ from canvasapi.util import combine_kwargs, obj_or_id
 from canvasapi.upload import Uploader
 
 
-@python_2_unicode_compatible
 class Folder(CanvasObject):
     def __str__(self):
         return "{}".format(self.full_name)

--- a/canvasapi/gradebook_history.py
+++ b/canvasapi/gradebook_history.py
@@ -1,29 +1,21 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 
 
-@python_2_unicode_compatible
 class Day(CanvasObject):
     def __str__(self):
         return "{}".format(self.date)
 
 
-@python_2_unicode_compatible
 class Grader(CanvasObject):
     def __str__(self):
         return "{}".format(self.id)
 
 
-@python_2_unicode_compatible
 class SubmissionHistory(CanvasObject):
     def __str__(self):
         return "{}".format(self.submission_id)
 
 
-@python_2_unicode_compatible
 class SubmissionVersion(CanvasObject):
     def __str__(self):
         return "{} {}".format(self.assignment_id, self.id)

--- a/canvasapi/grading_period.py
+++ b/canvasapi/grading_period.py
@@ -1,13 +1,8 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.exceptions import RequiredFieldMissing
 from canvasapi.util import combine_kwargs
 
 
-@python_2_unicode_compatible
 class GradingPeriod(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.title, self.id)

--- a/canvasapi/grading_standard.py
+++ b/canvasapi/grading_standard.py
@@ -1,11 +1,6 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 
 
-@python_2_unicode_compatible
 class GradingStandard(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.title, self.id)

--- a/canvasapi/group.py
+++ b/canvasapi/group.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible, text_type, string_types
-
 import warnings
 
 from canvasapi.canvas_object import CanvasObject
@@ -16,7 +12,6 @@ from canvasapi.usage_rights import UsageRights
 from canvasapi.util import combine_kwargs, is_multivalued, obj_or_id
 
 
-@python_2_unicode_compatible
 class Group(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.name, self.id)
@@ -37,7 +32,7 @@ class Group(CanvasObject):
 
         if isinstance(migration_type, Migrator):
             kwargs["migration_type"] = migration_type.type
-        elif isinstance(migration_type, string_types):
+        elif isinstance(migration_type, str):
             kwargs["migration_type"] = migration_type
         else:
             raise TypeError("Parameter migration_type must be of type Migrator or str")
@@ -956,10 +951,10 @@ class Group(CanvasObject):
         """
         # Convert list or tuple to comma-separated string
         if is_multivalued(order):
-            order = ",".join([text_type(topic_id) for topic_id in order])
+            order = ",".join([str(topic_id) for topic_id in order])
 
         # Check if is a string with commas
-        if not isinstance(order, text_type) or "," not in order:
+        if not isinstance(order, str) or "," not in order:
             raise ValueError("Param `order` must be a list, tuple, or string.")
 
         response = self._requester.request(
@@ -1052,7 +1047,6 @@ class Group(CanvasObject):
         ).start()
 
 
-@python_2_unicode_compatible
 class GroupMembership(CanvasObject):
     def __str__(self):
         return "{} - {} ({})".format(self.user_id, self.group_id, self.id)
@@ -1112,7 +1106,6 @@ class GroupMembership(CanvasObject):
         return GroupMembership(self._requester, response.json())
 
 
-@python_2_unicode_compatible
 class GroupCategory(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.name, self.id)

--- a/canvasapi/license.py
+++ b/canvasapi/license.py
@@ -1,11 +1,6 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 
 
-@python_2_unicode_compatible
 class License(CanvasObject):
     def __str__(self):
         return "{} {}".format(self.name, self.id)

--- a/canvasapi/login.py
+++ b/canvasapi/login.py
@@ -1,13 +1,8 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.paginated_list import PaginatedList
 from canvasapi.util import combine_kwargs
 
 
-@python_2_unicode_compatible
 class Login(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.id, self.unique_id)

--- a/canvasapi/module.py
+++ b/canvasapi/module.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
 import warnings
 
 from canvasapi.canvas_object import CanvasObject
@@ -9,7 +6,6 @@ from canvasapi.paginated_list import PaginatedList
 from canvasapi.util import combine_kwargs, obj_or_id
 
 
-@python_2_unicode_compatible
 class Module(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.name, self.id)
@@ -171,7 +167,6 @@ class Module(CanvasObject):
         return ModuleItem(self._requester, module_item_json)
 
 
-@python_2_unicode_compatible
 class ModuleItem(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.title, self.id)

--- a/canvasapi/notification_preference.py
+++ b/canvasapi/notification_preference.py
@@ -1,11 +1,6 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 
 
-@python_2_unicode_compatible
 class NotificationPreference(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.notification, self.frequency)

--- a/canvasapi/outcome.py
+++ b/canvasapi/outcome.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
 import warnings
 
 from canvasapi.canvas_object import CanvasObject
@@ -8,7 +5,6 @@ from canvasapi.paginated_list import PaginatedList
 from canvasapi.util import combine_kwargs, obj_or_id
 
 
-@python_2_unicode_compatible
 class Outcome(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.title, self.url)
@@ -33,7 +29,6 @@ class Outcome(CanvasObject):
         return "id" in response.json()
 
 
-@python_2_unicode_compatible
 class OutcomeLink(CanvasObject):
     def __str__(self):
         return "Group {} with Outcome {} ({})".format(
@@ -83,7 +78,6 @@ class OutcomeLink(CanvasObject):
         return OutcomeGroup(self._requester, response.json())
 
 
-@python_2_unicode_compatible
 class OutcomeGroup(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.title, self.url)

--- a/canvasapi/outcome_import.py
+++ b/canvasapi/outcome_import.py
@@ -1,11 +1,6 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 
 
-@python_2_unicode_compatible
 class OutcomeImport(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.workflow_state, self.id)

--- a/canvasapi/page.py
+++ b/canvasapi/page.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
 import warnings
 
 from canvasapi.canvas_object import CanvasObject
@@ -8,7 +5,6 @@ from canvasapi.paginated_list import PaginatedList
 from canvasapi.util import combine_kwargs, obj_or_id
 
 
-@python_2_unicode_compatible
 class Page(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.title, self.url)
@@ -219,7 +215,6 @@ class Page(CanvasObject):
         return PageRevision(self._requester, response.json())
 
 
-@python_2_unicode_compatible
 class PageRevision(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.updated_at, self.revision_id)

--- a/canvasapi/page_view.py
+++ b/canvasapi/page_view.py
@@ -1,11 +1,6 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 
 
-@python_2_unicode_compatible
 class PageView(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.context_type, self.id)

--- a/canvasapi/paginated_list.py
+++ b/canvasapi/paginated_list.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import re
 
 

--- a/canvasapi/peer_review.py
+++ b/canvasapi/peer_review.py
@@ -1,11 +1,6 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 
 
-@python_2_unicode_compatible
 class PeerReview(CanvasObject):
     def __str__(self):
         return "{} {} ({})".format(self.asset_id, self.user_id, self.id)

--- a/canvasapi/planner.py
+++ b/canvasapi/planner.py
@@ -1,12 +1,7 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 
 
-@python_2_unicode_compatible
 class PlannerNote(CanvasObject):
     def __str__(self):
         return "{} {} ({})".format(self.title, self.todo_date, self.id)
@@ -44,7 +39,6 @@ class PlannerNote(CanvasObject):
         return PlannerNote(self._requester, response.json())
 
 
-@python_2_unicode_compatible
 class PlannerOverride(CanvasObject):
     def __str__(self):
         return "{} {} ({})".format(self.plannable_id, self.marked_complete, self.id)

--- a/canvasapi/poll.py
+++ b/canvasapi/poll.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.exceptions import RequiredFieldMissing
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.paginated_list import PaginatedList
@@ -10,7 +6,6 @@ from canvasapi.poll_session import PollSession
 from canvasapi.util import combine_kwargs, obj_or_id
 
 
-@python_2_unicode_compatible
 class Poll(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.question, self.id)

--- a/canvasapi/poll_choice.py
+++ b/canvasapi/poll_choice.py
@@ -1,13 +1,8 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.exceptions import RequiredFieldMissing
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 
 
-@python_2_unicode_compatible
 class PollChoice(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.text, self.id)

--- a/canvasapi/poll_session.py
+++ b/canvasapi/poll_session.py
@@ -1,14 +1,9 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.exceptions import RequiredFieldMissing
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs, obj_or_id
 from canvasapi.poll_submission import PollSubmission
 
 
-@python_2_unicode_compatible
 class PollSession(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.poll_id, self.id)

--- a/canvasapi/poll_submission.py
+++ b/canvasapi/poll_submission.py
@@ -1,11 +1,6 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 
 
-@python_2_unicode_compatible
 class PollSubmission(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.poll_choice_id, self.id)

--- a/canvasapi/progress.py
+++ b/canvasapi/progress.py
@@ -1,11 +1,6 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 
 
-@python_2_unicode_compatible
 class Progress(CanvasObject):
     def __str__(self):
         return "{} - {} ({})".format(self.tag, self.workflow_state, self.id)

--- a/canvasapi/quiz.py
+++ b/canvasapi/quiz.py
@@ -1,8 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import warnings
-
-from six import python_2_unicode_compatible
 
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.exceptions import RequiredFieldMissing
@@ -13,7 +9,6 @@ from canvasapi.user import User
 from canvasapi.util import combine_kwargs, obj_or_id
 
 
-@python_2_unicode_compatible
 class Quiz(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.title, self.id)
@@ -490,13 +485,11 @@ class Quiz(CanvasObject):
         ]
 
 
-@python_2_unicode_compatible
 class QuizStatistic(CanvasObject):
     def __str__(self):
         return "Quiz Statistic {}".format(self.id)
 
 
-@python_2_unicode_compatible
 class QuizSubmission(CanvasObject):
     def __str__(self):
         return "Quiz {} - User {} ({})".format(self.quiz_id, self.user_id, self.id)
@@ -704,13 +697,11 @@ class QuizSubmission(CanvasObject):
         return QuizSubmission(self._requester, response_json)
 
 
-@python_2_unicode_compatible
 class QuizExtension(CanvasObject):
     def __str__(self):
         return "{}-{}".format(self.quiz_id, self.user_id)
 
 
-@python_2_unicode_compatible
 class QuizQuestion(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.question_name, self.id)
@@ -758,7 +749,6 @@ class QuizQuestion(CanvasObject):
         return self
 
 
-@python_2_unicode_compatible
 class QuizReport(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.report_type, self.id)
@@ -786,13 +776,11 @@ class QuizReport(CanvasObject):
         return response.status_code == 204
 
 
-@python_2_unicode_compatible
 class QuizSubmissionEvent(CanvasObject):
     def __str__(self):
         return "{}".format(self.event_type)
 
 
-@python_2_unicode_compatible
 class QuizSubmissionQuestion(CanvasObject):
     def __str__(self):
         return "QuizSubmissionQuestion #{}".format(self.id)
@@ -888,7 +876,6 @@ class QuizSubmissionQuestion(CanvasObject):
         return True
 
 
-@python_2_unicode_compatible
 class QuizAssignmentOverrideSet(CanvasObject):
     def __str__(self):
         return "Overrides for quiz_id {}".format(self.quiz_id)

--- a/canvasapi/quiz_group.py
+++ b/canvasapi/quiz_group.py
@@ -1,13 +1,8 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.exceptions import RequiredFieldMissing
 from canvasapi.util import combine_kwargs
 
 
-@python_2_unicode_compatible
 class QuizGroup(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.name, self.id)

--- a/canvasapi/requester.py
+++ b/canvasapi/requester.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 from datetime import datetime
 import logging
 from pprint import pformat

--- a/canvasapi/rubric.py
+++ b/canvasapi/rubric.py
@@ -1,18 +1,12 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 
 
-@python_2_unicode_compatible
 class Rubric(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.title, self.id)
 
 
-@python_2_unicode_compatible
 class RubricAssociation(CanvasObject):
     def __str__(self):
         return "{}, {}".format(self.id, self.association_type)

--- a/canvasapi/scope.py
+++ b/canvasapi/scope.py
@@ -1,11 +1,6 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 
 
-@python_2_unicode_compatible
 class Scope(CanvasObject):
     def __str__(self):
         return "{}".format(self.resource)

--- a/canvasapi/section.py
+++ b/canvasapi/section.py
@@ -1,7 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import warnings
-
-from six import python_2_unicode_compatible
 
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.paginated_list import PaginatedList
@@ -10,7 +7,6 @@ from canvasapi.submission import GroupedSubmission, Submission
 from canvasapi.util import combine_kwargs, obj_or_id, normalize_bool
 
 
-@python_2_unicode_compatible
 class Section(CanvasObject):
     def __str__(self):
         return "{} - {} ({})".format(self.name, self.course_id, self.id)

--- a/canvasapi/sis_import.py
+++ b/canvasapi/sis_import.py
@@ -1,13 +1,8 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.progress import Progress
 from canvasapi.util import combine_kwargs
 
 
-@python_2_unicode_compatible
 class SisImport(CanvasObject):
     def __str__(self):  # pragma: no cover
         return "{} ({})".format(self.workflow_state, self.id)

--- a/canvasapi/submission.py
+++ b/canvasapi/submission.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.paginated_list import PaginatedList
 from canvasapi.peer_review import PeerReview
@@ -9,7 +5,6 @@ from canvasapi.upload import Uploader
 from canvasapi.util import combine_kwargs, obj_or_id
 
 
-@python_2_unicode_compatible
 class Submission(CanvasObject):
     def __str__(self):
         return "{}-{}".format(self.assignment_id, self.user_id)
@@ -176,7 +171,6 @@ class Submission(CanvasObject):
         return response
 
 
-@python_2_unicode_compatible
 class GroupedSubmission(CanvasObject):
     def __init__(self, requester, attributes):
         super(GroupedSubmission, self).__init__(requester, attributes)

--- a/canvasapi/tab.py
+++ b/canvasapi/tab.py
@@ -1,12 +1,7 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.util import combine_kwargs
 
 
-@python_2_unicode_compatible
 class Tab(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.label, self.id)

--- a/canvasapi/upload.py
+++ b/canvasapi/upload.py
@@ -1,8 +1,5 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import json
 import os
-
-from six import string_types
 
 from canvasapi.util import combine_kwargs
 
@@ -21,7 +18,7 @@ class Uploader(object):
         :param file: A file handler or path of the file to upload.
         :type file: file or str
         """
-        if isinstance(file, string_types):
+        if isinstance(file, str):
             if not os.path.exists(file):
                 raise IOError("File " + file + " does not exist.")
             self._using_filename = True

--- a/canvasapi/usage_rights.py
+++ b/canvasapi/usage_rights.py
@@ -1,11 +1,6 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible
-
 from canvasapi.canvas_object import CanvasObject
 
 
-@python_2_unicode_compatible
 class UsageRights(CanvasObject):
     def __str__(self):
         return "{} {}".format(self.use_justification, self.license)

--- a/canvasapi/user.py
+++ b/canvasapi/user.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from six import python_2_unicode_compatible, string_types
 import warnings
 
 from canvasapi.calendar_event import CalendarEvent
@@ -15,7 +12,6 @@ from canvasapi.usage_rights import UsageRights
 from canvasapi.util import combine_kwargs, obj_or_id, obj_or_str
 
 
-@python_2_unicode_compatible
 class User(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.name, self.id)
@@ -87,7 +83,7 @@ class User(CanvasObject):
 
         if isinstance(migration_type, Migrator):
             kwargs["migration_type"] = migration_type.type
-        elif isinstance(migration_type, string_types):
+        elif isinstance(migration_type, str):
             kwargs["migration_type"] = migration_type
         else:
             raise TypeError("Parameter migration_type must be of type Migrator or str")
@@ -1024,7 +1020,6 @@ class User(CanvasObject):
         ).start()
 
 
-@python_2_unicode_compatible
 class UserDisplay(CanvasObject):
     def __str__(self):
         return "{}".format(self.display_name)

--- a/canvasapi/util.py
+++ b/canvasapi/util.py
@@ -1,8 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os
-
-from six import binary_type, string_types, text_type
 
 
 def is_multivalued(value):
@@ -20,7 +16,7 @@ def is_multivalued(value):
     """
 
     # special cases: iterable, but not multivalued
-    if isinstance(value, (string_types, binary_type)):
+    if isinstance(value, (str, bytes)):
         return False
 
     # general rule: multivalued if iterable
@@ -59,7 +55,7 @@ def combine_kwargs(**kwargs):
                 for tup in flatten_kwarg("", i):
                     combined_kwargs.append(("{}{}".format(kw, tup[0]), tup[1]))
         else:
-            combined_kwargs.append((text_type(kw), arg))
+            combined_kwargs.append((str(kw), arg))
 
     return combined_kwargs
 
@@ -99,7 +95,7 @@ def flatten_kwarg(key, obj):
         return new_list
     else:
         # Base case. Return list with tuple containing the value
-        return [("[{}]".format(text_type(key)), obj)]
+        return [("[{}]".format(str(key)), obj)]
 
 
 def obj_or_id(parameter, param_name, object_types):
@@ -151,16 +147,16 @@ def obj_or_str(obj, attr, object_types):
     :rtype: str
     """
     try:
-        return text_type(getattr(obj, attr))
+        return str(getattr(obj, attr))
     except (AttributeError, TypeError):
-        if not isinstance(attr, string_types):
+        if not isinstance(attr, str):
             raise TypeError(
                 "Atttibute parameter {} must be of type string".format(attr)
             )
         for obj_type in object_types:
             if isinstance(obj, obj_type):
                 try:
-                    return text_type(getattr(obj, attr))
+                    return str(getattr(obj, attr))
                 except AttributeError:
                     raise AttributeError("{} object does not have {} attribute").format(
                         obj, attr
@@ -199,7 +195,7 @@ def file_or_path(file):
     """
 
     is_path = False
-    if isinstance(file, string_types):
+    if isinstance(file, str):
         if not os.path.exists(file):
             raise IOError("File at path " + file + " does not exist.")
         file = open(file, "rb")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pytz
 requests
-six

--- a/scripts/alphabetic.py
+++ b/scripts/alphabetic.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import inspect
 import operator
 import os

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import inspect
 import os
 import re

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import re
 from setuptools import setup
 
@@ -23,7 +22,7 @@ setup(
     license='MIT License',
     packages=['canvasapi'],
     include_package_data=True,
-    install_requires=['pytz', 'requests', 'six'],
+    install_requires=['pytz', 'requests'],
     zip_safe=False,
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -33,11 +33,10 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: Libraries',
     ],
 )

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 BASE_URL = "https://example.com"
 BASE_URL_GRAPHQL = "https://example.com/api/"
 BASE_URL_WITH_VERSION = "https://example.com/api/v1/"

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import datetime
 import pytz
 import unittest

--- a/tests/test_appointment_group.py
+++ b/tests/test_appointment_group.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 import uuid
 

--- a/tests/test_authentication_event.py
+++ b/tests/test_authentication_event.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_authentication_providers.py
+++ b/tests/test_authentication_providers.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_bookmark.py
+++ b/tests/test_bookmark.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_calendar_event.py
+++ b/tests/test_calendar_event.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -1,12 +1,9 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import unittest
 import warnings
 from datetime import datetime
 
 import pytz
 import requests_mock
-from six import text_type
 
 from canvasapi import Canvas
 from canvasapi.account import Account
@@ -166,7 +163,7 @@ class TestCanvas(unittest.TestCase):
         course = self.canvas.get_course(2)
 
         self.assertTrue(hasattr(course, "start_at"))
-        self.assertIsInstance(course.start_at, text_type)
+        self.assertIsInstance(course.start_at, str)
         self.assertTrue(hasattr(course, "start_at_date"))
         self.assertIsInstance(course.start_at_date, datetime)
         self.assertEqual(course.start_at_date.tzinfo, pytz.utc)

--- a/tests/test_canvas_object.py
+++ b/tests/test_canvas_object.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 import warnings
 

--- a/tests/test_collaboration.py
+++ b/tests/test_collaboration.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_comm_messages.py
+++ b/tests/test_comm_messages.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_communication_channel.py
+++ b/tests/test_communication_channel.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_content_export.py
+++ b/tests/test_content_export.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_content_migration.py
+++ b/tests/test_content_migration.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_course.py
+++ b/tests/test_course.py
@@ -1,12 +1,10 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
+from urllib.parse import quote
 import uuid
 import warnings
 
 import requests
 import requests_mock
-from six import text_type
-from six.moves.urllib.parse import quote
 
 from canvasapi import Canvas
 from canvasapi.assignment import Assignment, AssignmentGroup, AssignmentOverride
@@ -42,8 +40,7 @@ from canvasapi.rubric import Rubric, RubricAssociation
 from canvasapi.section import Section
 from canvasapi.submission import GroupedSubmission, Submission
 from canvasapi.tab import Tab
-from canvasapi.user import User
-from canvasapi.user import UserDisplay
+from canvasapi.user import User, UserDisplay
 from canvasapi.usage_rights import UsageRights
 from canvasapi.content_migration import ContentMigration, Migrator
 from canvasapi.content_export import ContentExport
@@ -224,7 +221,7 @@ class TestCourse(unittest.TestCase):
         html_str = "<script></script><p>hello</p>"
         prev_html = self.course.preview_html(html_str)
 
-        self.assertIsInstance(prev_html, text_type)
+        self.assertIsInstance(prev_html, str)
         self.assertEqual(prev_html, "<p>hello</p>")
 
     # get_settings()

--- a/tests/test_course_epub_export.py
+++ b/tests/test_course_epub_export.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_current_user.py
+++ b/tests/test_current_user.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_discussion_topic.py
+++ b/tests/test_discussion_topic.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_enrollment.py
+++ b/tests/test_enrollment.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_enrollment_term.py
+++ b/tests/test_enrollment_term.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_external_feed.py
+++ b/tests/test_external_feed.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_external_tool.py
+++ b/tests/test_external_tool.py
@@ -1,8 +1,6 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock
-from six import text_type
 
 from canvasapi import Canvas
 from canvasapi.account import Account
@@ -93,9 +91,7 @@ class TestExternalTool(unittest.TestCase):
         requires = {"external_tool": ["get_sessionless_launch_url_course"]}
         register_uris(requires, m)
 
-        self.assertIsInstance(
-            self.ext_tool_course.get_sessionless_launch_url(), text_type
-        )
+        self.assertIsInstance(self.ext_tool_course.get_sessionless_launch_url(), str)
 
     def test_get_sessionless_launch_url_no_url(self, m):
         requires = {

--- a/tests/test_favorite.py
+++ b/tests/test_favorite.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 from os.path import isfile
 

--- a/tests/test_folder.py
+++ b/tests/test_folder.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 import uuid
 

--- a/tests/test_gradebook_history.py
+++ b/tests/test_gradebook_history.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_grading_period.py
+++ b/tests/test_grading_period.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_grading_standard.py
+++ b/tests/test_grading_standard.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1,11 +1,10 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
+from urllib.parse import quote
 import uuid
 import warnings
 
 import requests
 import requests_mock
-from six.moves.urllib.parse import quote
 
 from canvasapi import Canvas
 from canvasapi.assignment import AssignmentOverride

--- a/tests/test_licenses.py
+++ b/tests/test_licenses.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_notification_preference.py
+++ b/tests/test_notification_preference.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_outcome.py
+++ b/tests/test_outcome.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_outcome_import.py
+++ b/tests/test_outcome_import.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_page_view.py
+++ b/tests/test_page_view.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_paginated_list.py
+++ b/tests/test_paginated_list.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_peer_review.py
+++ b/tests/test_peer_review.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_poll.py
+++ b/tests/test_poll.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_poll_choice.py
+++ b/tests/test_poll_choice.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_poll_session.py
+++ b/tests/test_poll_session.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_poll_submission.py
+++ b/tests/test_poll_submission.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_quiz.py
+++ b/tests/test_quiz.py
@@ -1,9 +1,7 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 import warnings
 
 import requests_mock
-from six import text_type
 
 from canvasapi import Canvas
 from canvasapi.exceptions import RequiredFieldMissing
@@ -454,7 +452,7 @@ class TestQuizSubmission(unittest.TestCase):
         self.assertIn("end_at", submission)
         self.assertIn("time_left", submission)
         self.assertIsInstance(submission["time_left"], int)
-        self.assertIsInstance(submission["end_at"], text_type)
+        self.assertIsInstance(submission["end_at"], str)
 
     # update_score_and_comments
     def test_update_score_and_comments(self, m):

--- a/tests/test_quiz_group.py
+++ b/tests/test_quiz_group.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_requester.py
+++ b/tests/test_requester.py
@@ -1,10 +1,9 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 from datetime import datetime
 import unittest
+from urllib.parse import quote
 
 import requests
 import requests_mock
-from six.moves.urllib.parse import quote
 
 from canvasapi import Canvas
 from canvasapi.exceptions import (

--- a/tests/test_rubric.py
+++ b/tests/test_rubric.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 import warnings
 

--- a/tests/test_sis_import.py
+++ b/tests/test_sis_import.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 import uuid
 import warnings

--- a/tests/test_tab.py
+++ b/tests/test_tab.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 import uuid
 

--- a/tests/test_usage_rights.py
+++ b/tests/test_usage_rights.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 
 import requests_mock

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 import uuid
 import warnings

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest
 import uuid
 
@@ -18,8 +17,6 @@ from canvasapi.util import (
     normalize_bool,
 )
 from itertools import chain
-from six import integer_types, iterkeys, itervalues, iteritems, string_types, text_type
-from six.moves import zip
 from tests import settings
 from tests.util import cleanup_file, register_uris
 
@@ -33,9 +30,8 @@ class TestUtil(unittest.TestCase):
     def test_is_multivalued_bool(self, m):
         self.assertFalse(is_multivalued(False))
 
-    def test_is_multivalued_integer_types(self, m):
-        for type in integer_types:
-            self.assertFalse(is_multivalued(type(1)))
+    def test_is_multivalued_integer(self, m):
+        self.assertFalse(is_multivalued(int(1)))
 
     def test_is_multivalued_str(self, m):
         self.assertFalse(is_multivalued("string"))
@@ -71,13 +67,13 @@ class TestUtil(unittest.TestCase):
         self.assertTrue(is_multivalued(iter({"key": "value"})))
 
     def test_is_multivalued_dict_keys(self, m):
-        self.assertTrue(is_multivalued(iterkeys({"key": "value"})))
+        self.assertTrue(is_multivalued({"key": "value"}.keys()))
 
     def test_is_multivalued_dict_values(self, m):
-        self.assertTrue(is_multivalued(itervalues({"key": "value"})))
+        self.assertTrue(is_multivalued({"key": "value"}.values()))
 
     def test_is_multivalued_dict_items(self, m):
-        self.assertTrue(is_multivalued(iteritems({"key": "value"})))
+        self.assertTrue(is_multivalued({"key": "value"}.items()))
 
     def test_is_multivalued_generator_expr(self, m):
         self.assertTrue(is_multivalued(item for item in ("item",)))
@@ -428,7 +424,7 @@ class TestUtil(unittest.TestCase):
     def test_obj_or_id_user_self(self, m):
         user_id = obj_or_id("self", "user_id", (User,))
 
-        self.assertIsInstance(user_id, text_type)
+        self.assertIsInstance(user_id, str)
         self.assertEqual(user_id, "self")
 
     def test_obj_or_id_nonuser_self(self, m):
@@ -443,7 +439,7 @@ class TestUtil(unittest.TestCase):
 
         user_name = obj_or_str(user, "name", (User,))
 
-        self.assertIsInstance(user_name, string_types)
+        self.assertIsInstance(user_name, str)
         self.assertEqual(user_name, "John Doe")
 
     def test_obj_or_str_obj_no_attr(self, m):
@@ -461,7 +457,7 @@ class TestUtil(unittest.TestCase):
 
         user_name = obj_or_str(user, "name", (CourseNickname, User))
 
-        self.assertIsInstance(user_name, string_types)
+        self.assertIsInstance(user_name, str)
 
     def test_obj_or_str_invalid_attr_parameter(self, m):
         register_uris({"user": ["get_by_id"]}, m)

--- a/tests/test_validate_docstrings.py
+++ b/tests/test_validate_docstrings.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import re
 import io
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import json
 import os
 


### PR DESCRIPTION
# Proposed Changes

* Drop support and testing for Python 2.7, 3.4, and 3.5
* Add support and testing for Python 3.8
* Remove `six` as a dependency
* Remove `six` methods or replace with their Py3-only equivalent
* Remove `__future__` imports

Fixes #384.
