### PR TITLE
Issue #466 Add RateLimitExceeded Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### General
+
+- Added `RateLimitExceeded` exception to distinguish between being rate limited and being otherwise forbidden from accesing a resource. It is a subclass of the `Forbidden` exception.
+
 ## [2.1.0] - 2020-12-04
 
 ### New Endpoint Coverage

--- a/canvasapi/exceptions.py
+++ b/canvasapi/exceptions.py
@@ -55,6 +55,15 @@ class Forbidden(CanvasException):
     pass
 
 
+class RateLimitExceeded(Forbidden):
+    """
+    Canvas has recieved to many requests from this access token and is
+    throttling this request. Try again later.
+    """
+
+    pass
+
+
 class Conflict(CanvasException):
     """Canvas had a conflict with an existing resource."""
 

--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -17,6 +17,8 @@ Quick Guide
 +-----------------------------------------------------+-----------------+---------------------------------------------------------------------------------+
 | :class:`~canvasapi.exceptions.Forbidden`            | 403             | Canvas has denied access to the resource for this user.                         |
 +-----------------------------------------------------+-----------------+---------------------------------------------------------------------------------+
+| :class:`~canvasapi.exceptions.RateLimitExceeded`    | 403             | Canvas is throttling this request. Try again later.                             |
++-----------------------------------------------------+-----------------+---------------------------------------------------------------------------------+
 | :class:`~canvasapi.exceptions.ResourceDoesNotExist` | 404             | Canvas could not locate the requested resource.                                 |
 +-----------------------------------------------------+-----------------+---------------------------------------------------------------------------------+
 | :class:`~canvasapi.exceptions.Conflict`             | 409             | Canvas had a conflict with an existing resource.                                |
@@ -81,7 +83,17 @@ Class Reference
 
     The :class:`~canvasapi.exceptions.Forbidden` exception is thrown when Canvas returns an HTTP 403 error.
 
+.. autoclass:: canvasapi.exceptions.RateLimitExceeded
+    :members:
+
+    The :class:`~canvasapi.exceptions.RateLimitExceeded` exception is thrown when Canvas returns an HTTP 403 error that includes the body "403 Forbidden (Rate Limit Exceeded)". It will include the value of the ``X-Rate-Limit-Remaining`` header (if available) for reference.
+
 .. autoclass:: canvasapi.exceptions.Conflict
     :members:
 
     The :class:`~canvasapi.exceptions.Conflict` exception is thrown when Canvas returns an HTTP 409 error.
+
+.. autoclass:: canvasapi.exceptions.UnprocessableEntity
+    :members:
+
+    The :class:`~canvasapi.exceptions.UnprocessableEntity` exception is thrown when Canvas returns an HTTP 422 error.

--- a/tests/fixtures/requests.json
+++ b/tests/fixtures/requests.json
@@ -20,6 +20,31 @@
 		"data": {},
 		"status_code": 401
 	},
+	"403": {
+		"method": "ANY",
+		"endpoint": "403",
+		"data": {},
+		"status_code": 403
+	},
+	"403_rate_limit": {
+		"method": "ANY",
+		"endpoint": "403_rate_limit",
+		"data": "403 Forbidden (Rate Limit Exceeded)",
+		"headers": {
+			"X-Rate-Limit-Remaining": "3.14159265359",
+			"X-Request-Cost": "1.61803398875"
+		},
+		"status_code": 403
+	},
+	"403_rate_limit_no_remaining_header": {
+		"method": "ANY",
+		"endpoint": "403_rate_limit_no_remaining_header",
+		"data": "403 Forbidden (Rate Limit Exceeded)",
+		"headers": {
+			"X-Request-Cost": "1.61803398875"
+		},
+		"status_code": 403
+	},
 	"404": {
 		"method": "ANY",
 		"endpoint": "404",

--- a/tests/test_requester.py
+++ b/tests/test_requester.py
@@ -10,7 +10,9 @@ from canvasapi.exceptions import (
     BadRequest,
     CanvasException,
     Conflict,
+    Forbidden,
     InvalidAccessToken,
+    RateLimitExceeded,
     ResourceDoesNotExist,
     Unauthorized,
     UnprocessableEntity,
@@ -144,6 +146,28 @@ class TestRequester(unittest.TestCase):
 
         with self.assertRaises(Unauthorized):
             self.requester.request("GET", "401_unauthorized")
+
+    def test_request_403(self, m):
+        register_uris({"requests": ["403"]}, m)
+
+        with self.assertRaises(Forbidden):
+            self.requester.request("GET", "403")
+
+    def test_request_403_RateLimitExeeded(self, m):
+        register_uris({"requests": ["403_rate_limit"]}, m)
+
+        with self.assertRaises(RateLimitExceeded) as exc:
+            self.requester.request("GET", "403_rate_limit")
+
+        exc.exception.message == "Rate Limit Exceeded. X-Rate-Limit-Remaining: 3.14159265359"
+
+    def test_request_403_RateLimitExeeded_no_remaining_header(self, m):
+        register_uris({"requests": ["403_rate_limit_no_remaining_header"]}, m)
+
+        with self.assertRaises(RateLimitExceeded) as exc:
+            self.requester.request("GET", "403_rate_limit_no_remaining_header")
+
+        exc.exception.message == "Rate Limit Exceeded. X-Rate-Limit-Remaining: Unknown"
 
     def test_request_404(self, m):
         register_uris({"requests": ["404"]}, m)

--- a/tests/test_requester.py
+++ b/tests/test_requester.py
@@ -159,7 +159,10 @@ class TestRequester(unittest.TestCase):
         with self.assertRaises(RateLimitExceeded) as exc:
             self.requester.request("GET", "403_rate_limit")
 
-        exc.exception.message == "Rate Limit Exceeded. X-Rate-Limit-Remaining: 3.14159265359"
+        self.assertEqual(
+            exc.exception.message,
+            "Rate Limit Exceeded. X-Rate-Limit-Remaining: 3.14159265359",
+        )
 
     def test_request_403_RateLimitExeeded_no_remaining_header(self, m):
         register_uris({"requests": ["403_rate_limit_no_remaining_header"]}, m)
@@ -167,7 +170,10 @@ class TestRequester(unittest.TestCase):
         with self.assertRaises(RateLimitExceeded) as exc:
             self.requester.request("GET", "403_rate_limit_no_remaining_header")
 
-        exc.exception.message == "Rate Limit Exceeded. X-Rate-Limit-Remaining: Unknown"
+        self.assertEqual(
+            exc.exception.message,
+            "Rate Limit Exceeded. X-Rate-Limit-Remaining: Unknown",
+        )
 
     def test_request_404(self, m):
         register_uris({"requests": ["404"]}, m)


### PR DESCRIPTION
# Proposed Changes

* Add a new exception `RateLimitExceeded` to handle 403 responses with content `403 Forbidden (Rate Limit Exceeded)`

Fixes #466
