### PR TITLE
Issue/480 add support for delete rubric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ venv/
 setup.sh
 .python-version
 .*.swp
+.idea*

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,3 @@ venv/
 setup.sh
 .python-version
 .*.swp
-.idea*

--- a/canvasapi/assignment.py
+++ b/canvasapi/assignment.py
@@ -85,7 +85,7 @@ class Assignment(CanvasObject):
             if upload_response[0]:
                 file_ids.append(upload_response[1]["id"])
             else:
-                raise CanvasException("File upload failed.")
+                raise CanvasException(f"File {file} upload failed.")
 
         return file_ids
 
@@ -510,7 +510,7 @@ class Assignment(CanvasObject):
                 self.course_id, self.id, user_id
             ),
             file,
-            **kwargs
+            **kwargs,
         ).start()
 
 

--- a/canvasapi/assignment.py
+++ b/canvasapi/assignment.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from canvasapi.canvas_object import CanvasObject
 from canvasapi.exceptions import CanvasException, RequiredFieldMissing
 from canvasapi.paginated_list import PaginatedList
@@ -7,7 +9,6 @@ from canvasapi.submission import Submission
 from canvasapi.upload import FileOrPathLike, Uploader
 from canvasapi.user import User, UserDisplay
 from canvasapi.util import combine_kwargs, obj_or_id
-from typing import List
 
 
 class Assignment(CanvasObject):

--- a/canvasapi/assignment.py
+++ b/canvasapi/assignment.py
@@ -7,6 +7,7 @@ from canvasapi.submission import Submission
 from canvasapi.upload import FileOrPathLike, Uploader
 from canvasapi.user import User, UserDisplay
 from canvasapi.util import combine_kwargs, obj_or_id
+from typing import List
 
 
 class Assignment(CanvasObject):
@@ -62,7 +63,7 @@ class Assignment(CanvasObject):
 
         return Submission(self._requester, response_json)
 
-    def bulk_upload(self, files: list[FileOrPathLike], user="self", **kwargs):
+    def bulk_upload(self, files: List[FileOrPathLike], user="self", **kwargs):
         """
         Upload multiples files to a submission.
 

--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -528,6 +528,7 @@ class Course(CanvasObject):
 
         if "rubric" in dictionary:
             r_dict = dictionary["rubric"]
+            r_dict.update({"course_id": self.id})
             rubric = Rubric(self._requester, r_dict)
 
             rubric_dict = {"rubric": rubric}

--- a/canvasapi/rubric.py
+++ b/canvasapi/rubric.py
@@ -6,6 +6,25 @@ class Rubric(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.title, self.id)
 
+    # def delete(self, **kwargs):
+    #     """
+    #     Delete a Rubric.
+
+    #     :calls: `DELETE /api/v1/courses/:course_id/rubrics/:id \
+    #     <https://canvas.instructure.com/doc/api/rubrics.html#method.rubrics.destroy>
+
+    #     :rtype: :class:`canvasapi.rubric.Rubric`
+    #     """
+    #     from canvasapi.rubric import Rubric
+
+    #     response = self._requester.request(
+    #         "DELETE",
+    #         "courses/{}/rubrics/{}".format(self.course_id, self.id),
+    #         _kwargs=combine_kwargs(**kwargs),
+    #     )
+
+    #     return Rubric(self._requester, response.json())
+
 
 class RubricAssociation(CanvasObject):
     def __str__(self):

--- a/canvasapi/rubric.py
+++ b/canvasapi/rubric.py
@@ -6,24 +6,24 @@ class Rubric(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.title, self.id)
 
