### PR TITLE
Issue/424 time zone support for smart date times

### DIFF
--- a/canvasapi/canvas_object.py
+++ b/canvasapi/canvas_object.py
@@ -80,15 +80,23 @@ class CanvasObject(object):
 
                     # using https://gist.github.com/heyalexej/8bf688fd67d7199be4a1682b3eec7568
                     # to create string to localize the timezone
-                    local_string = f"Etc/GMT{timezone_offset[0]}"
+                    local_string = "Etc/GMT"
+
+                    # flip for GMT+/-
+                    if timezone_offset[0] == "+":
+                        local_string += "-"
+                    else:
+                        local_string += "+"
+
                     # if the first character is 1, then we need both hour digits
-                    if timezone_offset[1] == 1:
-                        local_string += timezone_offset[1:3]
+                    if timezone_offset[1] == "1":
+                        local_string = local_string + timezone_offset[1:3]
                     # otherwise, we only need the second hour digit
                     else:
                         local_string += timezone_offset[2]
 
                     local_time = pytz.timezone(local_string)
+                    naive = naive.replace(tzinfo=None)
                     local_datetime = local_time.localize(naive)
                     aware = local_datetime.astimezone(pytz.utc)
 

--- a/canvasapi/canvas_object.py
+++ b/canvasapi/canvas_object.py
@@ -1,7 +1,7 @@
 import re
-from datetime import datetime
 
 import pytz
+from dateutil import parser
 
 DATE_PATTERN = re.compile("[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z")
 
@@ -66,7 +66,9 @@ class CanvasObject(object):
             self.__setattr__(attribute, value)
 
             # datetime field
-            if DATE_PATTERN.match(str(value)):
-                naive = datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+            try:
+                naive = parser.isoparse(str(value))
                 aware = naive.replace(tzinfo=pytz.utc)
                 self.__setattr__(attribute + "_date", aware)
+            except ValueError:
+                pass

--- a/canvasapi/canvas_object.py
+++ b/canvasapi/canvas_object.py
@@ -68,7 +68,31 @@ class CanvasObject(object):
             # datetime field
             try:
                 naive = parser.isoparse(str(value))
-                aware = naive.replace(tzinfo=pytz.utc)
+                # UTC or no timezone offset, so set accordingly
+                if "Z" in str(value) or "T" not in str(value) or len(str(value)) <= 6:
+                    aware = naive.replace(tzinfo=pytz.utc)
+
+                # otherwise, localize and use astimezone to fix time to UTC
+                # credit to https://bit.ly/3abuvOf
+                else:
+                    # get timezone offset
+                    timezone_offset = str(value)[-6:]
+
+                    # using https://gist.github.com/heyalexej/8bf688fd67d7199be4a1682b3eec7568
+                    # to create string to localize the timezone
+                    local_string = f"Etc/GMT{timezone_offset[0]}"
+                    # if the first character is 1, then we need both hour digits
+                    if timezone_offset[1] == 1:
+                        local_string += timezone_offset[1:3]
+                    # otherwise, we only need the second hour digit
+                    else:
+                        local_string += timezone_offset[2]
+
+                    local_time = pytz.timezone(local_string)
+                    local_datetime = local_time.localize(naive)
+                    aware = local_datetime.astimezone(pytz.utc)
+
                 self.__setattr__(attribute + "_date", aware)
+
             except ValueError:
                 pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytz
 requests
+python-dateutil

--- a/tests/test_canvas_object.py
+++ b/tests/test_canvas_object.py
@@ -21,6 +21,8 @@ class TestCanvasObject(unittest.TestCase):
             "start_at": "2012-05-05T00:00:00Z",
             "end_at": "2012-08-05",
             "offset_time": "2018-05-21T10:22:25+01:00",
+            "big_offset_time": "2018-05-21T23:22:25+14:00",
+            "big_offset_neg": "2018-05-20T23:22:25-10:00"
         }
 
         start_date = datetime.strptime(
@@ -41,6 +43,10 @@ class TestCanvasObject(unittest.TestCase):
         self.assertEqual(self.canvas_object.end_at_date, end_date)
         self.assertTrue(hasattr(self.canvas_object, "offset_time_date"))
         self.assertEqual(self.canvas_object.offset_time_date, offset_time)
+        self.assertTrue(hasattr(self.canvas_object, "big_offset_time_date"))
+        self.assertEqual(self.canvas_object.big_offset_time_date, offset_time)
+        self.assertTrue(hasattr(self.canvas_object, "big_offset_neg_date"))
+        self.assertEqual(self.canvas_object.big_offset_neg_date, offset_time)
 
     def test_set_attributes_invalid_date(self, m):
         attributes = {"start_at": "2017-01-01T00:00+00:00:00", "end_at": "2012-08-0"}

--- a/tests/test_canvas_object.py
+++ b/tests/test_canvas_object.py
@@ -7,8 +7,6 @@ from canvasapi.canvas_object import CanvasObject
 from canvasapi.requester import Requester
 from tests import settings
 
-from dateutil import parser
-
 
 @requests_mock.Mocker()
 class TestCanvasObject(unittest.TestCase):
@@ -35,19 +33,13 @@ class TestCanvasObject(unittest.TestCase):
             "2018-05-21T09:22:25Z", "%Y-%m-%dT%H:%M:%SZ"
         ).replace(tzinfo=pytz.utc)
 
