### PR TITLE
Issue/490 Add support for submission comment editing/deleting

### DIFF
--- a/canvasapi/submission.py
+++ b/canvasapi/submission.py
@@ -1,4 +1,5 @@
 from canvasapi.canvas_object import CanvasObject
+from canvasapi.file import File
 from canvasapi.paginated_list import PaginatedList
 from canvasapi.peer_review import PeerReview
 from canvasapi.upload import FileOrPathLike, Uploader
@@ -10,11 +11,15 @@ class Submission(CanvasObject):
     def __init__(self, requester, attributes):
         super(Submission, self).__init__(requester, attributes)
 
-        if "submission_comments" in attributes:
-            self.submission_comments = [
-                SubmissionComment(self._requester, submission_comment)
-                for submission_comment in attributes["submission_comments"]
-            ]
+        self.submission_comments = [
+            SubmissionComment(self._requester, submission_comment)
+            for submission_comment in attributes.get("submission_comments", [])
+        ]
+
+        self.attachments = [
+            File(self._requester, attachment)
+            for attachment in attributes.get("attachments", [])
+        ]
 
     def __str__(self):
         return "{}-{}".format(self.assignment_id, self.user_id)

--- a/canvasapi/submission.py
+++ b/canvasapi/submission.py
@@ -54,6 +54,9 @@ class Submission(CanvasObject):
             submissions/:user_id/comments/:id \
         <https://canvas.instructure.com/doc/api/submission_comments.html#method.submission_comments_api.destroy>`_
 
+        :param submission_comment: The comment to be deleted
+        :type user: :class:`canvasapi.submission.SubmissionComment` or int
+
         :rtype: :class:`canvasapi.submission.SubmissionComment`
         """
         submission_comment_id = obj_or_id(
@@ -124,6 +127,9 @@ class Submission(CanvasObject):
         :calls: `PUT /api/v1/courses/:course_id/assignments/:assignment_id/ \
             submissions/:user_id/comments/:id
         <https://canvas.instructure.com/doc/api/submission_comments.html#method.submission_comments_api.update>`_
+
+        :param submission_comment: The comment to be edited
+        :type user: :class:`canvasapi.submission.SubmissionComment` or int
 
         :rtype: :class:`canvasapi.submission.SubmissionComment`
         """

--- a/canvasapi/submission.py
+++ b/canvasapi/submission.py
@@ -2,10 +2,20 @@ from canvasapi.canvas_object import CanvasObject
 from canvasapi.paginated_list import PaginatedList
 from canvasapi.peer_review import PeerReview
 from canvasapi.upload import FileOrPathLike, Uploader
+from canvasapi.user import UserDisplay
 from canvasapi.util import combine_kwargs, obj_or_id
 
 
 class Submission(CanvasObject):
+    def __init__(self, requester, attributes):
+        super(Submission, self).__init__(requester, attributes)
+
+        if "submission_comments" in attributes:
+            self.submission_comments = [
+                SubmissionComment(self._requester, submission_comment)
+                for submission_comment in attributes["submission_comments"]
+            ]
+
     def __str__(self):
         return "{}-{}".format(self.assignment_id, self.user_id)
 
@@ -35,6 +45,28 @@ class Submission(CanvasObject):
         )
 
         return PeerReview(self._requester, response.json())
