### PR TITLE
Updating documentation to include references to AssignmentOverride an…

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -61,6 +61,7 @@ Patches and Suggestions
 - Kenny Perez [@kennygperez](https://github.com/kennygperez)
 - [@kensler](https://github.com/kensler)
 - Lawrence Oks [@ljoks](https://github.com/ljoks)
+- Lee Fent [@lafent](https://github.com/lafent)
 - Leonard Camacho [@lcamacho](https://github.com/lcamacho)
 - Mark Lalor [@MarkLalor](https://github.com/MarkLalor)
 - Markus [@elec3647](https://github.com/elec3647)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Fixed an issue where kwargs were not passed along to Canvas in `Course.get_module()`. (Thanks, [@bennettscience](https://github.com/bennettscience))
 - Fixed an issue where not all functions allowed arbitrary keyword arguments. Added a test to detect and prevent this for the future.
 - Fixed an issue with `Course.get_enabled_features()` where it would throw an error trying to paginate. It now returns a list of strings directly. (Thanks, [@bennettscience](https://github.com/bennettscience))
+- Added missing docs for `AssignmentOverride`. (Thanks, [@lafent](https://github.com/lafent))
 
 ## [3.0.0] - 2022-09-21
 

--- a/canvasapi/assignment.py
+++ b/canvasapi/assignment.py
@@ -563,7 +563,7 @@ class AssignmentOverride(CanvasObject):
         """
         Delete this assignment override.
 
-        :calls: `DELETE /api/v1/courses/:course_id/assignments/:assignment_id/overrides/:id
+        :calls: `DELETE /api/v1/courses/:course_id/assignments/:assignment_id/overrides/:id \
         <https://canvas.instructure.com/doc/api/assignments.html#method.assignment_overrides.destroy>`_
 
         :returns: The previous content of the now-deleted assignment override.
@@ -588,7 +588,7 @@ class AssignmentOverride(CanvasObject):
 
         Note: All current overridden values must be supplied if they are to be retained.
 
-        :calls: `PUT /api/v1/courses/:course_id/assignments/:assignment_id/overrides/:id
+        :calls: `PUT /api/v1/courses/:course_id/assignments/:assignment_id/overrides/:id \
         <https://canvas.instructure.com/doc/api/assignments.html#method.assignment_overrides.update>`_
 
         :rtype: :class:`canvasapi.assignment.AssignmentOverride`

--- a/docs/assignment-ref.rst
+++ b/docs/assignment-ref.rst
@@ -16,3 +16,9 @@ AssignmentGroup
 ===============
 .. autoclass:: canvasapi.assignment.AssignmentGroup
     :members:
+
+==================
+AssignmentOverride
+==================
+.. autoclass:: canvasapi.assignment.AssignmentOverride
+    :members:


### PR DESCRIPTION
…d to display functionality of same.

# Proposed Changes

* This adds a reference to the autoclass for Assignments to pull in the AssignmentOverride details
* Also adds a line break to the `assignments.py` docstrings so they parse properly (same structure used in AssignmentGroup.

Fixes # .
