### PR TITLE
New Quizzes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### New Endpoint Coverage
+
+- New Quizzes
+
 ### General
 
 - Added support for pagination with metadata when headers are missing (Thanks, [@bennettscience](https://github.com/bennettscience))

--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -471,8 +471,10 @@ class Course(CanvasObject):
             _url=self._requester.original_url + "/api/quiz/v1/" + endpoint,
             _kwargs=combine_kwargs(**kwargs),
         )
+        response_json = response.json()
+        response_json.update({"course_id": self.id})
 
-        return NewQuiz(self._requester, response.json())
+        return NewQuiz(self._requester, response_json)
 
     def create_page(self, wiki_page, **kwargs):
         """
@@ -1747,8 +1749,10 @@ class Course(CanvasObject):
             _url=self._requester.original_url + "/api/quiz/v1/" + endpoint,
             _kwargs=combine_kwargs(**kwargs),
         )
+        response_json = response.json()
+        response_json.update({"course_id": self.id})
 
-        return NewQuiz(self._requester, response.json())
+        return NewQuiz(self._requester, response_json)
 
     def get_new_quizzes(self, **kwargs):
         """

--- a/canvasapi/new_quiz.py
+++ b/canvasapi/new_quiz.py
@@ -1,0 +1,6 @@
+from canvasapi.canvas_object import CanvasObject
+
+
+class NewQuiz(CanvasObject):
+    def __str__(self):
+        return "{} ({})".format(self.title, self.id)

--- a/canvasapi/new_quiz.py
+++ b/canvasapi/new_quiz.py
@@ -1,6 +1,53 @@
 from canvasapi.canvas_object import CanvasObject
+from canvasapi.util import combine_kwargs
 
 
 class NewQuiz(CanvasObject):
     def __str__(self):
         return "{} ({})".format(self.title, self.id)
+
+    def delete(self, **kwargs):
+        """
+        Delete a single new quiz.
+
+        :calls: `DELETE /api/quiz/v1/courses/:course_id/quizzes/:assignment_id \
+        <https://canvas.instructure.com/doc/api/new_quizzes.html#method.new_quizzes/quizzes_api.destroy>`_
+
+        :returns: The deleted New Quiz object
+        :rtype: :class:`canvasapi.new_quiz.NewQuiz`
+        """
+        endpoint = "courses/{}/quizzes/{}".format(self.course_id, self.id)
+
+        response = self._requester.request(
+            "DELETE",
+            endpoint,
+            _url=self._requester.original_url + "/api/quiz/v1/" + endpoint,
+            _kwargs=combine_kwargs(**kwargs),
+        )
+        response_json = response.json()
+        response_json.update({"course_id": self.course_id})
+
+        return NewQuiz(self._requester, response_json)
+
+    def update(self, **kwargs):
+        """
+        Update a single New Quiz for the course.
+
+        :calls: `PATCH /api/quiz/v1/courses/:course_id/quizzes/:assignment_id \
+        <https://canvas.instructure.com/doc/api/new_quizzes.html#method.new_quizzes/quizzes_api.update>`_
+
+        :returns: The updated New Quiz object
+        :rtype: :class:`canvasapi.new_quiz.NewQuiz`
+        """
+        endpoint = "courses/{}/quizzes/{}".format(self.course_id, self.id)
+
+        response = self._requester.request(
+            "PATCH",
+            endpoint,
+            _url=self._requester.original_url + "/api/quiz/v1/" + endpoint,
+            _kwargs=combine_kwargs(**kwargs),
+        )
+        response_json = response.json()
+        response_json.update({"course_id": self.course_id})
+
+        return NewQuiz(self._requester, response_json)

--- a/canvasapi/paginated_list.py
+++ b/canvasapi/paginated_list.py
@@ -25,6 +25,7 @@ class PaginatedList(object):
         first_url,
         extra_attribs=None,
         _root=None,
+        _url_override=None,
         **kwargs
     ):
         self._elements = list()
@@ -39,6 +40,7 @@ class PaginatedList(object):
         self._extra_attribs = extra_attribs or {}
         self._request_method = request_method
         self._root = _root
+        self._url_override = _url_override
 
     def __iter__(self):
         for element in self._elements:
@@ -53,7 +55,10 @@ class PaginatedList(object):
 
     def _get_next_page(self):
         response = self._requester.request(
-            self._request_method, self._next_url, **self._next_params
+            self._request_method,
+            self._next_url,
+            _url=self._url_override,
+            **self._next_params,
         )
         data = response.json()
         self._next_url = None

