### PR TITLE
change update_score_and_comments to wrap args

### DIFF
--- a/canvasapi/quiz.py
+++ b/canvasapi/quiz.py
@@ -662,12 +662,19 @@ class QuizSubmission(CanvasObject):
         :returns: The updated quiz.
         :rtype: :class:`canvasapi.quiz.QuizSubmission`
         """
+        args = dict(**kwargs)
+        if 'quiz_submissions' not in args:
+            # we need to wrap the parameters in a quiz_submissions list.
+            # there will only be one element because this object represents one attempt.
+            args['attempt'] = self.attempt
+            args = {'quiz_submissions': [ args ]}
+
         response = self._requester.request(
             "PUT",
             "courses/{}/quizzes/{}/submissions/{}".format(
                 self.course_id, self.quiz_id, self.id
             ),
-            _kwargs=combine_kwargs(**kwargs),
+            _kwargs=combine_kwargs(**args),
         )
         response_json = response.json()["quiz_submissions"][0]
         response_json.update({"course_id": self.course_id})


### PR DESCRIPTION
when calling update_score_and_comments on a quiz submission, the attempt is already in self and there will be only one item in the update list.
# Proposed Changes

* this change wraps the passed arguments in a unary quiz_submissions list if quiz_submissions is not one of the parameters to the call.

* legacy behavior is preserved if quiz_submissions is in the calling parameters.

Fixes #601  
