### PR TITLE
Update `PaginatedList`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### General
+
+- Added support for pagination with metadata when headers are missing (Thanks, [@bennettscience](https://github.com/bennettscience))
+
 ## [3.1.0] - 2023-04-21
 
 ### New Endpoint Coverage

--- a/canvasapi/paginated_list.py
+++ b/canvasapi/paginated_list.py
@@ -63,14 +63,13 @@ class PaginatedList(object):
         # See https://github.com/ucfopen/canvasapi/discussions/605
         if response.links:
             next_link = response.links.get("next")
-        elif type(data) is dict and data.get("meta") is not None:
+        elif isinstance(data, dict) and "meta" in data:
             # requests parses headers into dicts, this returns the same
             # structure so the regex will still work.
-            next_link = (
-                {"url": data.get("meta").get("pagination").get("next"), "rel": "next"}
-                if data["meta"]["pagination"]["next"]
-                else None
-            )
+            try:
+                next_link = {"url": data["meta"]["pagination"]["next"], "rel": "next"}
+            except KeyError:
+                next_link = None
         else:
             next_link = None
 

--- a/tests/fixtures/paginated_list.json
+++ b/tests/fixtures/paginated_list.json
@@ -158,7 +158,16 @@
 		"method": "ANY",
 		"endpoint": "no_header_no_next_key",
 		"data": {
-			"assessments": [],
+			"assessments": [
+				{
+					"id": "1",
+					"name": "object 1"
+				},
+				{
+					"id": "2",
+					"name": "object 2"
+				}
+			],
 			"meta": {
 				"pagination": {
 					"prev": "https://example.com/api/v1/previous"

--- a/tests/fixtures/paginated_list.json
+++ b/tests/fixtures/paginated_list.json
@@ -114,5 +114,57 @@
 			}
 		],
 		"status_code": 200
-	}
+	},
+	"no_header_4_2_pages_p1": {
+		"method": "ANY",
+		"endpoint": "no_header_four_objects_two_pages",
+		"data": {
+			"assessments": [
+				{
+					"id": "1",
+					"name": "object 1"
+				},
+				{
+					"id": "2",
+					"name": "object 2"
+				}
+			],
+			"meta": {
+				"pagination": {
+					"next": "https://example.com/api/v1/no_header_four_objects_two_pages?page=2"
+				}
+			}
+		},
+		"status_code": 200
+	},
+	"no_header_4_2_pages_p2": {
+		"method": "ANY",
+		"endpoint": "no_header_four_objects_two_pages?page=2",
+		"data": {
+			"assessments": [
+				{
+					"id": "3",
+					"name": "object 3"
+				},
+				{
+					"id": "4",
+					"name": "object 4"
+				}
+			]
+		},
+		"status_code": 200
+	},
+	"no_header_no_next_key": {
+		"method": "ANY",
+		"endpoint": "no_header_no_next_key",
+		"data": {
+			"assessments": [],
+			"meta": {
+				"pagination": {
+					"prev": "https://example.com/api/v1/previous"
+				}
+			}
+		}
+	},
+	"status_code": 200
 }

--- a/tests/test_paginated_list.py
+++ b/tests/test_paginated_list.py
@@ -231,3 +231,5 @@ class TestPaginatedList(unittest.TestCase):
         )
 
         self.assertIsInstance(pag_list, PaginatedList)
+        self.assertEqual(len(list(pag_list)), 2)
+        self.assertIsInstance(pag_list[0], User)

--- a/tests/test_paginated_list.py
+++ b/tests/test_paginated_list.py
@@ -156,6 +156,9 @@ class TestPaginatedList(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             pag_list[0]
+            self.assertEqual(
+                pag_list[0], "The key <wrong> does not exist in the response."
+            )
 
     def test_root_element(self, m):
         register_uris({"account": ["get_enrollment_terms"]}, m)
@@ -202,3 +205,29 @@ class TestPaginatedList(unittest.TestCase):
 
         with self.assertRaises(IndexError):
             pag_list[:-1]
+
+    def test_paginated_list_no_header(self, m):
+        register_uris(
+            {"paginated_list": ["no_header_4_2_pages_p1", "no_header_4_2_pages_p2"]}, m
+        )
+
+        pag_list = PaginatedList(
+            User,
+            self.requester,
+            "GET",
+            "no_header_four_objects_two_pages",
+            _root="assessments",
+        )
+
+        self.assertIsInstance(pag_list, PaginatedList)
+        self.assertEqual(len(list(pag_list)), 4)
+        self.assertIsInstance(pag_list[0], User)
+
+    def test_paginated_list_no_header_no_next(self, m):
+        register_uris({"paginated_list": ["no_header_no_next_key"]}, m)
+
+        pag_list = PaginatedList(
+            User, self.requester, "GET", "no_header_no_next_key", _root="assessments"
+        )
+
+        self.assertIsInstance(pag_list, PaginatedList)


### PR DESCRIPTION
Based on #605, `PaginatedList` could not process requests which return pagination info in the response body. This update checks for `Link` headers before checking the `meta` property in the response body.

Resolves #605
Related: #565 