### PR TITLE
implement kwargs (fix #631) for upload_comment

### DIFF
--- a/canvasapi/submission.py
+++ b/canvasapi/submission.py
@@ -177,7 +177,11 @@ class Submission(CanvasObject):
         ).start()
 
         if response[0]:
-            self.edit(comment={"file_ids": [response[1]["id"]]})
+            if "comment" in kwargs:
+                kwargs["comment"].update({"file_ids": [response[1]["id"]]})
+            else:
+                kwargs["comment"] = {"file_ids": [response[1]["id"]]}
+            self.edit(**kwargs)
         return response
 
 

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -122,6 +122,25 @@ class TestSubmission(unittest.TestCase):
         finally:
             cleanup_file(filename)
 
+    def test_upload_comment_with_kwargs(self, m):
+        register_uris(
+            {"submission": ["upload_comment", "upload_comment_final", "edit"]}, m
+        )
+
+        filename = "testfile_submission_{}".format(uuid.uuid4().hex)
+
+        try:
+            with open(filename, "w+") as file:
+                response = self.submission.upload_comment(
+                    file, comment={"attempt": 1, "text_comment": "This is just a test."}
+                )
+
+            self.assertTrue(response[0])
+            self.assertIsInstance(response[1], dict)
+            self.assertIn("url", response[1])
+        finally:
+            cleanup_file(filename)
+
 
 class TestGroupedSubmission(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
# Proposed Changes
* Updates `upload_comment` to allow `kwargs` to be passed as part of the upload file process.
* non-breaking change

Indirectly fixes #631 and also allows for other arbitrary submission edit properties to be posted along with the attachments. 

# Limitations
Note, this implementation emulates the original implementation's flaw of returning the _outcome of the upload file process_ but **not** the actually updated `submission` object that `Submission.edit` returns. This means in the test cases, you can only test to see if the file was successfully updated, not if the comment itself was posted on the submission.

It's also worth noting it doesn't directly fix #631 since you still need to manually specify the attempt. Not sure if that should be a default value or not given the way the `edit` function works currently.

```
some_submission.upload_comment(
    file, comment={"attempt": some_submission.attempt, "text_comment": "Text that can appear instead of generic 'See Attached Files' message."}
```

Editors Note: earlier PR wasn't compatible with 3.7. When fixing the issue I nuked the repo. My bad.

# Quick Fix

If anyone needs to patch this in the meantime, you can do so wherever you need to use the upload_comment method:

```python
from canvasapi.submission import Submission
from canvasapi.upload import FileOrPathLike, Uploader

def upload_comment(self, file: FileOrPathLike, **kwargs):
    """
    Upload a file to attach to this submission as a comment.

    :calls: `POST \
    /api/v1/courses/:course_id/assignments/:assignment_id/submissions/:user_id/comments/files \
    <https://canvas.instructure.com/doc/api/submission_comments.html#method.submission_comments_api.create_file>`_

    :param file: The file or path of the file to upload.
    :type file: file or str
    :returns: True if the file uploaded successfully, False otherwise, \
        and the JSON response from the API.
    :rtype: tuple
    """
    response = Uploader(
        self._requester,
        "courses/{}/assignments/{}/submissions/{}/comments/files".format(
            self.course_id, self.assignment_id, self.user_id
        ),
        file,
        **kwargs
    ).start()

    if response[0]:
        if "comment" in kwargs:
            kwargs["comment"].update({"file_ids": [response[1]["id"]]})
        else:
            kwargs["comment"] = {"file_ids": [response[1]["id"]]}

        self.edit(**kwargs)

    return response

# monkey patching built-in Submission.upload_comment with the new version
Submission.upload_comment = upload_comment
```
