### PR TITLE
Issue #402 Create External Tool - Client ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 ### Bugfixes
 
-- Fixed an issue where Quiz.get_quiz_group incorrectly set `course_id` to the quiz ID.  (Thanks,[@hcolclou](https://github.com/hcolclou))
+- Fixed an issue where `Quiz.get_quiz_group` incorrectly set `course_id` to the quiz ID.  (Thanks,[@hcolclou](https://github.com/hcolclou))
+- Fixed an issue where `Course.create_external_tool` didn't accept `client_id` (LTI 1.3 support).
+
+### Breaking Changes
+
+- `Course.create_external_tool` no longer supports positional arguments for its required parameters. Use keyword arguments instead.
 
 ## [1.0.0] - 2020-07-09
 

--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -275,9 +275,7 @@ class Course(CanvasObject):
         )
         return ExternalFeed(self._requester, response.json())
 
-    def create_external_tool(
-        self, name, privacy_level, consumer_key, shared_secret, **kwargs
-    ):
+    def create_external_tool(self, **kwargs):
         """
         Create an external tool in the current course.
 
@@ -286,24 +284,21 @@ class Course(CanvasObject):
 
         :param name: The name of the tool
         :type name: str
-        :param privacy_level: What information to send to the external
-            tool. Options are "anonymous", "name_only", "public"
-        :type privacy_level: str
-        :param consumer_key: The consumer key for the external tool
-        :type consumer_key: str
-        :param shared_secret: The shared secret with the external tool
-        :type shared_secret: str
+
         :rtype: :class:`canvasapi.external_tool.ExternalTool`
         """
         from canvasapi.external_tool import ExternalTool
 
+        required_params = ["name", "privacy_level", "consumer_key", "shared_secret"]
+        if "client_id" not in kwargs and not all(x in kwargs for x in required_params):
+            raise RequiredFieldMissing(
+                "Must pass either `client_id` parameter or "
+                "`name`, `privacy_level`, `consumer_key`, and `shared_secret` parameters."
+            )
+
         response = self._requester.request(
             "POST",
             "courses/{}/external_tools".format(self.id),
-            name=name,
-            privacy_level=privacy_level,
-            consumer_key=consumer_key,
-            shared_secret=shared_secret,
             _kwargs=combine_kwargs(**kwargs),
         )
         response_json = response.json()

--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -289,7 +289,7 @@ class Course(CanvasObject):
         """
         from canvasapi.external_tool import ExternalTool
 
-        required_params = ["name", "privacy_level", "consumer_key", "shared_secret"]
+        required_params = ("name", "privacy_level", "consumer_key", "shared_secret")
         if "client_id" not in kwargs and not all(x in kwargs for x in required_params):
             raise RequiredFieldMissing(
                 "Must pass either `client_id` parameter or "

--- a/tests/test_course.py
+++ b/tests/test_course.py
@@ -883,6 +883,25 @@ class TestCourse(unittest.TestCase):
         self.assertTrue(hasattr(response, "id"))
         self.assertEqual(response.id, 20)
 
+    def test_create_external_tool_client_id(self, m):
+        register_uris({"external_tool": ["create_tool_course"]}, m)
+
+        response = self.course.create_external_tool(client_id="10000000000001")
+
+        self.assertIsInstance(response, ExternalTool)
+        self.assertTrue(hasattr(response, "id"))
+        self.assertEqual(response.id, 20)
+
+    def test_create_external_tool_no_params(self, m):
+        with self.assertRaises(RequiredFieldMissing):
+            self.course.create_external_tool()
+
+    def test_create_external_tool_missing_params(self, m):
+        with self.assertRaises(RequiredFieldMissing):
+            self.course.create_external_tool(
+                consumer_key="key", shared_secret="secret",
+            )
+
     # get_collaborations
     def test_get_collaborations(self, m):
         register_uris({"course": ["get_collaborations"]}, m)


### PR DESCRIPTION
# Proposed Changes

* Remove positional arguments from `Course.create_external_tool` to allow `client_id` to be passed for LTI 1.3 support.

Fixes #402.