--- a/tests/fixtures/new_quiz.json
+++ b/tests/fixtures/new_quiz.json
@@ -1,0 +1,29 @@
+{
+	"get_new_quiz": {
+		"method": "GET",
+		"endpoint": "courses/1/quizzes/1",
+		"data": {
+			"id": 1,
+			"title": "New Quiz One",
+			"instructions": "<p>This is the first New Quiz. Good luck!</p>"
+		},
+		"status_code": 200
+	},
+	"get_new_quizzes": {
+		"method": "GET",
+		"endpoint": "courses/1/quizzes",
+		"data": [
+			{
+				"id": 1,
+				"title": "New Quiz One",
+				"instructions": "<p>This is the first New Quiz. Good luck!</p>"
+			},
+			{
+				"id": 2,
+				"title": "New Quiz Two",
+				"instructions": "<p>This is the second New Quiz. Good luck!</p>"
+			}
+		],
+		"status_code": 200
+	}
+}

--- a/tests/fixtures/new_quiz.json
+++ b/tests/fixtures/new_quiz.json
@@ -1,4 +1,24 @@
 {
+	"create_new_quiz": {
+		"method": "POST",
+		"endpoint": "courses/1/quizzes",
+		"data": {
+			"id": 1,
+			"title": "New Quiz One",
+			"instructions": "<p>This is the first New Quiz. Good luck!</p>"
+		},
+		"status_code": 200
+	},
+	"delete_new_quiz": {
+		"method": "DELETE",
+		"endpoint": "courses/1/quizzes/1",
+		"data": {
+			"id": 1,
+			"title": "New Quiz One",
+			"instructions": "<p>This is the first New Quiz. Good luck!</p>"
+		},
+		"status_code": 200
+	},
 	"get_new_quiz": {
 		"method": "GET",
 		"endpoint": "courses/1/quizzes/1",
@@ -24,6 +44,16 @@
 				"instructions": "<p>This is the second New Quiz. Good luck!</p>"
 			}
 		],
+		"status_code": 200
+	},
+	"update_new_quiz": {
+		"method": "PATCH",
+		"endpoint": "courses/1/quizzes/1",
+		"data": {
+			"id": 1,
+			"title": "New Quiz One - Updated!",
+			"instructions": "<p>This is the updated New Quiz. You got this!</p>"
+		},
 		"status_code": 200
 	}
 }

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,5 +1,6 @@
 BASE_URL = "https://example.com"
 BASE_URL_GRAPHQL = "https://example.com/api/"
+BASE_URL_NEW_QUIZZES = "https://example.com/api/quiz/v1/"
 BASE_URL_WITH_VERSION = "https://example.com/api/v1/"
 BASE_URL_AS_HTTP = "http://example.com"
 BASE_URL_AS_BLANK = ""

--- a/tests/test_course.py
+++ b/tests/test_course.py
@@ -35,6 +35,7 @@ from canvasapi.grading_standard import GradingStandard
 from canvasapi.group import Group, GroupCategory
 from canvasapi.license import License
 from canvasapi.module import Module
+from canvasapi.new_quiz import NewQuiz
 from canvasapi.outcome import OutcomeGroup, OutcomeLink, OutcomeResult
 from canvasapi.outcome_import import OutcomeImport
 from canvasapi.paginated_list import PaginatedList
@@ -389,6 +390,36 @@ class TestCourse(unittest.TestCase):
         self.assertIsInstance(quiz_list[0], Quiz)
         self.assertTrue(hasattr(quiz_list[0], "course_id"))
         self.assertEqual(quiz_list[0].course_id, self.course.id)
+
+    # get_new_quiz()
+    def test_get_new_quiz(self, m):
+        register_uris(
+            {"new_quiz": ["get_new_quiz"]},
+            m,
+            base_url=settings.BASE_URL_NEW_QUIZZES,
+        )
+
+        new_quiz = self.course.get_new_quiz(1)
+
+        self.assertIsInstance(new_quiz, NewQuiz)
+        self.assertTrue(hasattr(new_quiz, "title"))
+        self.assertEqual(new_quiz.title, "New Quiz One")
+
+    # get_new_quizzes()
+    def test_get_new_quizzes(self, m):
+        register_uris(
+            {"new_quiz": ["get_new_quizzes"]},
+            m,
+            base_url=settings.BASE_URL_NEW_QUIZZES,
+        )
+
+        new_quizzes = self.course.get_new_quizzes()
+        new_quiz_list = list(new_quizzes)
+
+        self.assertEqual(len(new_quiz_list), 2)
+        self.assertIsInstance(new_quiz_list[0], NewQuiz)
+        self.assertTrue(hasattr(new_quiz_list[0], "title"))
+        self.assertEqual(new_quiz_list[0].title, "New Quiz One")
 
     # get_modules()
     def test_get_modules(self, m):

--- a/tests/test_course.py
+++ b/tests/test_course.py
@@ -334,6 +334,23 @@ class TestCourse(unittest.TestCase):
         with self.assertRaises(RequiredFieldMissing):
             self.course.create_quiz({})
 
