### PR TITLE
Issue/669 GraphQL Updates to PaginatedList

### DIFF
--- a/canvasapi/paginated_list.py
+++ b/canvasapi/paginated_list.py
@@ -52,7 +52,7 @@ class PaginatedList(object):
         self._content_class = content_class
         self._first_url = first_url
         self._first_params = kwargs or {}
-        self._first_params["per_page"] = kwargs.get("per_page", 100)
+        self._first_params["per_page"] = kwargs.get("per_page", 20)
         self._next_url = first_url
         self._next_params = self._first_params
         self._extra_attribs = extra_attribs or {}

--- a/tests/fixtures/account.json
+++ b/tests/fixtures/account.json
@@ -1885,7 +1885,7 @@
 	},
 	"get_authentication_events": {
 		"method": "GET",
-		"endpoint": "audit/authentication/accounts/1?per_page=100",
+		"endpoint": "audit/authentication/accounts/1?per_page=20",
 		"data": [
 			{
 				"created_at": "2012-07-19T15:00:00-06:00",

--- a/tests/fixtures/content_migration.json
+++ b/tests/fixtures/content_migration.json
@@ -105,7 +105,7 @@
 	},
 	"get_migration_issue_multiple": {
 		"method": "GET",
-		"endpoint": "accounts/1/content_migrations/1/migration_issues/?per_page=100",
+		"endpoint": "accounts/1/content_migrations/1/migration_issues/?per_page=20",
 		"data": [
 			{
 				"id": 1,

--- a/tests/fixtures/paginated_list.json
+++ b/tests/fixtures/paginated_list.json
@@ -173,7 +173,7 @@
 					"prev": "https://example.com/api/v1/previous"
 				}
 			}
-		}
-	},
-	"status_code": 200
+		},
+		"status_code": 200
+	}
 }

--- a/tests/fixtures/paginated_list.json
+++ b/tests/fixtures/paginated_list.json
@@ -175,5 +175,75 @@
 			}
 		},
 		"status_code": 200
+	},
+	"21_2_pages_p1": {
+		"method": "ANY",
+		"endpoint": "twenty_one_objects_two_pages",
+		"data": [
+			{"id": "1", "name": "object 1"},
+			{"id": "2", "name": "object 2"},
+			{"id": "3", "name": "object 3"},
+			{"id": "4", "name": "object 4"},
+			{"id": "5", "name": "object 5"},
+			{"id": "6", "name": "object 6"},
+			{"id": "7", "name": "object 7"},
+			{"id": "8", "name": "object 8"},
+			{"id": "9", "name": "object 9"},
+			{"id": "10", "name": "object 10"},
+			{"id": "11", "name": "object 11"},
+			{"id": "12", "name": "object 12"},
+			{"id": "13", "name": "object 13"},
+			{"id": "14", "name": "object 14"},
+			{"id": "15", "name": "object 15"},
+			{"id": "16", "name": "object 16"},
+			{"id": "17", "name": "object 17"},
+			{"id": "18", "name": "object 18"},
+			{"id": "19", "name": "object 19"},
+			{"id": "20", "name": "object 20"}
+		],
+		"headers": {
+			"Link": "<https://example.com/api/v1/twenty_one_objects_two_pages?page=2>; rel=\"next\""
+		},
+		"status_code": 200
+	},
+	"21_2_pages_p2": {
+		"method": "ANY",
+		"endpoint": "twenty_one_objects_two_pages?page=2",
+		"data": [
+			{"id": "21", "name": "object 21"}
+		],
+		"status_code": 200
+	},
+	"no_per_page_4_2_pages_p1": {
+		"method": "ANY",
+		"endpoint": "no_per_page_four_objects_two_pages",
+		"data": [
+			{
+				"id": "1",
+				"name": "object 1"
+			},
+			{
+				"id": "2",
+				"name": "object 2"
+			},
+			{
+				"id": "3",
+				"name": "object 3"
+			},
+			{
+				"id": "4",
+				"name": "object 4"
+			}
+		],
+		"headers": {
+			"Link": "<https://example.com/api/v1/no_per_page_four_objects_two_pages?page=2>; rel=\"next\""
+		},
+		"status_code": 200
+	},
+	"no_per_page_4_2_pages_p2": {
+		"method": "ANY",
+		"endpoint": "no_per_page_four_objects_two_pages?page=2",
+		"data": [],
+		"status_code": 200
 	}
 }

