### PR TITLE
issue/97 accept path like objects for file uploads

### DIFF
--- a/canvasapi/assignment.py
+++ b/canvasapi/assignment.py
@@ -4,7 +4,7 @@ from canvasapi.paginated_list import PaginatedList
 from canvasapi.peer_review import PeerReview
 from canvasapi.progress import Progress
 from canvasapi.submission import Submission
-from canvasapi.upload import Uploader
+from canvasapi.upload import Uploader, FileOrPathLike
 from canvasapi.user import User, UserDisplay
 from canvasapi.util import combine_kwargs, obj_or_id
 
@@ -318,7 +318,7 @@ class Assignment(CanvasObject):
 
         return Submission(self._requester, response_json)
 
-    def upload_to_submission(self, file, user="self", **kwargs):
+    def upload_to_submission(self, file: FileOrPathLike, user="self", **kwargs):
         """
         Upload a file to a submission.
 
@@ -327,7 +327,7 @@ class Assignment(CanvasObject):
         <https://canvas.instructure.com/doc/api/submissions.html#method.submissions_api.create_file>`_
 
         :param file: The file or path of the file to upload.
-        :type file: file or str
+        :type file: FileLike
         :param user: The object or ID of the related user, or 'self' for the
             current user. Defaults to 'self'.
         :type user: :class:`canvasapi.user.User`, int, or str

--- a/canvasapi/assignment.py
+++ b/canvasapi/assignment.py
@@ -4,7 +4,7 @@ from canvasapi.paginated_list import PaginatedList
 from canvasapi.peer_review import PeerReview
 from canvasapi.progress import Progress
 from canvasapi.submission import Submission
-from canvasapi.upload import Uploader, FileOrPathLike
+from canvasapi.upload import FileOrPathLike, Uploader
 from canvasapi.user import User, UserDisplay
 from canvasapi.util import combine_kwargs, obj_or_id
 

--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -28,7 +28,7 @@ from canvasapi.rubric import Rubric, RubricAssociation
 from canvasapi.submission import GroupedSubmission, Submission
 from canvasapi.tab import Tab
 from canvasapi.todo import Todo
-from canvasapi.upload import Uploader, FileOrPathLike
+from canvasapi.upload import FileOrPathLike, Uploader
 from canvasapi.usage_rights import UsageRights
 from canvasapi.util import (
     combine_kwargs,

--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -28,7 +28,7 @@ from canvasapi.rubric import Rubric, RubricAssociation
 from canvasapi.submission import GroupedSubmission, Submission
 from canvasapi.tab import Tab
 from canvasapi.todo import Todo
-from canvasapi.upload import Uploader
+from canvasapi.upload import Uploader, FileOrPathLike
 from canvasapi.usage_rights import UsageRights
 from canvasapi.util import (
     combine_kwargs,
@@ -2621,7 +2621,7 @@ class Course(CanvasObject):
         )
         return response.json()
 
-    def upload(self, file, **kwargs):
+    def upload(self, file: FileOrPathLike, **kwargs):
         """
         Upload a file to this course.
 

--- a/canvasapi/folder.py
+++ b/canvasapi/folder.py
@@ -1,6 +1,6 @@
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.paginated_list import PaginatedList
-from canvasapi.upload import Uploader, FileOrPathLike
+from canvasapi.upload import FileOrPathLike, Uploader
 from canvasapi.util import combine_kwargs, obj_or_id
 
 

--- a/canvasapi/folder.py
+++ b/canvasapi/folder.py
@@ -1,6 +1,6 @@
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.paginated_list import PaginatedList
-from canvasapi.upload import Uploader
+from canvasapi.upload import Uploader, FileOrPathLike
 from canvasapi.util import combine_kwargs, obj_or_id
 
 
@@ -119,7 +119,7 @@ class Folder(CanvasObject):
 
         return Folder(self._requester, response.json())
 
-    def upload(self, file, **kwargs):
+    def upload(self, file: FileOrPathLike, **kwargs):
         """
         Upload a file to this folder.
 

--- a/canvasapi/group.py
+++ b/canvasapi/group.py
@@ -6,9 +6,9 @@ from canvasapi.folder import Folder
 from canvasapi.license import License
 from canvasapi.paginated_list import PaginatedList
 from canvasapi.tab import Tab
+from canvasapi.upload import FileOrPathLike, Uploader
 from canvasapi.usage_rights import UsageRights
 from canvasapi.util import combine_kwargs, is_multivalued, obj_or_id
-from canvasapi.upload import Uploader, FileOrPathLike
 
 
 class Group(CanvasObject):

--- a/canvasapi/group.py
+++ b/canvasapi/group.py
@@ -8,6 +8,7 @@ from canvasapi.paginated_list import PaginatedList
 from canvasapi.tab import Tab
 from canvasapi.usage_rights import UsageRights
 from canvasapi.util import combine_kwargs, is_multivalued, obj_or_id
+from canvasapi.upload import Uploader, FileOrPathLike
 
 
 class Group(CanvasObject):
@@ -966,7 +967,7 @@ class Group(CanvasObject):
         )
         return GroupMembership(self._requester, response.json())
 
-    def upload(self, file, **kwargs):
+    def upload(self, file: FileOrPathLike, **kwargs):
         """
         Upload a file to the group.
         Only those with the 'Manage Files' permission on a group can upload files to the group.
