### PR TITLE
Modified the flatten_kwarg function to include the index number in HT…

### DIFF
--- a/canvasapi/util.py
+++ b/canvasapi/util.py
@@ -89,8 +89,8 @@ def flatten_kwarg(key, obj):
     elif is_multivalued(obj):
         # Add empty brackets (i.e. "[]")
         new_list = []
-        for i in obj:
-            for tup in flatten_kwarg(key + "][", i):
+        for index, i in enumerate(obj):
+            for tup in flatten_kwarg(key + "][" + str(index), i):
                 new_list.append((tup[0], tup[1]))
         return new_list
     else:


### PR DESCRIPTION
Provide an index number to arrays in POST variables

# Proposed Changes

* The `flatten_kwarg` function should include an index number, such as `[0]` instead of just `[]`, otherwise an Internal Server Error is thrown by Canvas


Fixes #494 
