### PR TITLE
#629 Implement default request timeouts

### DIFF
--- a/canvasapi/canvas.py
+++ b/canvasapi/canvas.py
@@ -72,7 +72,9 @@ class Canvas(object):
         access_token = access_token.strip()
         base_url = get_institution_url(base_url)
 
-        self.__requester = Requester(base_url, access_token, default_timeout=default_timeout)
+        self.__requester = Requester(
+            base_url, access_token, default_timeout=default_timeout
+        )
 
     def clear_course_nicknames(self, **kwargs):
         """

--- a/canvasapi/canvas.py
+++ b/canvasapi/canvas.py
@@ -33,12 +33,14 @@ class Canvas(object):
     The main class to be instantiated to provide access to Canvas's API.
     """
 
-    def __init__(self, base_url, access_token):
+    def __init__(self, base_url, access_token, default_timeout=None):
         """
         :param base_url: The base URL of the Canvas instance's API.
         :type base_url: str
         :param access_token: The API key to authenticate requests with.
         :type access_token: str
+        :param default_timeout: The default timeout for all requests in seconds.
+        :type default_timeout: int
         """
         if "api/v1" in base_url:
             raise ValueError(
@@ -70,7 +72,7 @@ class Canvas(object):
         access_token = access_token.strip()
         base_url = get_institution_url(base_url)
 
-        self.__requester = Requester(base_url, access_token)
+        self.__requester = Requester(base_url, access_token, default_timeout=default_timeout)
 
     def clear_course_nicknames(self, **kwargs):
         """

--- a/canvasapi/requester.py
+++ b/canvasapi/requester.py
@@ -53,7 +53,9 @@ class Requester(object):
         :param data: The data to send with this request.
         :type data: dict
         """
-        return self._session.delete(url, headers=headers, data=data, timeout=self._default_timeout)
+        return self._session.delete(
+            url, headers=headers, data=data, timeout=self._default_timeout
+        )
 
     def _get_request(self, url, headers, params=None, **kwargs):
         """
@@ -66,7 +68,9 @@ class Requester(object):
         :param params: The parameters to send with this request.
         :type params: dict
         """
-        return self._session.get(url, headers=headers, params=params, timeout=self._default_timeout)
+        return self._session.get(
+            url, headers=headers, params=params, timeout=self._default_timeout
+        )
 
     def _patch_request(self, url, headers, data=None, **kwargs):
         """
@@ -79,7 +83,9 @@ class Requester(object):
         :param data: The data to send with this request.
         :type data: dict
         """
-        return self._session.patch(url, headers=headers, data=data, timeout=self._default_timeout)
+        return self._session.patch(
+            url, headers=headers, data=data, timeout=self._default_timeout
+        )
 
     def _post_request(self, url, headers, data=None, json=False):
         """
@@ -95,7 +101,9 @@ class Requester(object):
         :type json: bool
         """
         if json:
-            return self._session.post(url, headers=headers, json=dict(data), timeout=self._default_timeout)
+            return self._session.post(
+                url, headers=headers, json=dict(data), timeout=self._default_timeout
+            )
 
         # Grab file from data.
         files = None
@@ -110,7 +118,9 @@ class Requester(object):
         # Remove file entry from data.
         data[:] = [tup for tup in data if tup[0] != "file"]
 
-        return self._session.post(url, headers=headers, data=data, files=files, timeout=self._default_timeout)
+        return self._session.post(
+            url, headers=headers, data=data, files=files, timeout=self._default_timeout
+        )
 
     def _put_request(self, url, headers, data=None, **kwargs):
         """
@@ -123,7 +133,9 @@ class Requester(object):
         :param data: The data to send with this request.
         :type data: dict
         """
-        return self._session.put(url, headers=headers, data=data, timeout=self._default_timeout)
+        return self._session.put(
+            url, headers=headers, data=data, timeout=self._default_timeout
+        )
 
     def request(
         self,

--- a/canvasapi/requester.py
+++ b/canvasapi/requester.py
@@ -25,12 +25,14 @@ class Requester(object):
     Responsible for handling HTTP requests.
     """
 
-    def __init__(self, base_url, access_token):
+    def __init__(self, base_url, access_token, default_timeout=None):
         """
         :param base_url: The base URL of the Canvas instance's API.
         :type base_url: str
         :param access_token: The API key to authenticate requests with.
         :type access_token: str
+        :param default_timeout: The default timeout for all requests in seconds.
+        :type default_timeout: int
         """
         # Preserve the original base url and add "/api/v1" to it
         self.original_url = base_url
@@ -38,6 +40,7 @@ class Requester(object):
         self.access_token = access_token
         self._session = requests.Session()
         self._cache = []
+        self._default_timeout = default_timeout
 
     def _delete_request(self, url, headers, data=None, **kwargs):
         """
@@ -50,7 +53,7 @@ class Requester(object):
         :param data: The data to send with this request.
         :type data: dict
         """
-        return self._session.delete(url, headers=headers, data=data)
+        return self._session.delete(url, headers=headers, data=data, timeout=self._default_timeout)
 
     def _get_request(self, url, headers, params=None, **kwargs):
         """
@@ -63,7 +66,7 @@ class Requester(object):
         :param params: The parameters to send with this request.
         :type params: dict
         """
-        return self._session.get(url, headers=headers, params=params)
+        return self._session.get(url, headers=headers, params=params, timeout=self._default_timeout)
 
     def _patch_request(self, url, headers, data=None, **kwargs):
         """
@@ -76,7 +79,7 @@ class Requester(object):
         :param data: The data to send with this request.
         :type data: dict
         """
-        return self._session.patch(url, headers=headers, data=data)
+        return self._session.patch(url, headers=headers, data=data, timeout=self._default_timeout)
 
     def _post_request(self, url, headers, data=None, json=False):
         """
@@ -92,7 +95,7 @@ class Requester(object):
         :type json: bool
         """
         if json:
-            return self._session.post(url, headers=headers, json=dict(data))
+            return self._session.post(url, headers=headers, json=dict(data), timeout=self._default_timeout)
 
         # Grab file from data.
         files = None
@@ -107,7 +110,7 @@ class Requester(object):
         # Remove file entry from data.
         data[:] = [tup for tup in data if tup[0] != "file"]
 
-        return self._session.post(url, headers=headers, data=data, files=files)
+        return self._session.post(url, headers=headers, data=data, files=files, timeout=self._default_timeout)
 
     def _put_request(self, url, headers, data=None, **kwargs):
         """
@@ -120,7 +123,7 @@ class Requester(object):
         :param data: The data to send with this request.
         :type data: dict
         """
-        return self._session.put(url, headers=headers, data=data)
+        return self._session.put(url, headers=headers, data=data, timeout=self._default_timeout)
 
     def request(
         self,


### PR DESCRIPTION
# Proposed Changes

Adds a default API request timeout. I originally wanted to have a timeout keyword argument for every Requester.request call, but there were far too many instances of self._requester.request in the codebase, so I've instead insisted on a global default timeout.

I was unsure how to write the unit test for the mocked request wait and raise a ReadTimeout, so I'll just have to leave that up to a reviewer.

Fixes #629 .
