### PR TITLE
find_missing_modules should import rather than append to prioritize local

### DIFF
--- a/scripts/find_missing_modules.py
+++ b/scripts/find_missing_modules.py
@@ -2,7 +2,7 @@ import inspect
 import os
 import sys
 
-sys.path.append(os.path.join(sys.path[0], ".."))
+sys.path.insert(0,(os.path.join(sys.path[0], "..")))
 
 import canvasapi  # noqa
 


### PR DESCRIPTION
# Proposed Changes

* Just change the script action to import rather than append which will put the local path first

Fixes #675
