### PR TITLE
Add missing endpoint on File

### DIFF
--- a/canvasapi/file.py
+++ b/canvasapi/file.py
@@ -44,3 +44,17 @@ class File(CanvasObject):
             return response.content
         else:
             return response.text
+
+    def update(self, **kwargs):
+        """
+        Update some settings on the specified file.
+
+        :calls: `PUT /api/v1/files/:id \
+                <https://canvas.instructure.com/doc/api/files.html#method.files.api_update>`_
+
+        :rtype: `canvasapi.file.File`
+        """
+        response = self._requester.request(
+            "PUT", "files/{}".format(self.id), _kwargs=combine_kwargs(**kwargs)
+        )
+        return File(self._requester, response.json())

--- a/tests/fixtures/file.json
+++ b/tests/fixtures/file.json
@@ -32,5 +32,14 @@
         "endpoint": "ANY",
         "data": "file contents are here",
         "status_code": 200
+    },
+    "update_file": {
+        "method": "PUT",
+        "endpoint": "files/1",
+        "data": {
+            "id": 1,
+            "display_name": "New filename.docx"
+        },
+        "status_code": 200
     }
 }

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -55,3 +55,13 @@ class TestFile(unittest.TestCase):
         self.assertEqual(contents, '"Hello there"')
         contents_binary = self.file.get_contents(binary=True)
         self.assertEqual(contents_binary, b'"Hello there"')
+
+    # update()
+    def test_update_file(self, m):
+        register_uris({"file": ["update_file"]}, m)
+
+        updated_file = self.file.update(name="New filename.docx")
+
+        self.assertIsInstance(updated_file, File)
+        self.assertTrue(hasattr(updated_file, "display_name"))
+        self.assertEqual(updated_file.display_name, "New filename.docx")


### PR DESCRIPTION
The `update` method was missing on the `File` object. Add the missing method, fixtures, and test.

Fixes #600.