### PR TITLE
Fix Quiz Group Course ID

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -30,6 +30,7 @@ Patches and Suggestions
 - Erik Tews [@eriktews](https://github.com/eriktews)
 - Ethan Finlay [@atarisafari](https://github.com/atarisafari)
 - Gabriela Dijkhoffz [@gdijkhoffz](https://github.com/gdijkhoffz)
+- Harlan Colclough [@hcolclou](https://github.com/hcolclou)
 - Henry Acevedo [@Colombiangmr](https://github.com/Colombiangmr)
 - Ian Altgilbers [@altgilbers](https://github.com/altgilbers)
 - Ian Turgeon [@iturgeon](https://github.com/iturgeon)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Bugfixes
+
+- Fixed an issue where Quiz.get_quiz_group incorrectly set `course_id` to the quiz ID.  (Thanks,[@hcolclou](https://github.com/hcolclou))
+
+
 ## [1.0.0] - 2020-07-09
 
 ### General

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 - Fixed an issue where Quiz.get_quiz_group incorrectly set `course_id` to the quiz ID.  (Thanks,[@hcolclou](https://github.com/hcolclou))
 
-
 ## [1.0.0] - 2020-07-09
 
 ### General

--- a/canvasapi/quiz.py
+++ b/canvasapi/quiz.py
@@ -292,7 +292,7 @@ class Quiz(CanvasObject):
         )
 
         response_json = response.json()
-        response_json.update({"course_id": self.id})
+        response_json.update({"course_id": self.course_id})
 
         return QuizGroup(self._requester, response_json)
 

--- a/tests/fixtures/quiz.json
+++ b/tests/fixtures/quiz.json
@@ -68,12 +68,21 @@
 		},
 		"status_code": 200
 	},
+	"get_by_id_5": {
+		"method": "GET",
+		"endpoint": "courses/1/quizzes/5",
+		"data": {
+			"id": 5,
+			"title": "Quiz Numbah Five"
+		},
+		"status_code": 200
+	},
 	"get_quiz_group": {
 		"method": "GET",
-		"endpoint": "courses/1/quizzes/1/groups/1",
+		"endpoint": "courses/1/quizzes/5/groups/10",
 		"data": {
-			"id": 1,
-			"quiz_id": 1,
+			"id": 10,
+			"quiz_id": 5,
 			"name": "Test Group",
 			"pick_count": 1,
 			"question_points": 2,

--- a/tests/fixtures/quiz_group.json
+++ b/tests/fixtures/quiz_group.json
@@ -1,11 +1,11 @@
 {
 	"update": {
 		"method": "PUT",
-		"endpoint": "courses/1/quizzes/1/groups/1",
+		"endpoint": "courses/1/quizzes/5/groups/10",
 		"data": {"quiz_groups": [
 			{
-				"id": 1,
-				"quiz_id": 1,
+				"id": 10,
+				"quiz_id": 5,
 				"name": "Test Group",
 				"pick_count": 1,
 				"question_points": 2,
@@ -16,12 +16,12 @@
 	},
 	"delete": {
 		"method": "DELETE",
-		"endpoint": "courses/1/quizzes/1/groups/1",
+		"endpoint": "courses/1/quizzes/5/groups/10",
 		"status_code": 204
 	},
 	"reorder_question_group": {
 		"method": "POST",
-		"endpoint": "courses/1/quizzes/1/groups/1/reorder",
+		"endpoint": "courses/1/quizzes/5/groups/10/reorder",
 		"status_code": 204
 	}
 }

--- a/tests/test_quiz.py
+++ b/tests/test_quiz.py
@@ -87,12 +87,16 @@ class TestQuiz(unittest.TestCase):
 
     # get_quiz_group()
     def test_get_quiz_group(self, m):
-        register_uris({"quiz": ["get_quiz_group"]}, m)
+        register_uris({"quiz": ["get_by_id_5", "get_quiz_group"]}, m)
 
-        result = self.quiz.get_quiz_group(1)
+        quiz = self.course.get_quiz(5)
+
+        result = quiz.get_quiz_group(10)
         self.assertIsInstance(result, QuizGroup)
-        self.assertEqual(result.id, 1)
-        self.assertEqual(result.quiz_id, 1)
+        self.assertEqual(result.id, 10)
+        self.assertEqual(result.quiz_id, 5)
+        self.assertTrue(hasattr(result, "course_id"))
+        self.assertEqual(result.course_id, 1)
 
     # create_question_group()
     def test_create_question_group(self, m):

--- a/tests/test_quiz_group.py
+++ b/tests/test_quiz_group.py
@@ -15,11 +15,11 @@ class TestQuizGroup(unittest.TestCase):
 
         with requests_mock.Mocker() as m:
             register_uris(
-                {"course": ["get_by_id"], "quiz": ["get_by_id", "get_quiz_group"]}, m
+                {"course": ["get_by_id"], "quiz": ["get_by_id_5", "get_quiz_group"]}, m
             )
 
             self.course = self.canvas.get_course(1)
-            self.quiz_group = self.course.get_quiz(1).get_quiz_group(1)
+            self.quiz_group = self.course.get_quiz(5).get_quiz_group(10)
 
     # __str__()
     def test__str__(self, m):
@@ -31,13 +31,13 @@ class TestQuizGroup(unittest.TestCase):
         register_uris({"quiz_group": ["update"]}, m)
 
         quiz_group = [{"name": "Test Group", "pick_count": 1, "question_points": 2}]
-        result = self.quiz_group.update(1, quiz_group)
+        result = self.quiz_group.update(10, quiz_group)
 
         self.assertIsInstance(result, bool)
         self.assertTrue(result)
 
-        self.assertEqual(self.quiz_group.id, 1)
-        self.assertEqual(self.quiz_group.quiz_id, 1)
+        self.assertEqual(self.quiz_group.id, 10)
+        self.assertEqual(self.quiz_group.quiz_id, 5)
         self.assertEqual(self.quiz_group.name, quiz_group[0].get("name"))
         self.assertEqual(self.quiz_group.pick_count, quiz_group[0].get("pick_count"))
         self.assertEqual(
@@ -50,7 +50,7 @@ class TestQuizGroup(unittest.TestCase):
         quiz_group = []
 
         with self.assertRaises(ValueError):
-            self.quiz_group.update(1, quiz_group)
+            self.quiz_group.update(10, quiz_group)
 
     def test_update_incorrect_param(self, m):
         register_uris({"quiz_group": ["update"]}, m)
@@ -58,7 +58,7 @@ class TestQuizGroup(unittest.TestCase):
         quiz_group = [1]
 
         with self.assertRaises(ValueError):
-            self.quiz_group.update(1, quiz_group)
+            self.quiz_group.update(10, quiz_group)
 
     def test_update_incorrect_dict(self, m):
         register_uris({"quiz_group": ["update"]}, m)
@@ -66,13 +66,13 @@ class TestQuizGroup(unittest.TestCase):
         quiz_group = [{}]
 
         with self.assertRaises(RequiredFieldMissing):
-            self.quiz_group.update(1, quiz_group)
+            self.quiz_group.update(10, quiz_group)
 
     # delete_question_group()
     def test_delete(self, m):
         register_uris({"quiz_group": ["delete"]}, m)
 
-        result = self.quiz_group.delete(1)
+        result = self.quiz_group.delete(10)
 
         self.assertTrue(result)
 
@@ -81,7 +81,7 @@ class TestQuizGroup(unittest.TestCase):
         register_uris({"quiz_group": ["reorder_question_group"]}, m)
 
         newOrdering = [{"id": 2}, {"id": 1, "type": "question"}]
-        result = self.quiz_group.reorder_question_group(1, newOrdering)
+        result = self.quiz_group.reorder_question_group(10, newOrdering)
 
         self.assertTrue(result)
 
@@ -91,7 +91,7 @@ class TestQuizGroup(unittest.TestCase):
         order = []
 
         with self.assertRaises(ValueError):
-            self.quiz_group.reorder_question_group(1, order)
+            self.quiz_group.reorder_question_group(10, order)
 
     def test_reorderquestion_group_incorrect_param(self, m):
         register_uris({"quiz_group": ["reorder_question_group"]}, m)
@@ -99,7 +99,7 @@ class TestQuizGroup(unittest.TestCase):
         order = [1]
 
         with self.assertRaises(ValueError):
-            self.quiz_group.reorder_question_group(1, order)
+            self.quiz_group.reorder_question_group(10, order)
 
     def test_reorderquestion_group_incorrect_dict(self, m):
         register_uris({"quiz_group": ["reorder_question_group"]}, m)
@@ -107,4 +107,4 @@ class TestQuizGroup(unittest.TestCase):
         order = [{"something": 2}]
 
         with self.assertRaises(ValueError):
-            self.quiz_group.reorder_question_group(1, order)
+            self.quiz_group.reorder_question_group(10, order)


### PR DESCRIPTION
# Proposed Changes

Previously, Quiz.get_quiz_group set the course ID of the quiz group to be the ID of the quiz. This caused errors when using the constructed QuizGroup to make requests as the course ID was incorrect causing the URL to be incorrect. This change fixes that issue by setting the course ID of the quiz group to be the course ID of the course the quiz is contained in.