+
+    def delete_comment(self, submission_comment, **kwargs):
+        """
+        Delete a submission comment
+
+        :calls: `DELETE /api/v1/courses/:course_id/assignments/:assignment_id/ \
+            submissions/:user_id/comments/:id \
+        <https://canvas.instructure.com/doc/api/submission_comments.html#method.submission_comments_api.destroy>`_
+
+        :rtype: :class:`canvasapi.submission.SubmissionComment`
+        """
+        submission_comment_id = obj_or_id(
+            submission_comment, "submission_comment", (SubmissionComment,)
+        )
+        response = self._requester.request(
+            "DELETE",
+            "courses/{}/assignments/{}/submissions/{}/comments/{}".format(
+                self.course_id, self.assignment_id, self.user_id, submission_comment_id
+            ),
+            _kwargs=combine_kwargs(**kwargs),
+        )
+        return SubmissionComment(self._requester, response.json())
 
     def delete_submission_peer_review(self, user, **kwargs):
         """
@@ -84,6 +116,28 @@ class Submission(CanvasObject):
 
         super(Submission, self).set_attributes(response_json)
         return self
+
+    def edit_comment(self, submission_comment, **kwargs):
+        """
+        Edit a submission comment
+
+        :calls: `PUT /api/v1/courses/:course_id/assignments/:assignment_id/ \
+            submissions/:user_id/comments/:id
+        <https://canvas.instructure.com/doc/api/submission_comments.html#method.submission_comments_api.update>`_
+
+        :rtype: :class:`canvasapi.submission.SubmissionComment`
+        """
+        submission_comment_id = obj_or_id(
+            submission_comment, "submission_comment", (SubmissionComment,)
+        )
+        response = self._requester.request(
+            "PUT",
+            "courses/{}/assignments/{}/submissions/{}/comments/{}".format(
+                self.course_id, self.assignment_id, self.user_id, submission_comment_id
+            ),
+            _kwargs=combine_kwargs(**kwargs),
+        )
+        return SubmissionComment(self._requester, response.json())
 
     def get_submission_peer_reviews(self, **kwargs):
         """
@@ -164,7 +218,7 @@ class Submission(CanvasObject):
                 self.course_id, self.assignment_id, self.user_id
             ),
             file,
-            **kwargs
+            **kwargs,
         ).start()
 
         if response[0]:
@@ -188,3 +242,13 @@ class GroupedSubmission(CanvasObject):
         return "{} submission(s) for User #{}".format(
             len(self.submissions), self.user_id
         )
+
+
+class SubmissionComment(CanvasObject):
+    def __init__(self, requester, attributes):
+        super(SubmissionComment, self).__init__(requester, attributes)
+
+        self.author = UserDisplay(requester, self.author)
+
+    def __str__(self):
+        return f"{self.id} (by {self.author})"

--- a/tests/fixtures/submission.json
+++ b/tests/fixtures/submission.json
@@ -47,7 +47,17 @@
 			"assignment_id": 1,
 			"user_id": 1,
 			"html_url": "https://example.com/courses/1/assignments/1/submissions/1",
-			"submission_type": "online_upload"
+			"submission_type": "online_upload",
+			"submission_comments": [
+				{
+					"id": 1,
+					"comment": "Good job!",
+					"author": {
+						"id": 1,
+						"display_name": "John Doe"
+					}
+				}
+			]
 		},
 		"status_code": 200
 	},
@@ -55,8 +65,8 @@
 		"method": "GET",
 		"endpoint": "courses/1/quizzes/1/submissions/1/time",
 		"data": {
-		    "end_at": "9999-99-99T59:59:59Z",
-		    "time_left": 0
+				"end_at": "9999-99-99T59:59:59Z",
+				"time_left": 0
 		},
 		"status_code": 200
 	},
@@ -204,6 +214,30 @@
 					"answers": null
 				}
 			]
+		}
+	},
+	"edit_comment": {
+		"method": "PUT",
+		"endpoint": "courses/1/assignments/1/submissions/1/comments/1",
+		"data": {
+			"id": 1,
+			"comment": "Nice work!",
+			"author": {
+				"id": 1,
+				"display_name": "John Doe"
+			}
+		}
+	},
+	"delete_comment": {
+		"method": "DELETE",
+		"endpoint": "courses/1/assignments/1/submissions/1/comments/1",
+		"data": {
+			"id": 1,
+			"comment": "Good job!",
+			"author": {
+				"id": 1,
+				"display_name": "John Doe"
+			}
 		}
 	}
 }


### PR DESCRIPTION
# Proposed Changes

This PR addresses issue #490 by adding two additional methods to `canvasapi.submission.Submission`. To complete the testing, I've also added the optional "submission_comments" field to the original submission fixture. Technically, this will only be returned if you add `include=["submission_comments"]` to `GET /api/v1/courses/:course_id/assignments/:assignment_id/submissions/:user_id`, which is corresponding to `canvasapi.assignment.Assignment.get_submission`. That's why I updated the `__init__` method for `canvasapi.submission.Submission` as well.

Fixes #490.
