### PR TITLE
Use `new_quizzes` and `graphql` keywords

### DIFF
--- a/canvasapi/canvas.py
+++ b/canvasapi/canvas.py
@@ -1279,7 +1279,7 @@ class Canvas(object):
             _kwargs=combine_kwargs(**kwargs)
             + [("query", query), ("variables", variables)],
             # Needs to call special endpoint without api/v1
-            _url=self.__requester.original_url + "/api/graphql",
+            _url="graphql",
             json=True,
         )
 

--- a/canvasapi/course.py
+++ b/canvasapi/course.py
@@ -480,7 +480,7 @@ class Course(CanvasObject):
         response = self._requester.request(
             "POST",
             endpoint,
-            _url=self._requester.original_url + "/api/quiz/v1/" + endpoint,
+            _url="new_quizzes",
             _kwargs=combine_kwargs(**kwargs),
         )
         response_json = response.json()
@@ -1758,7 +1758,7 @@ class Course(CanvasObject):
         response = self._requester.request(
             "GET",
             endpoint,
-            _url=self._requester.original_url + "/api/quiz/v1/" + endpoint,
+            _url="new_quizzes",
             _kwargs=combine_kwargs(**kwargs),
         )
         response_json = response.json()
@@ -1783,7 +1783,7 @@ class Course(CanvasObject):
             self._requester,
             "GET",
             endpoint,
-            _url_override=self._requester.original_url + "/api/quiz/v1/" + endpoint,
+            _url_override="new_quizzes",
             _kwargs=combine_kwargs(**kwargs),
         )
 

--- a/canvasapi/new_quiz.py
+++ b/canvasapi/new_quiz.py
@@ -21,7 +21,7 @@ class NewQuiz(CanvasObject):
         response = self._requester.request(
             "DELETE",
             endpoint,
-            _url=self._requester.original_url + "/api/quiz/v1/" + endpoint,
+            _url="new_quizzes",
             _kwargs=combine_kwargs(**kwargs),
         )
         response_json = response.json()
@@ -44,7 +44,7 @@ class NewQuiz(CanvasObject):
         response = self._requester.request(
             "PATCH",
             endpoint,
-            _url=self._requester.original_url + "/api/quiz/v1/" + endpoint,
+            _url="new_quizzes",
             _kwargs=combine_kwargs(**kwargs),
         )
         response_json = response.json()

--- a/canvasapi/requester.py
+++ b/canvasapi/requester.py
@@ -36,7 +36,7 @@ class Requester(object):
         self.original_url = base_url
         self.base_url = base_url + "/api/v1/"
         self.new_quizzes_url = base_url + "/api/quiz/v1/"
-e       self.graphql = base_url + "/api/graphql"
+        self.graphql = base_url + "/api/graphql"
         self.access_token = access_token
         self._session = requests.Session()
         self._cache = []
@@ -172,9 +172,9 @@ e       self.graphql = base_url + "/api/graphql"
         if not _url:
             full_url = "{}{}".format(self.base_url, endpoint)
         elif _url == "new_quizzes":
-            full_url = "{}{}"".format(self.new_quizzes_url, endpoint)
+            full_url = "{}{}".format(self.new_quizzes_url, endpoint)
         elif _url == "graphql":
-            full_url_url = self.graphql
+            full_url = self.graphql
         else:
             full_url = _url
 

--- a/canvasapi/requester.py
+++ b/canvasapi/requester.py
@@ -35,6 +35,8 @@ class Requester(object):
         # Preserve the original base url and add "/api/v1" to it
         self.original_url = base_url
         self.base_url = base_url + "/api/v1/"
+        self.new_quizzes_url = base_url + "/api/quiz/v1/"
+        self.graphql = base_url + "/api/graphql"
         self.access_token = access_token
         self._session = requests.Session()
         self._cache = []
@@ -145,10 +147,16 @@ class Requester(object):
         :param use_auth: Optional flag to remove the authentication
             header from the request.
         :type use_auth: bool
-        :param _url: Optional argument to send a request to a URL
-            outside of the Canvas API. If this is selected and an
-            endpoint is provided, the endpoint will be ignored and
-            only the _url argument will be used.
+        :param _url: Optional argument to specify a request type to Canvas
+            or to send a request to a URL outside of the Canvas API.
+            If set to "new_quizzes", the new quizzes endpoint will be used.
+            If set to "graphql", a graphql POST request will be sent.
+            If any string URL is provided, it will be used instead of the
+            base REST URL.
+            If omitted or set to None, the base_url for the instance REST
+            endpoint will be used.
+            If this is selected and an endpoint is provided, the endpoint
+            will be ignored and only the `_url` argument will be used..
         :type _url: str
         :param _kwargs: A list of 2-tuples representing processed
             keyword arguments to be sent to Canvas as params or data.
@@ -159,7 +167,16 @@ class Requester(object):
         :type json: `bool`
         :rtype: :class:`requests.Response`
         """
-        full_url = _url if _url else "{}{}".format(self.base_url, endpoint)
+        # Check for specific URL endpoints available from Canvas. If not
+        # specified, pass the given URL and move on.
+        if _url == "new_quizzes":
+            request_url = "{}{}".format(self.new_quizzes_url, endpoint)
+        elif _url == "graphql":
+            request_url = self.graphql
+        else:
+            request_url = _url
+
+        full_url = request_url if _url else "{}{}".format(self.base_url, endpoint)
 
         if not headers:
             headers = {}

--- a/canvasapi/requester.py
+++ b/canvasapi/requester.py
@@ -36,7 +36,7 @@ class Requester(object):
         self.original_url = base_url
         self.base_url = base_url + "/api/v1/"
         self.new_quizzes_url = base_url + "/api/quiz/v1/"
-        self.graphql = base_url + "/api/graphql"
+e       self.graphql = base_url + "/api/graphql"
         self.access_token = access_token
         self._session = requests.Session()
         self._cache = []
@@ -169,14 +169,14 @@ class Requester(object):
         """
         # Check for specific URL endpoints available from Canvas. If not
         # specified, pass the given URL and move on.
-        if _url == "new_quizzes":
-            request_url = "{}{}".format(self.new_quizzes_url, endpoint)
+        if not _url:
+            full_url = "{}{}".format(self.base_url, endpoint)
+        elif _url == "new_quizzes":
+            full_url = "{}{}"".format(self.new_quizzes_url, endpoint)
         elif _url == "graphql":
-            request_url = self.graphql
+            full_url_url = self.graphql
         else:
-            request_url = _url
-
-        full_url = request_url if _url else "{}{}".format(self.base_url, endpoint)
+            full_url = _url
 
         if not headers:
             headers = {}


### PR DESCRIPTION
Based on #612 and as an issue in #619, this adds the `new_quizzes` and `graphql` keyword endpoints in the requester module. Methods which specify these locations will have the correct URL supplied by the library in the `_url` parameter for the requester.

Calls from the `canvas`, `course`, and `new_quizzes` modules have been updated to use they keywords rather than a formatted URL string.

All tests passing.

Fixes #619.