@@ -983,7 +984,6 @@ class Group(CanvasObject):
                     and the JSON response from the API.
         :rtype: tuple
         """
-        from canvasapi.upload import Uploader
 
         return Uploader(
             self._requester, "groups/{}/files".format(self.id), file, **kwargs

--- a/canvasapi/submission.py
+++ b/canvasapi/submission.py
@@ -1,7 +1,7 @@
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.paginated_list import PaginatedList
 from canvasapi.peer_review import PeerReview
-from canvasapi.upload import Uploader, FileOrPathLike
+from canvasapi.upload import FileOrPathLike, Uploader
 from canvasapi.util import combine_kwargs, obj_or_id
 
 

--- a/canvasapi/submission.py
+++ b/canvasapi/submission.py
@@ -1,7 +1,7 @@
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.paginated_list import PaginatedList
 from canvasapi.peer_review import PeerReview
-from canvasapi.upload import Uploader
+from canvasapi.upload import Uploader, FileOrPathLike
 from canvasapi.util import combine_kwargs, obj_or_id
 
 
@@ -143,7 +143,7 @@ class Submission(CanvasObject):
         )
         return response.status_code == 204
 
-    def upload_comment(self, file, **kwargs):
+    def upload_comment(self, file: FileOrPathLike, **kwargs):
         """
         Upload a file to attach to this submission as a comment.
 

--- a/canvasapi/upload.py
+++ b/canvasapi/upload.py
@@ -1,13 +1,14 @@
 import json
 import os
+import io
 
 from canvasapi.util import combine_kwargs
 
 from typing import Union
 
-PathLike = Union[os.PathLike, str]
+FileOrPathLike = Union[os.PathLike, str, io.IOBase, io.FileIO]
 """
-A path-like object. May be either a :class:`os.PathLike` or a `str`
+A path or file-like object. May be either a :class:`os.PathLike`, a `str`, or a file-like object
 """
 
 
@@ -16,7 +17,7 @@ class Uploader(object):
     Upload a file to Canvas.
     """
 
-    def __init__(self, requester, url, file: PathLike, **kwargs):
+    def __init__(self, requester, url, file: FileOrPathLike, **kwargs):
         """
         :param requester: The :class:`canvasapi.requester.Requester` to pass requests through.
         :type requester: :class:`canvasapi.requester.Requester`

--- a/canvasapi/upload.py
+++ b/canvasapi/upload.py
@@ -1,6 +1,7 @@
 import json
 import os
 import io
+from pathlib import Path
 
 from canvasapi.util import combine_kwargs
 
@@ -47,8 +48,11 @@ class Uploader(object):
             and the JSON response from the API.
         :rtype: tuple
         """
-        self.kwargs["name"] = os.path.basename(file.name)
-        self.kwargs["size"] = os.fstat(file.fileno()).st_size
+        if isinstance(file, Path):
+            self.kwargs.update({"name": file.name, "size": file.stat().st_size})
+        else:
+            self.kwargs["name"] = os.path.basename(file.name)
+            self.kwargs["size"] = os.fstat(file.fileno()).st_size
 
         response = self._requester.request(
             "POST", self.url, _kwargs=combine_kwargs(**self.kwargs)

--- a/canvasapi/upload.py
+++ b/canvasapi/upload.py
@@ -47,11 +47,8 @@ class Uploader(object):
             and the JSON response from the API.
         :rtype: tuple
         """
