### PR TITLE
Fix typos in assignment.py

### DIFF
--- a/canvasapi/assignment.py
+++ b/canvasapi/assignment.py
@@ -222,11 +222,11 @@ class Assignment(CanvasObject):
         >>> assignment.set_extensions([
         ...     {
         ...         'user_id': 3,
-        ...         'extra_attempts: 2
+        ...         'extra_attempts': 2
         ...     },
         ...     {
         ...         'user_id': 2,
-        ...         'extra_attempts: 2
+        ...         'extra_attempts': 2
         ...     }
         ... ])
         """


### PR DESCRIPTION
# Proposed Changes

Resolves two minor typos in `assignment.py` that result in invalid syntax.

Discovered when running doctests over the codebase for an unrelated branch.