### PR TITLE
Issue/480 Add Support for Delete Rubric

### DIFF
--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -528,6 +528,7 @@ class Course(CanvasObject):
 
         if "rubric" in dictionary:
             r_dict = dictionary["rubric"]
+            r_dict.update({"course_id": self.id})
             rubric = Rubric(self._requester, r_dict)
 
             rubric_dict = {"rubric": rubric}

--- a/canvasapi/rubric.py
+++ b/canvasapi/rubric.py
@@ -6,6 +6,25 @@ class Rubric(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.title, self.id)
 
+    def delete(self, **kwargs):
+        """
+        Delete a Rubric.
+
+        :calls: `DELETE /api/v1/courses/:course_id/rubrics/:id \
+        <https://canvas.instructure.com/doc/api/rubrics.html#method.rubrics.destroy>
+
+        :rtype: :class:`canvasapi.rubric.Rubric`
+        """
+        from canvasapi.rubric import Rubric
+
+        response = self._requester.request(
+            "DELETE",
+            "courses/{}/rubrics/{}".format(self.course_id, self.id),
+            _kwargs=combine_kwargs(**kwargs),
+        )
+
+        return Rubric(self._requester, response.json())
+
 
 class RubricAssociation(CanvasObject):
     def __str__(self):

--- a/tests/fixtures/rubric.json
+++ b/tests/fixtures/rubric.json
@@ -16,5 +16,21 @@
 			"association_type": "Assignment"
 		},
 		"status_code": 200
+	},
+	"delete_rubric": {
+		"method": "DELETE",
+		"endpoint": "courses/1/rubrics/1",
+		"data": {
+			"id": 1,
+			"title": "Course Rubric 1",
+			"context_id": 1,
+			"context_type": "Course",
+			"points_possible": 10.0,
+			"reusable": false,
+			"read_only": true,
+			"free_form_critereon_comments": true,
+			"hide_score_total": true
+		},
+		"status_code": 200
 	}
 }


### PR DESCRIPTION
# Proposed Changes
Addresses Issue #480 by adding a delete function to the Rubric class in rubric.py that calls the Rubric DELETE endpoint in the Canvas LMS REST API. 