+    # create_new_quiz()
+    def test_create_new_quiz(self, m):
+        register_uris(
+            {"new_quiz": ["create_new_quiz"]},
+            m,
+            base_url=settings.BASE_URL_NEW_QUIZZES,
+        )
+
+        title = "New Quiz One"
+        new_new_quiz = self.course.create_new_quiz(quiz={"title": title})
+
+        self.assertIsInstance(new_new_quiz, NewQuiz)
+        self.assertTrue(hasattr(new_new_quiz, "title"))
+        self.assertEqual(new_new_quiz.title, title)
+        self.assertTrue(hasattr(new_new_quiz, "course_id"))
+        self.assertEqual(new_new_quiz.course_id, self.course.id)
+
     # get_quiz()
     def test_get_quiz(self, m):
         register_uris({"course": ["get_quiz"]}, m)
@@ -404,6 +421,8 @@ class TestCourse(unittest.TestCase):
         self.assertIsInstance(new_quiz, NewQuiz)
         self.assertTrue(hasattr(new_quiz, "title"))
         self.assertEqual(new_quiz.title, "New Quiz One")
+        self.assertTrue(hasattr(new_quiz, "course_id"))
+        self.assertEqual(new_quiz.course_id, self.course.id)
 
     # get_new_quizzes()
     def test_get_new_quizzes(self, m):

--- a/tests/test_new_quiz.py
+++ b/tests/test_new_quiz.py
@@ -3,6 +3,7 @@ import unittest
 import requests_mock
 
 from canvasapi import Canvas
+from canvasapi.new_quiz import NewQuiz
 from tests import settings
 from tests.util import register_uris
 
@@ -27,3 +28,41 @@ class TestNewQuiz(unittest.TestCase):
     def test__str__(self, m):
         string = str(self.new_quiz)
         self.assertIsInstance(string, str)
+
+    # delete()
+    def test_delete(self, m):
+        register_uris(
+            {"new_quiz": ["delete_new_quiz"]},
+            m,
+            base_url=settings.BASE_URL_NEW_QUIZZES,
+        )
+
+        deleted_quiz = self.new_quiz.delete()
+
+        self.assertIsInstance(deleted_quiz, NewQuiz)
+        self.assertTrue(hasattr(deleted_quiz, "title"))
+        self.assertEqual(deleted_quiz.title, "New Quiz One")
+        self.assertTrue(hasattr(deleted_quiz, "course_id"))
+        self.assertEqual(deleted_quiz.course_id, self.course.id)
+
+    # update()
+    def test_update(self, m):
+        register_uris(
+            {"new_quiz": ["update_new_quiz"]},
+            m,
+            base_url=settings.BASE_URL_NEW_QUIZZES,
+        )
+
+        new_title = "New Quiz One - Updated!"
+        new_instructions = "<p>This is the updated New Quiz. You got this!</p>"
+        new_quiz = self.new_quiz.update(
+            quiz={"title": new_title, "instructions": new_instructions}
+        )
+
+        self.assertIsInstance(new_quiz, NewQuiz)
+        self.assertTrue(hasattr(new_quiz, "title"))
+        self.assertEqual(new_quiz.title, new_title)
+        self.assertTrue(hasattr(new_quiz, "instructions"))
+        self.assertEqual(new_quiz.instructions, new_instructions)
+        self.assertTrue(hasattr(new_quiz, "course_id"))
+        self.assertEqual(new_quiz.course_id, self.course.id)

--- a/tests/test_new_quiz.py
+++ b/tests/test_new_quiz.py
@@ -1,0 +1,29 @@
+import unittest
+
+import requests_mock
+
+from canvasapi import Canvas
+from tests import settings
+from tests.util import register_uris
+
+
+@requests_mock.Mocker()
+class TestNewQuiz(unittest.TestCase):
+    def setUp(self):
+        self.canvas = Canvas(settings.BASE_URL, settings.API_KEY)
+
+        with requests_mock.Mocker() as m:
+            register_uris({"course": ["get_by_id"]}, m)
+            register_uris(
+                {"new_quiz": ["get_new_quiz"]},
+                m,
+                base_url=settings.BASE_URL_NEW_QUIZZES,
+            )
+
+            self.course = self.canvas.get_course(1)
+            self.new_quiz = self.course.get_new_quiz(1)
+
+    # __str__()
+    def test__str__(self, m):
+        string = str(self.new_quiz)
+        self.assertIsInstance(string, str)


### PR DESCRIPTION
# Proposed Changes

* Add coverage for New Quizzes endpoints

**Note:** These endpoints follow a different base URL than most other endpoints (`/api/quiz/v1/` instead of `/api/v1/`)

Fixes #608
