### PR TITLE
Issue/462 Submit Multiple Files to assignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ venv/
 setup.sh
 .python-version
 .*.swp
+.idea*

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,3 @@ venv/
 setup.sh
 .python-version
 .*.swp
-.idea*

--- a/canvasapi/assignment.py
+++ b/canvasapi/assignment.py
@@ -85,7 +85,7 @@ class Assignment(CanvasObject):
             if upload_response[0]:
                 file_ids.append(upload_response[1]["id"])
             else:
-                raise CanvasException("File upload failed.")
+                raise CanvasException(f"File {file} upload failed.")
 
         return file_ids
 
@@ -510,7 +510,7 @@ class Assignment(CanvasObject):
                 self.course_id, self.id, user_id
             ),
             file,
-            **kwargs
+            **kwargs,
         ).start()
 
 

--- a/canvasapi/assignment.py
+++ b/canvasapi/assignment.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.exceptions import CanvasException, RequiredFieldMissing
 from canvasapi.paginated_list import PaginatedList
@@ -7,7 +9,6 @@ from canvasapi.submission import Submission
 from canvasapi.upload import FileOrPathLike, Uploader
 from canvasapi.user import User, UserDisplay
 from canvasapi.util import combine_kwargs, obj_or_id
-from typing import List
 
 
 class Assignment(CanvasObject):

--- a/canvasapi/assignment.py
+++ b/canvasapi/assignment.py
@@ -7,6 +7,7 @@ from canvasapi.submission import Submission
 from canvasapi.upload import FileOrPathLike, Uploader
 from canvasapi.user import User, UserDisplay
 from canvasapi.util import combine_kwargs, obj_or_id
+from typing import List
 
 
 class Assignment(CanvasObject):
@@ -62,7 +63,7 @@ class Assignment(CanvasObject):
 
         return Submission(self._requester, response_json)
 
