### PR TITLE
Issue/400 quiz group methods incorrectly require

### DIFF
--- a/canvasapi/quiz_group.py
+++ b/canvasapi/quiz_group.py
@@ -14,9 +14,6 @@ class QuizGroup(CanvasObject):
         :calls: `DELETE /api/v1/courses/:course_id/quizzes/:quiz_id/groups/:id \
         <https://canvas.instructure.com/doc/api/quiz_question_groups.html#method.quizzes/quiz_groups.destroy>`_
 
-        :param id: The ID of the question group.
-        :type id: int
-
         :returns: True if the result was successful (Status code of 204)
         :rtype: bool
         """

--- a/canvasapi/quiz_group.py
+++ b/canvasapi/quiz_group.py
@@ -7,7 +7,7 @@ class QuizGroup(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.name, self.id)
 
-    def delete(self, id, **kwargs):
+    def delete(self, **kwargs):
         """
         Get details of the quiz group with the given id.
 
@@ -22,20 +22,20 @@ class QuizGroup(CanvasObject):
         """
         response = self._requester.request(
             "DELETE",
-            "courses/{}/quizzes/{}/groups/{}".format(self.course_id, self.quiz_id, id),
+            "courses/{}/quizzes/{}/groups/{}".format(
+                self.course_id, self.quiz_id, self.id
+            ),
             _kwargs=combine_kwargs(**kwargs),
         )
         return response.status_code == 204
 
-    def reorder_question_group(self, id, order, **kwargs):
+    def reorder_question_group(self, order, **kwargs):
         """
         Update the order of questions within a given group
 
         :calls: `POST /api/v1/courses/:course_id/quizzes/:quiz_id/groups/:id/reorder \
         <https://canvas.instructure.com/doc/api/quiz_question_groups.html#method.quizzes/quiz_groups.reorder>`_
 
-        :param id: The ID of the question group.
-        :type id: int
         :param order: A list of dictionaries containing the key 'id' of
             the question to be placed at order's index.
         :type order: list[dict]
@@ -61,22 +61,20 @@ class QuizGroup(CanvasObject):
         response = self._requester.request(
             "POST",
             "courses/{}/quizzes/{}/groups/{}/reorder".format(
-                self.course_id, self.quiz_id, id
+                self.course_id, self.quiz_id, self.id
             ),
             _kwargs=combine_kwargs(**kwargs),
         )
 
         return response.status_code == 204
 
-    def update(self, id, quiz_groups, **kwargs):
+    def update(self, quiz_groups, **kwargs):
         """
         Update a question group given by id.
 
         :calls: `PUT /api/v1/courses/:course_id/quizzes/:quiz_id/groups/:id \
         <https://canvas.instructure.com/doc/api/quiz_question_groups.html#method.quizzes/quiz_groups.update>`_
 
-        :param id: The ID of the question group.
-        :type id: int
         :param quiz_groups: The name, pick count, and/or question points.
             All of these parameters are optional, but at least one must exist
             (even if empty) to recieve a response.
@@ -100,7 +98,9 @@ class QuizGroup(CanvasObject):
 
         response = self._requester.request(
             "PUT",
-            "courses/{}/quizzes/{}/groups/{}".format(self.course_id, self.quiz_id, id),
+            "courses/{}/quizzes/{}/groups/{}".format(
+                self.course_id, self.quiz_id, self.id
+            ),
             _kwargs=combine_kwargs(**kwargs),
         )
 

--- a/tests/test_quiz_group.py
+++ b/tests/test_quiz_group.py
@@ -31,7 +31,7 @@ class TestQuizGroup(unittest.TestCase):
         register_uris({"quiz_group": ["update"]}, m)
 
         quiz_group = [{"name": "Test Group", "pick_count": 1, "question_points": 2}]
-        result = self.quiz_group.update(10, quiz_group)
+        result = self.quiz_group.update(quiz_group)
 
         self.assertIsInstance(result, bool)
         self.assertTrue(result)
@@ -50,7 +50,7 @@ class TestQuizGroup(unittest.TestCase):
         quiz_group = []
 
         with self.assertRaises(ValueError):
-            self.quiz_group.update(10, quiz_group)
+            self.quiz_group.update(quiz_group)
 
     def test_update_incorrect_param(self, m):
         register_uris({"quiz_group": ["update"]}, m)
@@ -58,7 +58,7 @@ class TestQuizGroup(unittest.TestCase):
         quiz_group = [1]
 
         with self.assertRaises(ValueError):
-            self.quiz_group.update(10, quiz_group)
+            self.quiz_group.update(quiz_group)
 
     def test_update_incorrect_dict(self, m):
         register_uris({"quiz_group": ["update"]}, m)
@@ -66,13 +66,13 @@ class TestQuizGroup(unittest.TestCase):
         quiz_group = [{}]
 
         with self.assertRaises(RequiredFieldMissing):
-            self.quiz_group.update(10, quiz_group)
+            self.quiz_group.update(quiz_group)
 
     # delete_question_group()
     def test_delete(self, m):
         register_uris({"quiz_group": ["delete"]}, m)
 
-        result = self.quiz_group.delete(10)
+        result = self.quiz_group.delete()
 
         self.assertTrue(result)
 
@@ -81,7 +81,7 @@ class TestQuizGroup(unittest.TestCase):
         register_uris({"quiz_group": ["reorder_question_group"]}, m)
 
         newOrdering = [{"id": 2}, {"id": 1, "type": "question"}]
-        result = self.quiz_group.reorder_question_group(10, newOrdering)
+        result = self.quiz_group.reorder_question_group(newOrdering)
 
         self.assertTrue(result)
 
@@ -91,7 +91,7 @@ class TestQuizGroup(unittest.TestCase):
         order = []
 
         with self.assertRaises(ValueError):
-            self.quiz_group.reorder_question_group(10, order)
+            self.quiz_group.reorder_question_group(order)
 
     def test_reorderquestion_group_incorrect_param(self, m):
         register_uris({"quiz_group": ["reorder_question_group"]}, m)
@@ -99,7 +99,7 @@ class TestQuizGroup(unittest.TestCase):
         order = [1]
 
         with self.assertRaises(ValueError):
-            self.quiz_group.reorder_question_group(10, order)
+            self.quiz_group.reorder_question_group(order)
 
     def test_reorderquestion_group_incorrect_dict(self, m):
         register_uris({"quiz_group": ["reorder_question_group"]}, m)
@@ -107,4 +107,4 @@ class TestQuizGroup(unittest.TestCase):
         order = [{"something": 2}]
 
         with self.assertRaises(ValueError):
-            self.quiz_group.reorder_question_group(10, order)
+            self.quiz_group.reorder_question_group(order)


### PR DESCRIPTION
# Proposed Changes
This pr address issue #400 by removing the id parameter in the QuizGroup methods and change the code to use `self.id`
