### PR TITLE
Update get_appointment_groups, checks for creating new appointment groups

### DIFF
--- a/tests/fixtures/appointment_group.json
+++ b/tests/fixtures/appointment_group.json
@@ -67,6 +67,23 @@
 		],
 		"status_code": 200
 	},
+	"list_manageable_appointment_groups": {
+		"method": "GET",
+		"endpoint": "appointment_groups",
+		"data": [
+			{
+				"id": 999,
+				"context_codes": ["course_123"],
+				"title": "Test Group 1"
+			},
+			{
+				"id": 888,
+				"context_codes": ["course_456"],
+				"title": "Test Group 2"
+			}
+		],
+		"status_code": 200
+	},
 	"list_user_participants": {
 		"method": "GET",
 		"endpoint": "appointment_groups/222/users",

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -635,6 +635,14 @@ class TestCanvas(unittest.TestCase):
         appt_groups_list = [appt_group for appt_group in appt_groups]
         self.assertEqual(len(appt_groups_list), 2)
 
+    # get_appointment_group(), not reservable
+    def test_get_manageable_appointment_groups(self, m):
+        register_uris({"appointment_group": ["list_manageable_appointment_groups"]}, m)
+
+        appt_groups = self.canvas.get_appointment_groups(group_type="manageable")
+        appt_groups_list = [appt_group for appt_group in appt_groups]
+        self.assertEqual(len(appt_groups_list), 2)
+
     # get_appointment_group()
     def test_get_appointment_group(self, m):
         register_uris({"appointment_group": ["get_appointment_group"]}, m)
@@ -655,6 +663,17 @@ class TestCanvas(unittest.TestCase):
 
         evnt = self.canvas.create_appointment_group(
             {"context_codes": ["course_123"], "title": "Test Group"}
+        )
+
+        self.assertIsInstance(evnt, AppointmentGroup)
+        self.assertEqual(evnt.context_codes[0], "course_123")
+        self.assertEqual(evnt.id, 234)
+
+    def test_create_appointment_group_with_course_ids(self, m):
+        register_uris({"appointment_group": ["create_appointment_group"]}, m)
+
+        evnt = self.canvas.create_appointment_group(
+            {"context_codes": [123], "title": "Test Group"}
         )
 
         self.assertIsInstance(evnt, AppointmentGroup)


### PR DESCRIPTION
Two issues in one:

1. `canvas.get_appointment_groups()` returns an empty list for teachers because it defaults to "reservable", but instructors can't reserve, so the list is empty. Create a new param on the method that defaults to `reservable` but can be overridden. Update the docstring to note the change.

2. Update `create_appointment_group()` to take either a course ID or a `Course` object. Check that the `context_codes` key is present on the `appointment_group` dict before checking formatting.

All tests passing.

Fixes #678