-    def bulk_upload(self, files: list[FileOrPathLike], user="self", **kwargs):
+    def bulk_upload(self, files: List[FileOrPathLike], user="self", **kwargs):
         """
         Upload multiples files to a submission.
 

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -121,6 +121,61 @@ class TestAssignment(unittest.TestCase):
             cleanup_file(filename_one)
             cleanup_file(filename_two)
 
+    # bulk_upload()
+    def test_bulk_upload_self(self, m):
+        register_uris({"assignment": ["upload", "upload_final"]}, m)
+
+        filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
+        filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
+
+        try:
+            with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
+                files = [f1, f2]
+
+                file_ids = self.assignment.bulk_upload(files)
+
+            self.assertIsNotNone(file_ids)
+            self.assertIsInstance(file_ids, list)
+        finally:
+            cleanup_file(filename_one)
+            cleanup_file(filename_two)
+
+    def test_bulk_upload_failure(self, m):
+        register_uris({"assignment": ["upload", "upload_fail"]}, m)
+
+        filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
+        filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
+
+        try:
+            with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
+                files = [f1, f2]
+
+                with self.assertRaises(CanvasException):
+                    self.assignment.bulk_upload(files)
+        finally:
+            cleanup_file(filename_one)
+            cleanup_file(filename_two)
+
+    def test_bulk_upload_user(self, m):
+        register_uris({"assignment": ["upload_by_id", "upload_final"]}, m)
+
+        filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
+        filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
+
+        user_id = 1
+
+        try:
+            with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
+                files = [f1, f2]
+
+                file_ids = self.assignment.bulk_upload(files, user_id)
+
+            self.assertIsNotNone(file_ids)
+            self.assertIsInstance(file_ids, list)
+        finally:
+            cleanup_file(filename_one)
+            cleanup_file(filename_two)
+
     # create_override()
     def test_create_override(self, m):
         register_uris({"assignment": ["create_override"]}, m)

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -41,6 +41,86 @@ class TestAssignment(unittest.TestCase):
         self.assertEqual(len(assignment.overrides), 1)
         self.assertIsInstance(assignment.overrides[0], AssignmentOverride)
 
+        # bulk_submit()
+        def test_bulk_submit(self, m):
+            register_uris({"assignment": ["submit"]}, m)
+
+            sub_type = "online_upload"
+            sub_dict = {"submission_type": sub_type}
+            submission = self.assignment.bulk_submit(sub_dict)
+
+            self.assertIsInstance(submission, Submission)
+            self.assertTrue(hasattr(submission, "submission_type"))
+            self.assertEqual(submission.submission_type, sub_type)
+
+        def test_bulk_submit_fail(self, m):
+            with self.assertRaises(RequiredFieldMissing):
+                self.assignment.bulk_submit({})
+
+        def test_bulk_submit_file(self, m):
+            register_uris({"assignment": ["submit", "upload", "upload_final"]}, m)
+
+            filename = "testfile_assignment_{}".format(uuid.uuid4().hex)
+
+            try:
+                with open(filename, "w+") as file:
+                    sub_type = "online_upload"
+                    sub_dict = {"submission_type": sub_type}
+                    submission = self.assignment.bulk_submit(sub_dict, file)
+
+                self.assertIsInstance(submission, Submission)
+                self.assertTrue(hasattr(submission, "submission_type"))
+                self.assertEqual(submission.submission_type, sub_type)
+            finally:
+                cleanup_file(filename)
+
+        def test_bulk_submit_multiple_files(self, m):
+            register_uris({"assignment": ["submit", "upload", "upload_final"]}, m)
+
+            filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
+            filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
+
+            try:
+                with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
+                    files = [f1, f2]
+
+                    sub_type = "online_upload"
+                    sub_dict = {"submission_type": sub_type}
+                    submission = self.assignment.bulk_submit(sub_dict, files)
+
+                self.assertIsInstance(submission, Submission)
+                self.assertTrue(hasattr(submission, "submission_type"))
+                self.assertEqual(submission.submission_type, sub_type)
+            finally:
+                cleanup_file(filename_one)
+                cleanup_file(filename_two)
+
+        def test_bulk_submit_wrong_type(self, m):
+            filename = "testfile_assignment_{}".format(uuid.uuid4().hex)
+            sub_type = "online_text_entry"
+            sub_dict = {"submission_type": sub_type}
+
+            with self.assertRaises(ValueError):
+                self.assignment.bulk_submit(sub_dict, filename)
+
+        def test_bulk_submit_upload_failure(self, m):
+            register_uris({"assignment": ["submit", "upload", "upload_fail"]}, m)
+
+            filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
+            filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
+
+            try:
+                with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
+                    files = [f1, f2]
+
+                    sub_type = "online_upload"
+                    sub_dict = {"submission_type": sub_type}
+                    with self.assertRaises(CanvasException):
+                        self.assignment.bulk_submit(sub_dict, files)
+            finally:
+                cleanup_file(filename_one)
+                cleanup_file(filename_two)
+
     # create_override()
     def test_create_override(self, m):
         register_uris({"assignment": ["create_override"]}, m)
@@ -255,86 +335,6 @@ class TestAssignment(unittest.TestCase):
                     self.assignment.submit(sub_dict, file)
         finally:
             cleanup_file(filename)
-
-    # bulk_submit()
-    def test_bulk_submit(self, m):
-        register_uris({"assignment": ["submit"]}, m)
-
-        sub_type = "online_upload"
-        sub_dict = {"submission_type": sub_type}
-        submission = self.assignment.bulk_submit(sub_dict)
-
-        self.assertIsInstance(submission, Submission)
-        self.assertTrue(hasattr(submission, "submission_type"))
-        self.assertEqual(submission.submission_type, sub_type)
-
-    def test_bulk_submit_fail(self, m):
-        with self.assertRaises(RequiredFieldMissing):
-            self.assignment.bulk_submit({})
-
-    def test_bulk_submit_file(self, m):
-        register_uris({"assignment": ["submit", "upload", "upload_final"]}, m)
-
-        filename = "testfile_assignment_{}".format(uuid.uuid4().hex)
-
-        try:
-            with open(filename, "w+") as file:
-                sub_type = "online_upload"
-                sub_dict = {"submission_type": sub_type}
-                submission = self.assignment.bulk_submit(sub_dict, file)
-
-            self.assertIsInstance(submission, Submission)
-            self.assertTrue(hasattr(submission, "submission_type"))
-            self.assertEqual(submission.submission_type, sub_type)
-        finally:
-            cleanup_file(filename)
-
-    def test_bulk_submit_multiple_files(self, m):
-        register_uris({"assignment": ["submit", "upload", "upload_final"]}, m)
-
-        filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
-        filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
-
-        try:
-            with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
-                files = [f1, f2]
-
-                sub_type = "online_upload"
-                sub_dict = {"submission_type": sub_type}
-                submission = self.assignment.bulk_submit(sub_dict, files)
-
-            self.assertIsInstance(submission, Submission)
-            self.assertTrue(hasattr(submission, "submission_type"))
-            self.assertEqual(submission.submission_type, sub_type)
-        finally:
-            cleanup_file(filename_one)
-            cleanup_file(filename_two)
-
-    def test_bulk_submit_wrong_type(self, m):
-        filename = "testfile_assignment_{}".format(uuid.uuid4().hex)
-        sub_type = "online_text_entry"
-        sub_dict = {"submission_type": sub_type}
-
-        with self.assertRaises(ValueError):
-            self.assignment.bulk_submit(sub_dict, filename)
-
-    def test_bulk_submit_upload_failure(self, m):
-        register_uris({"assignment": ["submit", "upload", "upload_fail"]}, m)
-
-        filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
-        filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
-
-        try:
-            with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
-                files = [f1, f2]
-
-                sub_type = "online_upload"
-                sub_dict = {"submission_type": sub_type}
-                with self.assertRaises(CanvasException):
-                    self.assignment.bulk_submit(sub_dict, files)
-        finally:
-            cleanup_file(filename_one)
-            cleanup_file(filename_two)
 
     # __str__()
     def test__str__(self, m):

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -256,6 +256,86 @@ class TestAssignment(unittest.TestCase):
         finally:
             cleanup_file(filename)
 
+    # bulk_submit()
+    def test_bulk_submit(self, m):
+        register_uris({"assignment": ["submit"]}, m)
+
+        sub_type = "online_upload"
+        sub_dict = {"submission_type": sub_type}
+        submission = self.assignment.bulk_submit(sub_dict)
+
+        self.assertIsInstance(submission, Submission)
+        self.assertTrue(hasattr(submission, "submission_type"))
+        self.assertEqual(submission.submission_type, sub_type)
+
+    def test_bulk_submit_fail(self, m):
+        with self.assertRaises(RequiredFieldMissing):
+            self.assignment.bulk_submit({})
+
+    def test_bulk_submit_file(self, m):
+        register_uris({"assignment": ["submit", "upload", "upload_final"]}, m)
+
+        filename = "testfile_assignment_{}".format(uuid.uuid4().hex)
+
+        try:
+            with open(filename, "w+") as file:
+                sub_type = "online_upload"
+                sub_dict = {"submission_type": sub_type}
+                submission = self.assignment.bulk_submit(sub_dict, file)
+
+            self.assertIsInstance(submission, Submission)
+            self.assertTrue(hasattr(submission, "submission_type"))
+            self.assertEqual(submission.submission_type, sub_type)
+        finally:
+            cleanup_file(filename)
+
+    def test_bulk_submit_multiple_files(self, m):
+        register_uris({"assignment": ["submit", "upload", "upload_final"]}, m)
+
+        filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
+        filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
+
+        try:
+            with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
+                files = [f1, f2]
+
+                sub_type = "online_upload"
+                sub_dict = {"submission_type": sub_type}
+                submission = self.assignment.bulk_submit(sub_dict, files)
+
+            self.assertIsInstance(submission, Submission)
+            self.assertTrue(hasattr(submission, "submission_type"))
+            self.assertEqual(submission.submission_type, sub_type)
+        finally:
+            cleanup_file(filename_one)
+            cleanup_file(filename_two)
+
+    def test_bulk_submit_wrong_type(self, m):
+        filename = "testfile_assignment_{}".format(uuid.uuid4().hex)
+        sub_type = "online_text_entry"
+        sub_dict = {"submission_type": sub_type}
+
+        with self.assertRaises(ValueError):
+            self.assignment.bulk_submit(sub_dict, filename)
+
+    def test_bulk_submit_upload_failure(self, m):
+        register_uris({"assignment": ["submit", "upload", "upload_fail"]}, m)
+
+        filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
+        filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
+
+        try:
+            with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
+                files = [f1, f2]
+
+                sub_type = "online_upload"
+                sub_dict = {"submission_type": sub_type}
+                with self.assertRaises(CanvasException):
+                    self.assignment.bulk_submit(sub_dict, files)
+        finally:
+            cleanup_file(filename_one)
+            cleanup_file(filename_two)
+
     # __str__()
     def test__str__(self, m):
         string = str(self.assignment)

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -41,85 +41,85 @@ class TestAssignment(unittest.TestCase):
         self.assertEqual(len(assignment.overrides), 1)
         self.assertIsInstance(assignment.overrides[0], AssignmentOverride)
 
-        # bulk_submit()
-        def test_bulk_submit(self, m):
-            register_uris({"assignment": ["submit"]}, m)
+    # bulk_submit()
+    def test_bulk_submit(self, m):
+        register_uris({"assignment": ["submit"]}, m)
 
-            sub_type = "online_upload"
-            sub_dict = {"submission_type": sub_type}
-            submission = self.assignment.bulk_submit(sub_dict)
+        sub_type = "online_upload"
+        sub_dict = {"submission_type": sub_type}
+        submission = self.assignment.bulk_submit(sub_dict)
+
+        self.assertIsInstance(submission, Submission)
+        self.assertTrue(hasattr(submission, "submission_type"))
+        self.assertEqual(submission.submission_type, sub_type)
+
+    def test_bulk_submit_fail(self, m):
+        with self.assertRaises(RequiredFieldMissing):
+            self.assignment.bulk_submit({})
+
+    def test_bulk_submit_file(self, m):
+        register_uris({"assignment": ["submit", "upload", "upload_final"]}, m)
+
+        filename = "testfile_assignment_{}".format(uuid.uuid4().hex)
+
+        try:
+            with open(filename, "w+") as file:
+                sub_type = "online_upload"
+                sub_dict = {"submission_type": sub_type}
+                submission = self.assignment.bulk_submit(sub_dict, file)
 
             self.assertIsInstance(submission, Submission)
             self.assertTrue(hasattr(submission, "submission_type"))
             self.assertEqual(submission.submission_type, sub_type)
+        finally:
+            cleanup_file(filename)
 
-        def test_bulk_submit_fail(self, m):
-            with self.assertRaises(RequiredFieldMissing):
-                self.assignment.bulk_submit({})
+    def test_bulk_submit_multiple_files(self, m):
+        register_uris({"assignment": ["submit", "upload", "upload_final"]}, m)
 
-        def test_bulk_submit_file(self, m):
-            register_uris({"assignment": ["submit", "upload", "upload_final"]}, m)
+        filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
+        filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
 
-            filename = "testfile_assignment_{}".format(uuid.uuid4().hex)
+        try:
+            with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
+                files = [f1, f2]
 
-            try:
-                with open(filename, "w+") as file:
-                    sub_type = "online_upload"
-                    sub_dict = {"submission_type": sub_type}
-                    submission = self.assignment.bulk_submit(sub_dict, file)
+                sub_type = "online_upload"
+                sub_dict = {"submission_type": sub_type}
+                submission = self.assignment.bulk_submit(sub_dict, files)
 
-                self.assertIsInstance(submission, Submission)
-                self.assertTrue(hasattr(submission, "submission_type"))
-                self.assertEqual(submission.submission_type, sub_type)
-            finally:
-                cleanup_file(filename)
+            self.assertIsInstance(submission, Submission)
+            self.assertTrue(hasattr(submission, "submission_type"))
+            self.assertEqual(submission.submission_type, sub_type)
+        finally:
+            cleanup_file(filename_one)
+            cleanup_file(filename_two)
 
-        def test_bulk_submit_multiple_files(self, m):
-            register_uris({"assignment": ["submit", "upload", "upload_final"]}, m)
+    def test_bulk_submit_wrong_type(self, m):
+        filename = "testfile_assignment_{}".format(uuid.uuid4().hex)
+        sub_type = "online_text_entry"
+        sub_dict = {"submission_type": sub_type}
 
-            filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
-            filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
+        with self.assertRaises(ValueError):
+            self.assignment.bulk_submit(sub_dict, filename)
 
-            try:
-                with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
-                    files = [f1, f2]
+    def test_bulk_submit_upload_failure(self, m):
+        register_uris({"assignment": ["submit", "upload", "upload_fail"]}, m)
 
-                    sub_type = "online_upload"
-                    sub_dict = {"submission_type": sub_type}
-                    submission = self.assignment.bulk_submit(sub_dict, files)
+        filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
+        filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
 
-                self.assertIsInstance(submission, Submission)
-                self.assertTrue(hasattr(submission, "submission_type"))
-                self.assertEqual(submission.submission_type, sub_type)
-            finally:
-                cleanup_file(filename_one)
-                cleanup_file(filename_two)
+        try:
+            with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
+                files = [f1, f2]
 
-        def test_bulk_submit_wrong_type(self, m):
-            filename = "testfile_assignment_{}".format(uuid.uuid4().hex)
-            sub_type = "online_text_entry"
-            sub_dict = {"submission_type": sub_type}
-
-            with self.assertRaises(ValueError):
-                self.assignment.bulk_submit(sub_dict, filename)
-
-        def test_bulk_submit_upload_failure(self, m):
-            register_uris({"assignment": ["submit", "upload", "upload_fail"]}, m)
-
-            filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
-            filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
-
-            try:
-                with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
-                    files = [f1, f2]
-
-                    sub_type = "online_upload"
-                    sub_dict = {"submission_type": sub_type}
-                    with self.assertRaises(CanvasException):
-                        self.assignment.bulk_submit(sub_dict, files)
-            finally:
-                cleanup_file(filename_one)
-                cleanup_file(filename_two)
+                sub_type = "online_upload"
+                sub_dict = {"submission_type": sub_type}
+                with self.assertRaises(CanvasException):
+                    self.assignment.bulk_submit(sub_dict, files)
+        finally:
+            cleanup_file(filename_one)
+            cleanup_file(filename_two)
 
     # create_override()
     def test_create_override(self, m):


### PR DESCRIPTION
# Proposed Changes
This pull requests address issue #462 by adding two methods, bulk_submit and bulk_upload, which allow submitting and uploading multiple files to an assignment submission, respectively. 