-        if isinstance(file, Path):
-            self.kwargs.update({"name": file.name, "size": file.stat().st_size})
-        else:
-            self.kwargs["name"] = os.path.basename(file.name)
-            self.kwargs["size"] = os.fstat(file.fileno()).st_size
+        self.kwargs["name"] = os.path.basename(file.name)
+        self.kwargs["size"] = os.fstat(file.fileno()).st_size
 
         response = self._requester.request(
             "POST", self.url, _kwargs=combine_kwargs(**self.kwargs)

--- a/canvasapi/upload.py
+++ b/canvasapi/upload.py
@@ -3,24 +3,31 @@ import os
 
 from canvasapi.util import combine_kwargs
 
+from typing import Union
+
+PathLike = Union[os.PathLike, str]
+"""
+A path-like object. May be either a :class:`os.PathLike` or a `str`
+"""
+
 
 class Uploader(object):
     """
     Upload a file to Canvas.
     """
 
-    def __init__(self, requester, url, file, **kwargs):
+    def __init__(self, requester, url, file: PathLike, **kwargs):
         """
         :param requester: The :class:`canvasapi.requester.Requester` to pass requests through.
         :type requester: :class:`canvasapi.requester.Requester`
         :param url: The URL to upload the file to.
         :type url: str
         :param file: A file handler or path of the file to upload.
-        :type file: file or str
+        :type file: :class:`os.PathLike` or str
         """
-        if isinstance(file, str):
+        if isinstance(file, (os.PathLike, str)):
             if not os.path.exists(file):
-                raise IOError("File " + file + " does not exist.")
+                raise IOError("File {} does not exist.".format(os.fspath(file)))
             self._using_filename = True
         else:
             self._using_filename = False

--- a/canvasapi/upload.py
+++ b/canvasapi/upload.py
@@ -1,7 +1,6 @@
 import io
 import json
 import os
-from pathlib import Path
 from typing import Union
 
 from canvasapi.util import combine_kwargs

--- a/canvasapi/upload.py
+++ b/canvasapi/upload.py
@@ -1,11 +1,10 @@
+import io
 import json
 import os
-import io
 from pathlib import Path
+from typing import Union
 
 from canvasapi.util import combine_kwargs
-
-from typing import Union
 
 FileOrPathLike = Union[os.PathLike, str, io.IOBase, io.FileIO]
 """

--- a/canvasapi/user.py
+++ b/canvasapi/user.py
@@ -6,7 +6,7 @@ from canvasapi.folder import Folder
 from canvasapi.license import License
 from canvasapi.paginated_list import PaginatedList
 from canvasapi.pairing_code import PairingCode
-from canvasapi.upload import Uploader, FileOrPathLike
+from canvasapi.upload import FileOrPathLike, Uploader
 from canvasapi.usage_rights import UsageRights
 from canvasapi.util import combine_kwargs, obj_or_id, obj_or_str
 

--- a/canvasapi/user.py
+++ b/canvasapi/user.py
@@ -6,7 +6,7 @@ from canvasapi.folder import Folder
 from canvasapi.license import License
 from canvasapi.paginated_list import PaginatedList
 from canvasapi.pairing_code import PairingCode
-from canvasapi.upload import Uploader
+from canvasapi.upload import Uploader, FileOrPathLike
 from canvasapi.usage_rights import UsageRights
 from canvasapi.util import combine_kwargs, obj_or_id, obj_or_str
 
@@ -954,7 +954,7 @@ class User(CanvasObject):
         )
         return response.json()
 
-    def upload(self, file, **kwargs):
+    def upload(self, file:FileOrPathLike, **kwargs):
         """
         Upload a file for a user.
 

--- a/canvasapi/user.py
+++ b/canvasapi/user.py
@@ -954,7 +954,7 @@ class User(CanvasObject):
         )
         return response.json()
 
-    def upload(self, file:FileOrPathLike, **kwargs):
+    def upload(self, file: FileOrPathLike, **kwargs):
         """
         Upload a file for a user.
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import re
 from os import path
+
 from setuptools import setup
 
 # get version number

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -1,5 +1,6 @@
 import unittest
 import uuid
+from pathlib import Path
 
 import requests_mock
 
@@ -207,6 +208,24 @@ class TestAssignment(unittest.TestCase):
                 sub_type = "online_upload"
                 sub_dict = {"submission_type": sub_type}
                 submission = self.assignment.submit(sub_dict, file)
+
+            self.assertIsInstance(submission, Submission)
+            self.assertTrue(hasattr(submission, "submission_type"))
+            self.assertEqual(submission.submission_type, sub_type)
+
+        finally:
+            cleanup_file(filename)
+
+    def test_submit_file_pathlib(self, m):
+        register_uris({"assignment": ["submit", "upload", "upload_final"]}, m)
+
+        filename = Path("testfile_assignment_{}".format(uuid.uuid4().hex))
+        filename.write_bytes(b"test data")
+
+        try:
+            sub_type = "online_upload"
+            sub_dict = {"submission_type": sub_type}
+            submission = self.assignment.submit(sub_dict, filename)
 
             self.assertIsInstance(submission, Submission)
             self.assertTrue(hasattr(submission, "submission_type"))

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1,5 +1,6 @@
 import unittest
 import uuid
+from pathlib import Path
 
 import requests_mock
 
@@ -28,6 +29,17 @@ class TestUploader(unittest.TestCase):
         register_uris(requires, m)
 
         uploader = Uploader(self.requester, "upload_response", self.file)
+        result = uploader.start()
+
+        self.assertTrue(result[0])
+        self.assertIsInstance(result[1], dict)
+        self.assertIn("url", result[1])
+
+    def test_start_pathlib(self, m):
+        requires = {"uploader": ["upload_response", "upload_response_upload_url"]}
+        register_uris(requires, m)
+
+        uploader = Uploader(self.requester, "upload_response", Path(self.filename))
         result = uploader.start()
 
         self.assertTrue(result[0])


### PR DESCRIPTION
# Proposed Changes
Add `canvas.upload.FileOrPathLike` type, which represents any `os.PathLike`, `str`, or `io` based file like and path like objects.
Add support in `canvas.upload.Upload`  to accept any `FileOrPathLike`, as per #97 /
Add type annotations to all consumers of `file` arguments which are forwarded into `canvas.upload.Upload`.

Added two tests that use `pathlib.Path` objects to assert correctness.

Fixes #97 .
