### PR TITLE
Update 'Requester' to include new_quizzes_url attribute (#684)

### DIFF
--- a/canvasapi/paginated_list.py
+++ b/canvasapi/paginated_list.py
@@ -103,7 +103,7 @@ class PaginatedList(Iterable[T]):
 
         regex = r"(?:{}|{})(.*)".format(
             re.escape(self._requester.base_url),
-            re.escape(self._requester.new_quizzes_url),
+            re.escape(getattr(self._requester, "new_quizzes_url", "")),
         )
 
         self._next_url = (

--- a/canvasapi/requester.py
+++ b/canvasapi/requester.py
@@ -25,7 +25,7 @@ class Requester(object):
     Responsible for handling HTTP requests.
     """
 
-    def __init__(self, base_url, access_token):
+    def __init__(self, base_url, access_token, new_quizzes_url = None):
         """
         :param base_url: The base URL of the Canvas instance's API.
         :type base_url: str
@@ -35,7 +35,7 @@ class Requester(object):
         # Preserve the original base url and add "/api/v1" to it
         self.original_url = base_url
         self.base_url = base_url + "/api/v1/"
-        self.new_quizzes_url = base_url + "/api/quiz/v1/"
+        self.new_quizzes_url = new_quizzes_url or (base_url + "/api/quiz/v1/")
         self.graphql = base_url + "/api/graphql"
         self.access_token = access_token
         self._session = requests.Session()

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -171,6 +171,19 @@ class TestAssignment(unittest.TestCase):
         self.assertEqual(len(submission_list_by_id), 2)
         self.assertIsInstance(submission_list_by_id[0], Submission)
 
+    def test_get_submissions_without_new_quizzes_url(self, m):
+        register_uris({"submission": ["list_submissions"]}, m)
+
+        # Explicitly remove the `new_quizzes_url` attribute to simulate the base case
+        if hasattr(self.canvas._Canvas__requester, "new_quizzes_url"):
+            del self.canvas._Canvas__requester.new_quizzes_url
+
+        submissions = self.assignment.get_submissions()
+        submission_list = list(submissions)
+
+        self.assertEqual(len(submission_list), 2)
+        self.assertIsInstance(submission_list[0], Submission)
+        
     # set_extensions()
     def test_set_extensions(self, m):
         register_uris({"assignment": ["set_extensions"]}, m)


### PR DESCRIPTION
# Proposed Changes
* Add a new_quizzes_url attribute to "Requester"
* Change _get_next_page in paginated_list.py to use an empty string if new_quizzes_url is not defined which resolved the crash.
* Included a test in test_assignment.py  called test_get_submissions_without_new_quizzes_url in order to make sure my changes worked.

All tests passed and coverage remained at 100%.

Fixes #684 
