### PR TITLE
Issue/480 Add Support for Delete Rubric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### New Endpoint Coverage
+
+- Delete a Rubric (Thanks, [@kailukaitisBrendan](https://github.com/kailukaitisBrendan))
+
 ### Breaking Changes
 
 - Update `QuizSubmission.get_submission_events` to return a `PaginatedList`.

--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -528,6 +528,7 @@ class Course(CanvasObject):
 
         if "rubric" in dictionary:
             r_dict = dictionary["rubric"]
+            r_dict.update({"course_id": self.id})
             rubric = Rubric(self._requester, r_dict)
 
             rubric_dict = {"rubric": rubric}

--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -1972,7 +1972,10 @@ class Course(CanvasObject):
             _kwargs=combine_kwargs(**kwargs),
         )
 
-        return Rubric(self._requester, response.json())
+        response_json = response.json()
+        response_json.update({"course_id": self.id})
+
+        return Rubric(self._requester, response_json)
 
     def get_rubrics(self, **kwargs):
         """
@@ -1989,6 +1992,7 @@ class Course(CanvasObject):
             self._requester,
             "GET",
             "courses/%s/rubrics" % (self.id),
+            {"course_id": self.id},
             _kwargs=combine_kwargs(**kwargs),
         )
 

--- a/canvasapi/rubric.py
+++ b/canvasapi/rubric.py
@@ -6,6 +6,25 @@ class Rubric(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.title, self.id)
 
+    def delete(self, **kwargs):
+        """
+        Delete a Rubric.
+
+        :calls: `DELETE /api/v1/courses/:course_id/rubrics/:id \
+        <https://canvas.instructure.com/doc/api/rubrics.html#method.rubrics.destroy>
+
+        :rtype: :class:`canvasapi.rubric.Rubric`
+        """
+        from canvasapi.rubric import Rubric
+
+        response = self._requester.request(
+            "DELETE",
+            "courses/{}/rubrics/{}".format(self.course_id, self.id),
+            _kwargs=combine_kwargs(**kwargs),
+        )
+
+        return Rubric(self._requester, response.json())
+
 
 class RubricAssociation(CanvasObject):
     def __str__(self):

--- a/canvasapi/rubric.py
+++ b/canvasapi/rubric.py
@@ -11,7 +11,7 @@ class Rubric(CanvasObject):
         Delete a Rubric.
 
         :calls: `DELETE /api/v1/courses/:course_id/rubrics/:id \
-        <https://canvas.instructure.com/doc/api/rubrics.html#method.rubrics.destroy>
+        <https://canvas.instructure.com/doc/api/rubrics.html#method.rubrics.destroy>`_
 
         :rtype: :class:`canvasapi.rubric.Rubric`
         """

--- a/tests/fixtures/rubric.json
+++ b/tests/fixtures/rubric.json
@@ -16,5 +16,21 @@
 			"association_type": "Assignment"
 		},
 		"status_code": 200
+	},
+	"delete_rubric": {
+		"method": "DELETE",
+		"endpoint": "courses/1/rubrics/1",
+		"data": {
+			"id": 1,
+			"title": "Course Rubric 1",
+			"context_id": 1,
+			"context_type": "Course",
+			"points_possible": 10.0,
+			"reusable": false,
+			"read_only": true,
+			"free_form_critereon_comments": true,
+			"hide_score_total": true
+		},
+		"status_code": 200
 	}
 }

--- a/tests/test_course.py
+++ b/tests/test_course.py
@@ -1202,6 +1202,7 @@ class TestCourse(unittest.TestCase):
         self.assertIsInstance(rubric, Rubric)
         self.assertEqual(rubric.id, rubric_id)
         self.assertEqual(rubric.title, "Course Rubric 1")
+        self.assertTrue(hasattr(rubric, "course_id"))
 
     # get_rubrics
     def test_get_rubrics(self, m):
@@ -1214,9 +1215,12 @@ class TestCourse(unittest.TestCase):
         self.assertIsInstance(rubrics[0], Rubric)
         self.assertEqual(rubrics[0].id, 1)
         self.assertEqual(rubrics[0].title, "Course Rubric 1")
+        self.assertTrue(hasattr(rubrics[0], "course_id"))
+
         self.assertIsInstance(rubrics[1], Rubric)
         self.assertEqual(rubrics[1].id, 2)
         self.assertEqual(rubrics[1].title, "Course Rubric 2")
+        self.assertTrue(hasattr(rubrics[1], "course_id"))
 
     # get_root_outcome_group()
     def test_get_root_outcome_group(self, m):


### PR DESCRIPTION
# Proposed Changes
Addresses Issue #480 by adding a delete function to the Rubric class in rubric.py that calls the Rubric DELETE endpoint in the Canvas LMS REST API.

Sorry for the multiple pull requests - for some reason we failed a run on Github the first time.
