### PR TITLE
Call `combine_kwargs` on `course.get_module()`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,4 @@ repos:
     rev: stable
     hooks:
     - id: black
-      language_version: python3.7
+      language_version: python3.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Updated Codecov action to v3
 
+### Bugfixes
+
+- Fixed an issue where kwargs were not passed along to Canvas in `Course.get_module()`. (Thanks, [@bennettscience](https://github.com/bennettscience))
+
 ## [3.0.0] - 2022-09-21
 
 ### New Endpoint Coverage

--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -1658,8 +1658,11 @@ class Course(CanvasObject):
         module_id = obj_or_id(module, "module", (Module,))
 
         response = self._requester.request(
-            "GET", "courses/{}/modules/{}".format(self.id, module_id)
+            "GET",
+            "courses/{}/modules/{}".format(self.id, module_id),
+            _kwargs=combine_kwargs(**kwargs),
         )
+
         module_json = response.json()
         module_json.update({"course_id": self.id})
 


### PR DESCRIPTION
# Proposed Changes

* Call `combine_kwargs` on `course.get_module()` method. Keyword arguments were being omitted.

Fixes #572 .
