### PR TITLE
Issue #566 Moderation Set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### New Endpoint Coverage
+
+- Moderation Grading (Moderation Set)
+    - List students selected for moderation
+    - Select students for moderation
+
 ### General
 
 - Updated Codecov action to v3

--- a/canvasapi/assignment.py
+++ b/canvasapi/assignment.py
@@ -207,6 +207,26 @@ class Assignment(CanvasObject):
 
         return request_json.get("needs_provisional_grade")
 
+    def get_students_selected_for_moderation(self, **kwargs):
+        """
+        Get a list of students selected for moderation.
+
+        :calls: `GET /api/v1/courses/:course_id/assignments/:assignment_id/moderated_students \
+        <https://canvas.instructure.com/doc/api/moderated_grading.html#method.moderation_set.index>`_
+
+        :rtype: :class:`canvasapi.paginated_list.PaginatedList` of
+            :class:`canvasapi.user.User`
+        """
+        return PaginatedList(
+            User,
+            self._requester,
+            "GET",
+            "courses/{}/assignments/{}/moderated_students".format(
+                self.course_id, self.id
+            ),
+            _kwargs=combine_kwargs(**kwargs),
+        )
+
     def get_submission(self, user, **kwargs):
         """
         Get a single submission, based on user id.
@@ -276,6 +296,27 @@ class Assignment(CanvasObject):
             _kwargs=combine_kwargs(**kwargs),
         )
         return response.json()
+
+    def select_students_for_moderation(self, **kwargs):
+        """
+        Select student(s) for moderation.
+
+        :calls: `POST /api/v1/courses/:course_id/assignments/:assignment_id/moderated_students \
+        <https://canvas.instructure.com/doc/api/moderated_grading.html#method.moderation_set.create>`_
+
+        :returns: The list of users that were selected
+        :rtype: :class:`canvasapi.paginated_list.PaginatedList` of
+            :class:`canvasapi.user.User`
+        """
+        return PaginatedList(
+            User,
+            self._requester,
+            "POST",
+            "courses/{}/assignments/{}/moderated_students".format(
+                self.course_id, self.id
+            ),
+            _kwargs=combine_kwargs(**kwargs),
+        )
 
     def selected_provisional_grade(self, provisional_grade_id, **kwargs):
         """

--- a/tests/fixtures/assignment.json
+++ b/tests/fixtures/assignment.json
@@ -490,5 +490,33 @@
 		"data": {
 			"message": "OK"
 		}
+	},
+	"get_students_selected_moderation": {
+		"method": "GET",
+		"endpoint": "courses/1/assignments/1/moderated_students",
+		"data": [
+			{
+				"id": 1,
+				"name": "John Doe"
+			},
+			{
+				"id": 2,
+				"name": "John Smith"
+			}
+		]
+	},
+	"select_students_for_moderation": {
+		"method": "POST",
+		"endpoint": "courses/1/assignments/1/moderated_students",
+		"data": [
+			{
+				"id": 11,
+				"name": "Joyce Smith"
+			},
+			{
+				"id": 12,
+				"name": "Jane Doe"
+			}
+		]
 	}
 }

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -17,7 +17,7 @@ from canvasapi.paginated_list import PaginatedList
 from canvasapi.peer_review import PeerReview
 from canvasapi.progress import Progress
 from canvasapi.submission import Submission
-from canvasapi.user import UserDisplay
+from canvasapi.user import User, UserDisplay
 from tests import settings
 from tests.util import cleanup_file, register_uris
 
@@ -136,6 +136,16 @@ class TestAssignment(unittest.TestCase):
 
         self.assertEqual(len(peer_review_list), 2)
         self.assertIsInstance(peer_review_list[0], PeerReview)
+
+    # get_students_selected_for_moderation()
+    def test_get_students_selected_for_moderation(self, m):
+        register_uris({"assignment": ["get_students_selected_moderation"]}, m)
+
+        selected_students = self.assignment.get_students_selected_for_moderation()
+        selected_student_list = list(selected_students)
+
+        self.assertEqual(len(selected_student_list), 2)
+        self.assertIsInstance(selected_student_list[0], User)
 
     # get_submission()
     def test_get_submission(self, m):
@@ -332,6 +342,18 @@ class TestAssignment(unittest.TestCase):
         status = self.assignment.get_provisional_grades_status(user)
         self.assertIsInstance(status, bool)
         self.assertFalse(status)
+
+    # select_students_for_moderation()
+    def test_select_students_for_moderation(self, m):
+        register_uris({"assignment": ["select_students_for_moderation"]}, m)
+
+        selected_students = self.assignment.select_students_for_moderation(
+            student_ids=[11, 12]
+        )
+        selected_student_list = list(selected_students)
+
+        self.assertEqual(len(selected_student_list), 2)
+        self.assertIsInstance(selected_student_list[0], User)
 
     # selected_provisional_grade
     def test_selected_provisional_grade(self, m):


### PR DESCRIPTION
# Proposed Changes

Add Moderated Grading endpoints:

- [List students selected for moderation](https://canvas.instructure.com/doc/api/moderated_grading.html#method.moderation_set.index)
- [Select students for moderation](https://canvas.instructure.com/doc/api/moderated_grading.html#method.moderation_set.create)

Fixes #566