--- a/tests/test_paginated_list.py
+++ b/tests/test_paginated_list.py
@@ -233,18 +233,13 @@ class TestPaginatedList(unittest.TestCase):
         self.assertIsInstance(pag_list, PaginatedList)
         self.assertEqual(len(list(pag_list)), 2)
         self.assertIsInstance(pag_list[0], User)
-    
+
     # per_page param
     def test_default_per_page_value(self, m):
-        register_uris(
-            {"paginated_list": ["21_2_pages_p1", "21_2_pages_p2"]}, m
-        )
+        register_uris({"paginated_list": ["21_2_pages_p1", "21_2_pages_p2"]}, m)
 
         pag_list = PaginatedList(
-            User,
-            self.requester,
-            "GET",
-            "twenty_one_objects_two_pages"
+            User, self.requester, "GET", "twenty_one_objects_two_pages"
         )
 
         # check that default per_page value is set to 20
@@ -253,11 +248,25 @@ class TestPaginatedList(unittest.TestCase):
         item_list = [item for item in pag_list]
         self.assertEqual(len(item_list), 21)
         self.assertIsInstance(item_list[0], User)
-    
+
     def test_overriden_per_page_value(self, m):
-        register_uris({"paginated_list": ["no_per_page_4_2_pages_p1", "no_per_page_4_2_pages_p2"]}, m)
-        
-        pag_list = PaginatedList(User, self.requester, "GET", "no_per_page_four_objects_two_pages", per_page=2)
+        register_uris(
+            {
+                "paginated_list": [
+                    "no_per_page_4_2_pages_p1",
+                    "no_per_page_4_2_pages_p2",
+                ]
+            },
+            m,
+        )
+
+        pag_list = PaginatedList(
+            User,
+            self.requester,
+            "GET",
+            "no_per_page_four_objects_two_pages",
+            per_page=2,
+        )
 
         # check that per_page value is overriden to 2
         self.assertEqual(pag_list._first_params["per_page"], 2)
@@ -265,7 +274,3 @@ class TestPaginatedList(unittest.TestCase):
         item_list = [item for item in pag_list]
         self.assertEqual(len(item_list), 4)
         self.assertIsInstance(item_list[0], User)
-
-    
-
-

--- a/tests/test_paginated_list.py
+++ b/tests/test_paginated_list.py
@@ -233,3 +233,39 @@ class TestPaginatedList(unittest.TestCase):
         self.assertIsInstance(pag_list, PaginatedList)
         self.assertEqual(len(list(pag_list)), 2)
         self.assertIsInstance(pag_list[0], User)
+    
+    # per_page param
+    def test_default_per_page_value(self, m):
+        register_uris(
+            {"paginated_list": ["21_2_pages_p1", "21_2_pages_p2"]}, m
+        )
+
+        pag_list = PaginatedList(
+            User,
+            self.requester,
+            "GET",
+            "twenty_one_objects_two_pages"
+        )
+
+        # check that default per_page value is set to 20
+        self.assertEqual(pag_list._first_params["per_page"], 20)
+
+        item_list = [item for item in pag_list]
+        self.assertEqual(len(item_list), 21)
+        self.assertIsInstance(item_list[0], User)
+    
+    def test_overriden_per_page_value(self, m):
+        register_uris({"paginated_list": ["no_per_page_4_2_pages_p1", "no_per_page_4_2_pages_p2"]}, m)
+        
+        pag_list = PaginatedList(User, self.requester, "GET", "no_per_page_four_objects_two_pages", per_page=2)
+
+        # check that per_page value is overriden to 2
+        self.assertEqual(pag_list._first_params["per_page"], 2)
+
+        item_list = [item for item in pag_list]
+        self.assertEqual(len(item_list), 4)
+        self.assertIsInstance(item_list[0], User)
+
+    
+
+


### PR DESCRIPTION
# Proposed Changes
* Updates PaginatedList object (in paginated_list.py) to set default page size (per_page parameter) to 20 (previously 100) to adhere to [10/2024 GraphQL API changes](https://community.canvaslms.com/t5/Canvas-Change-Log/2024-GraphQL-API-Change-Log/ta-p/617064)
* Add associated tests/fixtures (see `test_paginated_list.py`, `fixtures/paginated_list.json`)

Fixes #669

# Effects
* With these changes, all tests are passing and coverage report remains at 100%.