-        time_1 = parser.isoparse(attributes["offset_time"])
-        time_2 = parser.isoparse("2018-05-21T09:22:25Z")
-
-        print(time_1.utcoffset())
-        print(time_2)
-
         self.canvas_object.set_attributes(attributes)
 
         self.assertTrue(hasattr(self.canvas_object, "start_at_date"))
         self.assertEqual(self.canvas_object.start_at_date, start_date)
         self.assertTrue(hasattr(self.canvas_object, "end_at_date"))
         self.assertEqual(self.canvas_object.end_at_date, end_date)
-        self.assertTrue(hasattr(self.canvas_object, "offset_time"))
+        self.assertTrue(hasattr(self.canvas_object, "offset_time_date"))
         self.assertEqual(self.canvas_object.offset_time_date, offset_time)
 
     def test_set_attributes_invalid_date(self, m):

--- a/tests/test_canvas_object.py
+++ b/tests/test_canvas_object.py
@@ -1,5 +1,61 @@
 import unittest
 
+import requests_mock
+import pytz
+from datetime import datetime
+from canvasapi.canvas_object import CanvasObject
+from canvasapi.requester import Requester
+from tests import settings
 
+from dateutil import parser
+
+
+@requests_mock.Mocker()
 class TestCanvasObject(unittest.TestCase):
-    pass
+    def setUp(self):
+        self.canvas_object = CanvasObject(
+            Requester(settings.BASE_URL, settings.API_KEY), {}
+        )
+
+    # set_attributes
+    def test_set_attributes_valid_date(self, m):
+        attributes = {
+            "start_at": "2012-05-05T00:00:00Z",
+            "end_at": "2012-08-05",
+            "offset_time": "2018-05-21T10:22:25+01:00",
+        }
+
+        start_date = datetime.strptime(
+            attributes["start_at"], "%Y-%m-%dT%H:%M:%SZ"
+        ).replace(tzinfo=pytz.utc)
+        end_date = datetime.strptime(attributes["end_at"], "%Y-%m-%d").replace(
+            tzinfo=pytz.utc
+        )
+        offset_time = datetime.strptime(
+            "2018-05-21T09:22:25Z", "%Y-%m-%dT%H:%M:%SZ"
+        ).replace(tzinfo=pytz.utc)
+
+        time_1 = parser.isoparse(attributes["offset_time"])
+        time_2 = parser.isoparse("2018-05-21T09:22:25Z")
+
+        print(time_1.utcoffset())
+        print(time_2)
+
+        self.canvas_object.set_attributes(attributes)
+
+        self.assertTrue(hasattr(self.canvas_object, "start_at_date"))
+        self.assertEqual(self.canvas_object.start_at_date, start_date)
+        self.assertTrue(hasattr(self.canvas_object, "end_at_date"))
+        self.assertEqual(self.canvas_object.end_at_date, end_date)
+        self.assertTrue(hasattr(self.canvas_object, "offset_time"))
+        self.assertEqual(self.canvas_object.offset_time_date, offset_time)
+
+    def test_set_attributes_invalid_date(self, m):
+        attributes = {"start_at": "2017-01-01T00:00+00:00:00", "end_at": "2012-08-0"}
+
+        self.canvas_object.set_attributes(attributes)
+
+        self.assertFalse(hasattr(self.canvas_object, "start_at_date"))
+        self.assertFalse(hasattr(self.canvas_object, "end_at_date"))
+        self.assertTrue(hasattr(self.canvas_object, "start_at"))
+        self.assertTrue(hasattr(self.canvas_object, "end_at"))


### PR DESCRIPTION
# Proposed Changes
Addresses Issue #424 by adding support for any string in the ISO 8601 format, including time offsets. The fix is a bit verbose, so please follow-up if you have any questions about its functionality. Also fixed the regex string originally used in the program.