### PR TITLE
Fixed file objects with hyphen issue and added test cases #647 

### DIFF
--- a/canvasapi/canvas_object.py
+++ b/canvasapi/canvas_object.py
@@ -59,12 +59,13 @@ class CanvasObject(object):
         :type attributes: dict
         """
         for attribute, value in attributes.items():
-            self.__setattr__(attribute, value)
+            safe_attribute = attribute.replace("-", "_")
+            self.__setattr__(safe_attribute, value)
 
             try:
                 naive = arrow.get(str(value)).datetime
                 aware = naive.replace(tzinfo=pytz.utc) - naive.utcoffset()
-                self.__setattr__(attribute + "_date", aware)
+                self.__setattr__(safe_attribute + "_date", aware)
             except arrow.ParserError:
                 pass
             except ValueError:

--- a/tests/test_canvas_object.py
+++ b/tests/test_canvas_object.py
@@ -52,6 +52,33 @@ class TestCanvasObject(unittest.TestCase):
 
         self.assertTrue(hasattr(self.canvas_object, "half_offset_date"))
         self.assertEqual(self.canvas_object.half_offset_date, offset_time)
+    
+    # set_attributes with a hyphen
+    def test_set_attributes_with_hyphens(self, m):
+        attributes = {
+            "content-type": "application/json",
+            "filename": "example.json",
+            "start-at": "2012-05-05T00:00:00Z",
+            "end-at": "2012-08-05",
+        }
+
+        start_date = datetime.strptime(
+            attributes["start-at"], "%Y-%m-%dT%H:%M:%SZ"
+        ).replace(tzinfo=pytz.utc)
+        end_date = datetime.strptime(attributes["end-at"], "%Y-%m-%d").replace(
+            tzinfo=pytz.utc
+        )
+
+        self.canvas_object.set_attributes(attributes)
+
+        self.assertTrue(hasattr(self.canvas_object, "start_at_date"))
+        self.assertEqual(self.canvas_object.start_at_date, start_date)
+        self.assertTrue(hasattr(self.canvas_object, "end_at_date"))
+        self.assertEqual(self.canvas_object.end_at_date, end_date)
+        self.assertTrue(hasattr(self.canvas_object, "content_type"))
+        self.assertEqual(self.canvas_object.content_type, "application/json")
+        self.assertTrue(hasattr(self.canvas_object, "filename"))
+        self.assertEqual(self.canvas_object.filename, "example.json")
 
     def test_set_attributes_invalid_date(self, m):
         attributes = {"start_at": "2017-01-01T00:00+00:00:00", "end_at": "2012-08-0"}


### PR DESCRIPTION
# Proposed Changes

* Based off the description of the issue in 647, the issue of attributes with hyphens can be narrowed down to set_attributes in canvas_object.py. Any attribute in the JSOn object with a hyphen("-") is translated to an underscore("_"). 
* In test_canvas_object.py, I have added a function to include test cases that may target this issue.

# Effects
* With these changes, all tests are passing, and the coverage report remains at 100%