### PR TITLE
Fixes #444

### DIFF
--- a/canvasapi/canvas.py
+++ b/canvasapi/canvas.py
@@ -12,6 +12,7 @@ from canvasapi.group import Group, GroupCategory
 from canvasapi.paginated_list import PaginatedList
 from canvasapi.requester import Requester
 from canvasapi.section import Section
+from canvasapi.todo import Todo
 from canvasapi.user import User
 from canvasapi.util import combine_kwargs, get_institution_url, obj_or_id
 
@@ -1170,10 +1171,13 @@ class Canvas(object):
 
         :rtype: dict
         """
-        response = self.__requester.request(
-            "GET", "users/self/todo", _kwargs=combine_kwargs(**kwargs)
+        return PaginatedList(
+            Todo,
+            self.__requester,
+            "GET",
+            "users/self/todo",
+            _kwargs=combine_kwargs(**kwargs),
         )
-        return response.json()
 
     def get_upcoming_events(self, **kwargs):
         """

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -21,6 +21,7 @@ from canvasapi.outcome import Outcome, OutcomeGroup
 from canvasapi.paginated_list import PaginatedList
 from canvasapi.progress import Progress
 from canvasapi.section import Section
+from canvasapi.todo import Todo
 from canvasapi.user import User
 from tests import settings
 from tests.util import register_uris
@@ -240,8 +241,9 @@ class TestCanvas(unittest.TestCase):
         register_uris({"user": ["todo_items"]}, m)
 
         todo_items = self.canvas.get_todo_items()
+        todo_list = [todo for todo in todo_items]
 
-        self.assertIsInstance(todo_items, list)
+        self.assertIsInstance(todo_list[0], Todo)
 
     # get_upcoming_events()
     def test_get_upcoming_events(self, m):


### PR DESCRIPTION
`canvas.get_todo_items` returns a `PaginatedList` of `Todo` items.

Fixes #444