-    # def delete(self, **kwargs):
-    #     """
-    #     Delete a Rubric.
+    def delete(self, **kwargs):
+        """
+        Delete a Rubric.
 
-    #     :calls: `DELETE /api/v1/courses/:course_id/rubrics/:id \
-    #     <https://canvas.instructure.com/doc/api/rubrics.html#method.rubrics.destroy>
+        :calls: `DELETE /api/v1/courses/:course_id/rubrics/:id \
+        <https://canvas.instructure.com/doc/api/rubrics.html#method.rubrics.destroy>
 
-    #     :rtype: :class:`canvasapi.rubric.Rubric`
-    #     """
-    #     from canvasapi.rubric import Rubric
+        :rtype: :class:`canvasapi.rubric.Rubric`
+        """
+        from canvasapi.rubric import Rubric
 
-    #     response = self._requester.request(
-    #         "DELETE",
-    #         "courses/{}/rubrics/{}".format(self.course_id, self.id),
-    #         _kwargs=combine_kwargs(**kwargs),
-    #     )
+        response = self._requester.request(
+            "DELETE",
+            "courses/{}/rubrics/{}".format(self.course_id, self.id),
+            _kwargs=combine_kwargs(**kwargs),
+        )
 
-    #     return Rubric(self._requester, response.json())
+        return Rubric(self._requester, response.json())
 
 
 class RubricAssociation(CanvasObject):

--- a/tests/fixtures/rubric.json
+++ b/tests/fixtures/rubric.json
@@ -16,5 +16,21 @@
 			"association_type": "Assignment"
 		},
 		"status_code": 200
+	},
+	"delete_rubric": {
+		"method": "DELETE",
+		"endpoint": "courses/1/rubrics/1",
+		"data": {
+			"id": 1,
+			"title": "Course Rubric 1",
+			"context_id": 1,
+			"context_type": "Course",
+			"points_possible": 10.0,
+			"reusable": false,
+			"read_only": true,
+			"free_form_critereon_comments": true,
+			"hide_score_total": true
+		},
+		"status_code": 200
 	}
 }

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -121,6 +121,61 @@ class TestAssignment(unittest.TestCase):
             cleanup_file(filename_one)
             cleanup_file(filename_two)
 
+    # bulk_upload()
+    def test_bulk_upload_self(self, m):
+        register_uris({"assignment": ["upload", "upload_final"]}, m)
+
+        filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
+        filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
+
+        try:
+            with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
+                files = [f1, f2]
+
+                file_ids = self.assignment.bulk_upload(files)
+
+            self.assertIsNotNone(file_ids)
+            self.assertIsInstance(file_ids, list)
+        finally:
+            cleanup_file(filename_one)
+            cleanup_file(filename_two)
+
+    def test_bulk_upload_failure(self, m):
+        register_uris({"assignment": ["upload", "upload_fail"]}, m)
+
+        filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
+        filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
+
+        try:
+            with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
+                files = [f1, f2]
+
+                with self.assertRaises(CanvasException):
+                    self.assignment.bulk_upload(files)
+        finally:
+            cleanup_file(filename_one)
+            cleanup_file(filename_two)
+
+    def test_bulk_upload_user(self, m):
+        register_uris({"assignment": ["upload_by_id", "upload_final"]}, m)
+
+        filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
+        filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
+
+        user_id = 1
+
+        try:
+            with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
+                files = [f1, f2]
+
+                file_ids = self.assignment.bulk_upload(files, user_id)
+
+            self.assertIsNotNone(file_ids)
+            self.assertIsInstance(file_ids, list)
+        finally:
+            cleanup_file(filename_one)
+            cleanup_file(filename_two)
+
     # create_override()
     def test_create_override(self, m):
         register_uris({"assignment": ["create_override"]}, m)

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -41,6 +41,86 @@ class TestAssignment(unittest.TestCase):
         self.assertEqual(len(assignment.overrides), 1)
         self.assertIsInstance(assignment.overrides[0], AssignmentOverride)
 
+        # bulk_submit()
+        def test_bulk_submit(self, m):
+            register_uris({"assignment": ["submit"]}, m)
+
+            sub_type = "online_upload"
+            sub_dict = {"submission_type": sub_type}
+            submission = self.assignment.bulk_submit(sub_dict)
+
+            self.assertIsInstance(submission, Submission)
+            self.assertTrue(hasattr(submission, "submission_type"))
+            self.assertEqual(submission.submission_type, sub_type)
+
+        def test_bulk_submit_fail(self, m):
+            with self.assertRaises(RequiredFieldMissing):
+                self.assignment.bulk_submit({})
+
+        def test_bulk_submit_file(self, m):
+            register_uris({"assignment": ["submit", "upload", "upload_final"]}, m)
+
+            filename = "testfile_assignment_{}".format(uuid.uuid4().hex)
+
+            try:
+                with open(filename, "w+") as file:
+                    sub_type = "online_upload"
+                    sub_dict = {"submission_type": sub_type}
+                    submission = self.assignment.bulk_submit(sub_dict, file)
+
+                self.assertIsInstance(submission, Submission)
+                self.assertTrue(hasattr(submission, "submission_type"))
+                self.assertEqual(submission.submission_type, sub_type)
+            finally:
+                cleanup_file(filename)
+
+        def test_bulk_submit_multiple_files(self, m):
+            register_uris({"assignment": ["submit", "upload", "upload_final"]}, m)
+
+            filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
+            filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
+
+            try:
+                with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
+                    files = [f1, f2]
+
+                    sub_type = "online_upload"
+                    sub_dict = {"submission_type": sub_type}
+                    submission = self.assignment.bulk_submit(sub_dict, files)
+
+                self.assertIsInstance(submission, Submission)
+                self.assertTrue(hasattr(submission, "submission_type"))
+                self.assertEqual(submission.submission_type, sub_type)
+            finally:
+                cleanup_file(filename_one)
+                cleanup_file(filename_two)
+
+        def test_bulk_submit_wrong_type(self, m):
+            filename = "testfile_assignment_{}".format(uuid.uuid4().hex)
+            sub_type = "online_text_entry"
+            sub_dict = {"submission_type": sub_type}
+
+            with self.assertRaises(ValueError):
+                self.assignment.bulk_submit(sub_dict, filename)
+
+        def test_bulk_submit_upload_failure(self, m):
+            register_uris({"assignment": ["submit", "upload", "upload_fail"]}, m)
+
+            filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
+            filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
+
+            try:
+                with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
+                    files = [f1, f2]
+
+                    sub_type = "online_upload"
+                    sub_dict = {"submission_type": sub_type}
+                    with self.assertRaises(CanvasException):
+                        self.assignment.bulk_submit(sub_dict, files)
+            finally:
+                cleanup_file(filename_one)
+                cleanup_file(filename_two)
+
     # create_override()
     def test_create_override(self, m):
         register_uris({"assignment": ["create_override"]}, m)
@@ -255,86 +335,6 @@ class TestAssignment(unittest.TestCase):
                     self.assignment.submit(sub_dict, file)
         finally:
             cleanup_file(filename)
-
-    # bulk_submit()
-    def test_bulk_submit(self, m):
-        register_uris({"assignment": ["submit"]}, m)
-
-        sub_type = "online_upload"
-        sub_dict = {"submission_type": sub_type}
-        submission = self.assignment.bulk_submit(sub_dict)
-
-        self.assertIsInstance(submission, Submission)
-        self.assertTrue(hasattr(submission, "submission_type"))
-        self.assertEqual(submission.submission_type, sub_type)
-
-    def test_bulk_submit_fail(self, m):
-        with self.assertRaises(RequiredFieldMissing):
-            self.assignment.bulk_submit({})
-
-    def test_bulk_submit_file(self, m):
-        register_uris({"assignment": ["submit", "upload", "upload_final"]}, m)
-
-        filename = "testfile_assignment_{}".format(uuid.uuid4().hex)
-
-        try:
-            with open(filename, "w+") as file:
-                sub_type = "online_upload"
-                sub_dict = {"submission_type": sub_type}
-                submission = self.assignment.bulk_submit(sub_dict, file)
-
-            self.assertIsInstance(submission, Submission)
-            self.assertTrue(hasattr(submission, "submission_type"))
-            self.assertEqual(submission.submission_type, sub_type)
-        finally:
-            cleanup_file(filename)
-
-    def test_bulk_submit_multiple_files(self, m):
-        register_uris({"assignment": ["submit", "upload", "upload_final"]}, m)
-
-        filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
-        filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
-
-        try:
-            with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
-                files = [f1, f2]
-
-                sub_type = "online_upload"
-                sub_dict = {"submission_type": sub_type}
-                submission = self.assignment.bulk_submit(sub_dict, files)
-
-            self.assertIsInstance(submission, Submission)
-            self.assertTrue(hasattr(submission, "submission_type"))
-            self.assertEqual(submission.submission_type, sub_type)
-        finally:
-            cleanup_file(filename_one)
-            cleanup_file(filename_two)
-
-    def test_bulk_submit_wrong_type(self, m):
-        filename = "testfile_assignment_{}".format(uuid.uuid4().hex)
-        sub_type = "online_text_entry"
-        sub_dict = {"submission_type": sub_type}
-
-        with self.assertRaises(ValueError):
-            self.assignment.bulk_submit(sub_dict, filename)
-
-    def test_bulk_submit_upload_failure(self, m):
-        register_uris({"assignment": ["submit", "upload", "upload_fail"]}, m)
-
-        filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
-        filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
-
-        try:
-            with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
-                files = [f1, f2]
-
-                sub_type = "online_upload"
-                sub_dict = {"submission_type": sub_type}
-                with self.assertRaises(CanvasException):
-                    self.assignment.bulk_submit(sub_dict, files)
-        finally:
-            cleanup_file(filename_one)
-            cleanup_file(filename_two)
 
     # __str__()
     def test__str__(self, m):

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -256,6 +256,86 @@ class TestAssignment(unittest.TestCase):
         finally:
             cleanup_file(filename)
 
+    # bulk_submit()
+    def test_bulk_submit(self, m):
+        register_uris({"assignment": ["submit"]}, m)
+
+        sub_type = "online_upload"
+        sub_dict = {"submission_type": sub_type}
+        submission = self.assignment.bulk_submit(sub_dict)
+
+        self.assertIsInstance(submission, Submission)
+        self.assertTrue(hasattr(submission, "submission_type"))
+        self.assertEqual(submission.submission_type, sub_type)
+
+    def test_bulk_submit_fail(self, m):
+        with self.assertRaises(RequiredFieldMissing):
+            self.assignment.bulk_submit({})
+
+    def test_bulk_submit_file(self, m):
+        register_uris({"assignment": ["submit", "upload", "upload_final"]}, m)
+
+        filename = "testfile_assignment_{}".format(uuid.uuid4().hex)
+
+        try:
+            with open(filename, "w+") as file:
+                sub_type = "online_upload"
+                sub_dict = {"submission_type": sub_type}
+                submission = self.assignment.bulk_submit(sub_dict, file)
+
+            self.assertIsInstance(submission, Submission)
+            self.assertTrue(hasattr(submission, "submission_type"))
+            self.assertEqual(submission.submission_type, sub_type)
+        finally:
+            cleanup_file(filename)
+
+    def test_bulk_submit_multiple_files(self, m):
+        register_uris({"assignment": ["submit", "upload", "upload_final"]}, m)
+
+        filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
+        filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
+
+        try:
+            with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
+                files = [f1, f2]
+
+                sub_type = "online_upload"
+                sub_dict = {"submission_type": sub_type}
+                submission = self.assignment.bulk_submit(sub_dict, files)
+
+            self.assertIsInstance(submission, Submission)
+            self.assertTrue(hasattr(submission, "submission_type"))
+            self.assertEqual(submission.submission_type, sub_type)
+        finally:
+            cleanup_file(filename_one)
+            cleanup_file(filename_two)
+
+    def test_bulk_submit_wrong_type(self, m):
+        filename = "testfile_assignment_{}".format(uuid.uuid4().hex)
+        sub_type = "online_text_entry"
+        sub_dict = {"submission_type": sub_type}
+
+        with self.assertRaises(ValueError):
+            self.assignment.bulk_submit(sub_dict, filename)
+
+    def test_bulk_submit_upload_failure(self, m):
+        register_uris({"assignment": ["submit", "upload", "upload_fail"]}, m)
+
+        filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
+        filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
+
+        try:
+            with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
+                files = [f1, f2]
+
+                sub_type = "online_upload"
+                sub_dict = {"submission_type": sub_type}
+                with self.assertRaises(CanvasException):
+                    self.assignment.bulk_submit(sub_dict, files)
+        finally:
+            cleanup_file(filename_one)
+            cleanup_file(filename_two)
+
     # __str__()
     def test__str__(self, m):
         string = str(self.assignment)

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -41,85 +41,85 @@ class TestAssignment(unittest.TestCase):
         self.assertEqual(len(assignment.overrides), 1)
         self.assertIsInstance(assignment.overrides[0], AssignmentOverride)
 
-        # bulk_submit()
-        def test_bulk_submit(self, m):
-            register_uris({"assignment": ["submit"]}, m)
+    # bulk_submit()
+    def test_bulk_submit(self, m):
+        register_uris({"assignment": ["submit"]}, m)
 
-            sub_type = "online_upload"
-            sub_dict = {"submission_type": sub_type}
-            submission = self.assignment.bulk_submit(sub_dict)
+        sub_type = "online_upload"
+        sub_dict = {"submission_type": sub_type}
+        submission = self.assignment.bulk_submit(sub_dict)
+
+        self.assertIsInstance(submission, Submission)
+        self.assertTrue(hasattr(submission, "submission_type"))
+        self.assertEqual(submission.submission_type, sub_type)
+
+    def test_bulk_submit_fail(self, m):
+        with self.assertRaises(RequiredFieldMissing):
+            self.assignment.bulk_submit({})
+
+    def test_bulk_submit_file(self, m):
+        register_uris({"assignment": ["submit", "upload", "upload_final"]}, m)
+
+        filename = "testfile_assignment_{}".format(uuid.uuid4().hex)
+
+        try:
+            with open(filename, "w+") as file:
+                sub_type = "online_upload"
+                sub_dict = {"submission_type": sub_type}
+                submission = self.assignment.bulk_submit(sub_dict, file)
 
             self.assertIsInstance(submission, Submission)
             self.assertTrue(hasattr(submission, "submission_type"))
             self.assertEqual(submission.submission_type, sub_type)
+        finally:
+            cleanup_file(filename)
 
-        def test_bulk_submit_fail(self, m):
-            with self.assertRaises(RequiredFieldMissing):
-                self.assignment.bulk_submit({})
+    def test_bulk_submit_multiple_files(self, m):
+        register_uris({"assignment": ["submit", "upload", "upload_final"]}, m)
 
-        def test_bulk_submit_file(self, m):
-            register_uris({"assignment": ["submit", "upload", "upload_final"]}, m)
+        filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
+        filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
 
-            filename = "testfile_assignment_{}".format(uuid.uuid4().hex)
+        try:
+            with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
+                files = [f1, f2]
 
-            try:
-                with open(filename, "w+") as file:
-                    sub_type = "online_upload"
-                    sub_dict = {"submission_type": sub_type}
-                    submission = self.assignment.bulk_submit(sub_dict, file)
+                sub_type = "online_upload"
+                sub_dict = {"submission_type": sub_type}
+                submission = self.assignment.bulk_submit(sub_dict, files)
 
-                self.assertIsInstance(submission, Submission)
-                self.assertTrue(hasattr(submission, "submission_type"))
-                self.assertEqual(submission.submission_type, sub_type)
-            finally:
-                cleanup_file(filename)
+            self.assertIsInstance(submission, Submission)
+            self.assertTrue(hasattr(submission, "submission_type"))
+            self.assertEqual(submission.submission_type, sub_type)
+        finally:
+            cleanup_file(filename_one)
+            cleanup_file(filename_two)
 
-        def test_bulk_submit_multiple_files(self, m):
-            register_uris({"assignment": ["submit", "upload", "upload_final"]}, m)
+    def test_bulk_submit_wrong_type(self, m):
+        filename = "testfile_assignment_{}".format(uuid.uuid4().hex)
+        sub_type = "online_text_entry"
+        sub_dict = {"submission_type": sub_type}
 
-            filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
-            filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
+        with self.assertRaises(ValueError):
+            self.assignment.bulk_submit(sub_dict, filename)
 
-            try:
-                with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
-                    files = [f1, f2]
+    def test_bulk_submit_upload_failure(self, m):
+        register_uris({"assignment": ["submit", "upload", "upload_fail"]}, m)
 
-                    sub_type = "online_upload"
-                    sub_dict = {"submission_type": sub_type}
-                    submission = self.assignment.bulk_submit(sub_dict, files)
+        filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
+        filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
 
-                self.assertIsInstance(submission, Submission)
-                self.assertTrue(hasattr(submission, "submission_type"))
-                self.assertEqual(submission.submission_type, sub_type)
-            finally:
-                cleanup_file(filename_one)
-                cleanup_file(filename_two)
+        try:
+            with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
+                files = [f1, f2]
 
-        def test_bulk_submit_wrong_type(self, m):
-            filename = "testfile_assignment_{}".format(uuid.uuid4().hex)
-            sub_type = "online_text_entry"
-            sub_dict = {"submission_type": sub_type}
-
-            with self.assertRaises(ValueError):
-                self.assignment.bulk_submit(sub_dict, filename)
-
-        def test_bulk_submit_upload_failure(self, m):
-            register_uris({"assignment": ["submit", "upload", "upload_fail"]}, m)
-
-            filename_one = "testfile_assignment_{}".format(uuid.uuid4().hex)
-            filename_two = "testfile_assignment_{}".format(uuid.uuid4().hex)
-
-            try:
-                with open(filename_one, "w+") as f1, open(filename_two, "w+") as f2:
-                    files = [f1, f2]
-
-                    sub_type = "online_upload"
-                    sub_dict = {"submission_type": sub_type}
-                    with self.assertRaises(CanvasException):
-                        self.assignment.bulk_submit(sub_dict, files)
-            finally:
-                cleanup_file(filename_one)
-                cleanup_file(filename_two)
+                sub_type = "online_upload"
+                sub_dict = {"submission_type": sub_type}
+                with self.assertRaises(CanvasException):
+                    self.assignment.bulk_submit(sub_dict, files)
+        finally:
+            cleanup_file(filename_one)
+            cleanup_file(filename_two)
 
     # create_override()
     def test_create_override(self, m):

--- a/tests/test_rubric.py
+++ b/tests/test_rubric.py
@@ -17,7 +17,7 @@ class TestRubric(unittest.TestCase):
             register_uris({"course": ["get_by_id", "create_rubric"]}, m)
 
             self.course = self.canvas.get_course(1)
-            self.rubric = self.course.get_rubric(1)
+            self.rubric = self.course.create_rubric()["rubric"]
 
     # delete
     def test_delete(self, m):

--- a/tests/test_rubric.py
+++ b/tests/test_rubric.py
@@ -3,9 +3,43 @@ import unittest
 import requests_mock
 
 from canvasapi import Canvas
-from canvasapi.rubric import RubricAssociation
+from canvasapi.rubric import Rubric, RubricAssociation
 from tests import settings
 from tests.util import register_uris
+
+
+@requests_mock.Mocker()
+class TestRubric(unittest.TestCase):
+    def setUp(self):
+        self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
+
+        with requests_mock.Mocker() as m:
+            register_uris({"course": ["get_by_id", "create_rubric"]}, m)
+
+            self.course = self.canvas.get_course(1)
+            self.rubric = self.course.get_rubric(1)
+
+    # delete
+    def test_delete(self, m):
+        register_uris({"rubric": ["delete_rubric"]})
+
+        rubric = self.rubric.delete()
+
+        self.assertIsInstance(rubric, Rubric)
+        self.assertEqual(rubric.id, 1)
+        self.assertEqual(rubric.title, "Course Rubric 1")
+        self.assertEqual(rubric.context_id, 1)
+        self.assertEqual(rubric.context_type, "Course")
+        self.assertEqual(rubric.points_possible, 10.0)
+        self.assertFalse(rubric.reusable)
+        self.assertTrue(rubric.read_only)
+        self.assertTrue(rubric.free_form_critereon_comments)
+        self.assertTrue(rubric.hide_score_total)
+
+    # __str__()
+    def test__str__(self, m):
+        string = str(self.rubric)
+        self.assertIsInstance(string, str)
 
 
 @requests_mock.Mocker()

--- a/tests/test_rubric.py
+++ b/tests/test_rubric.py
@@ -21,7 +21,7 @@ class TestRubric(unittest.TestCase):
 
     # delete
     def test_delete(self, m):
-        register_uris({"rubric": ["delete_rubric"]})
+        register_uris({"rubric": ["delete_rubric"]}, m)
 
         rubric = self.rubric.delete()
 


### PR DESCRIPTION
# Proposed Changes
This pull request addresses Issue #480 by creating a delete function that calls the Rubric DELETE Canvas LMS API in the Rubric class in rubric.py.
